### PR TITLE
UAF-1733 exclude both rice-kim-impl and rice-impl jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,10 @@
           <artifactId>maven-war-plugin</artifactId>
           <version>2.6</version>
           <configuration>
-            <packagingExcludes>WEB-INF/lib/rice-kim-impl-${rice.version}.jar</packagingExcludes>
+            <packagingExcludes>
+              WEB-INF/lib/rice-kim-impl-${rice.version}.jar,
+              WEB-INF/lib/rice-impl-${rice.version}.jar
+             </packagingExcludes>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
I left out one of the jars I was supposed to exclude. Need to exclude both rice-kim-impl and rice-impl.
