### PR TITLE
UAF-1733 exclude rice-impl jar from our war file to remove conflict w…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,14 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>2.6</version>
+          <configuration>
+            <packagingExcludes>WEB-INF/lib/rice-kim-impl-${rice.version}.jar</packagingExcludes>
+          </configuration>
+        </plugin>
+        <plugin>
           <groupId>org.apache.tomcat.maven</groupId>
           <artifactId>tomcat7-maven-plugin</artifactId>
           <version>${plugin.tomcat.version}</version>


### PR DESCRIPTION
Tested locally, with this update the rice-kim-impl-2.1.10.jar does not get packaged into our kfs war file, but the rice-kim-impl-ua-release4-SNAPSHOT-ua-ksd.jar does.
