### PR TITLE
UAF-174 Substituting system variable for directory path

### DIFF
--- a/kfs-web/start-tomcat.sh
+++ b/kfs-web/start-tomcat.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-export EXTERNAL_CONFIG="-Dadditional.kfs.config.locations=/Users/shaloo/java/env/kfs6/external_config/kfs-config.properties,/Users/shaloo/java/env/kfs6/external_config/kfs-rice-config.properties,/Users/shaloo/java/env/kfs6/external_config/kfs-security-config.properties"
+export EXTERNAL_CONFIG="-Dadditional.kfs.config.locations=$EXTERNAL_CONFIG_DIR/kfs-config.properties,$EXTERNAL_CONFIG_DIR/kfs-rice-config.properties,$EXTERNAL_CONFIG_DIR/kfs-security-config.properties"
 
 mvn $EXTERNAL_CONFIG -DskipTests=true -P oracle -Dserver.name="http://localhost:8080" tomcat7:run-war


### PR DESCRIPTION
The system variable will need to be defined on the developer's workstation. This has been documented on Confluence.
