### PR TITLE
UAF-101 subtask UAF-122 creating maven build for ua

### DIFF
--- a/kfs-ar/pom.xml
+++ b/kfs-ar/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kfs</artifactId>
     <groupId>org.kuali.kfs</groupId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>ua-release1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kfs-bc/pom.xml
+++ b/kfs-bc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kfs</artifactId>
     <groupId>org.kuali.kfs</groupId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>ua-release1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kfs-cam/pom.xml
+++ b/kfs-cam/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kfs</artifactId>
     <groupId>org.kuali.kfs</groupId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>ua-release1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kfs-cg/pom.xml
+++ b/kfs-cg/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kfs</artifactId>
     <groupId>org.kuali.kfs</groupId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>ua-release1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kfs-core/pom.xml
+++ b/kfs-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kfs</artifactId>
     <groupId>org.kuali.kfs</groupId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>ua-release1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kfs-ec/pom.xml
+++ b/kfs-ec/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kfs</artifactId>
     <groupId>org.kuali.kfs</groupId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>ua-release1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kfs-kc/pom.xml
+++ b/kfs-kc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kfs</artifactId>
     <groupId>org.kuali.kfs</groupId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>ua-release1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kfs-ld/pom.xml
+++ b/kfs-ld/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kfs</artifactId>
     <groupId>org.kuali.kfs</groupId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>ua-release1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kfs-purap/pom.xml
+++ b/kfs-purap/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kfs</artifactId>
     <groupId>org.kuali.kfs</groupId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>ua-release1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kfs-tem/pom.xml
+++ b/kfs-tem/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kfs</artifactId>
     <groupId>org.kuali.kfs</groupId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>ua-release1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kfs-web/pom.xml
+++ b/kfs-web/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kfs</artifactId>
     <groupId>org.kuali.kfs</groupId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>ua-release1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -79,6 +79,7 @@
               <directory>${help.web.sources}</directory>
             </resource>
           </webResources>
+          <classifier>ua-ksd</classifier>
         </configuration>
       </plugin>
     </plugins>
@@ -136,5 +137,18 @@
       <version>${project.version}</version>
     </dependency>
   </dependencies>
+
+    <distributionManagement>
+    <repository>
+       <id>deployment</id>
+       <name>Internal Releases</name>
+       <url>https://ka-tools.mosaic.arizona.edu/nexus/content/repositories/releases/</url>
+    </repository>
+    <snapshotRepository>
+       <id>deployment</id>
+       <name>Internal Releases</name>
+       <url>https://ka-tools.mosaic.arizona.edu/nexus/content/repositories/snapshots/</url>
+    </snapshotRepository>
+  </distributionManagement>
 
 </project>

--- a/mvn_install_test_jar.sh
+++ b/mvn_install_test_jar.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+cd kfs-core && \
+
+mvn jar:test-jar && \
+
+mvn install:install-file -Dfile=target/kfs-core-tests.jar \
+                         -DpomFile=pom.xml \
+                         -Dclassifier=tests \
+                         -DcreateChecksum=true && \
+
+cd ../kfs-cg && \
+
+mvn jar:test-jar && \
+
+mvn install:install-file -Dfile=target/kfs-cg-tests.jar \
+                         -DpomFile=pom.xml \
+                         -Dclassifier=tests \
+                         -DcreateChecksum=true && \
+
+cd ../kfs-purap && \
+
+mvn jar:test-jar && \
+
+mvn install:install-file -Dfile=target/kfs-purap-tests.jar \
+                         -DpomFile=pom.xml \
+                         -Dclassifier=tests \
+                         -DcreateChecksum=true && \      
+
+cd ../kfs-bc && \
+
+mvn jar:test-jar && \
+
+mvn install:install-file -Dfile=target/kfs-bc-tests.jar \
+                         -DpomFile=pom.xml \
+                         -Dclassifier=tests \
+                         -DcreateChecksum=true && \   
+
+mvn -Dmaven.test.skip=true install && \
+
+cd ../kfs-ld && \
+
+mvn jar:test-jar && \
+
+mvn install:install-file -Dfile=target/kfs-ld-tests.jar \
+                         -DpomFile=pom.xml \
+                         -Dclassifier=tests \
+                         -DcreateChecksum=true && \
+
+cd ../kfs-ar && \
+
+mvn jar:test-jar && \
+
+mvn install:install-file -Dfile=target/kfs-ar-tests.jar \
+                         -DpomFile=pom.xml \
+                         -Dclassifier=tests \
+                         -DcreateChecksum=true                     

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
   </parent>
   <groupId>org.kuali.kfs</groupId>
   <artifactId>kfs</artifactId>
-  <version>6.0.1-SNAPSHOT</version>
+  <version>ua-release1-SNAPSHOT</version>
   <name>Kuali Financial System</name>
   <description>Kuali Financials</description>
   <inceptionYear>2004</inceptionYear>
@@ -927,6 +927,19 @@
     </dependency>
 
   </dependencies>
+
+    <distributionManagement>
+    <repository>
+       <id>deployment</id>
+       <name>Internal Releases</name>
+       <url>https://ka-tools.mosaic.arizona.edu/nexus/content/repositories/releases/</url>
+    </repository>
+    <snapshotRepository>
+       <id>deployment</id>
+       <name>Internal Releases</name>
+       <url>https://ka-tools.mosaic.arizona.edu/nexus/content/repositories/snapshots/</url>
+    </snapshotRepository>
+  </distributionManagement>
 
 
 </project>


### PR DESCRIPTION
 I updated the pom files in the kfs project to:
1. Add our local nexus repository under the distribution management. This will ensure that when we deploy the artifacts, it will deploy to our local nexus repo.
2. Added a shell script to build and install the test jars locally. I needed to do this because the build was failing with the -Dmaven.test.skip=true flag as test jars were not being created for the projects. This shell script should be run before you run a build so that it will install the test jars locally and allow you to do the build and skip the tests.
3. Updated the versions in the pom files to reflect our ua-release1-SNAPSHOT version. This basically means we are working towards release 1 and this build is the current snapshot. This would basically be the nightly build. When we finish release 1, we will update the version to ua-release1 and deploy to our releases repository in Nexus. Then, after the release is complete, we will update the version in the development branch to be ua-release2-SNAPSHOT indicating that we are working towards the next release.
