### PR TITLE
UAF-1872 removed getDisplayCashReceiptDenominationDetail from the Doc…

### DIFF
--- a/kfs-core/src/main/java/org/kuali/kfs/fp/businessobject/CashDrawer.java
+++ b/kfs-core/src/main/java/org/kuali/kfs/fp/businessobject/CashDrawer.java
@@ -51,6 +51,7 @@ public class CashDrawer extends PersistableBusinessObjectBase {
     private KualiDecimal financialDocumentTwoDollarAmount;
     private KualiDecimal financialDocumentOneDollarAmount;
     private KualiDecimal financialDocumentOtherDollarAmount;
+    private KualiDecimal financialDocumentDollarAmount;
 
     private KualiDecimal financialDocumentHundredCentAmount;
     private KualiDecimal financialDocumentFiftyCentAmount;
@@ -59,6 +60,7 @@ public class CashDrawer extends PersistableBusinessObjectBase {
     private KualiDecimal financialDocumentFiveCentAmount;
     private KualiDecimal financialDocumentOneCentAmount;
     private KualiDecimal financialDocumentOtherCentAmount;
+    private KualiDecimal financialDocumentCentAmount;
 
     private KualiDecimal financialDocumentMiscellaneousAdvanceAmount;
 
@@ -440,6 +442,14 @@ public class CashDrawer extends PersistableBusinessObjectBase {
     public void setFinancialDocumentOtherDollarAmount(KualiDecimal financialDocumentOtherDollarAmount) {
         this.financialDocumentOtherDollarAmount = financialDocumentOtherDollarAmount;
     }
+    
+    public KualiDecimal getFinancialDocumentDollarAmount() {
+        return financialDocumentOtherDollarAmount;
+    }
+
+    public void setFinancialDocumentDollarAmount(KualiDecimal financialDocumentDollarAmount) {
+        this.financialDocumentOtherDollarAmount = financialDocumentDollarAmount;
+    }
 
 
     /**
@@ -649,6 +659,14 @@ public class CashDrawer extends PersistableBusinessObjectBase {
      */
     public void setFinancialDocumentOtherCentAmount(KualiDecimal financialDocumentOtherCentAmount) {
         this.financialDocumentOtherCentAmount = financialDocumentOtherCentAmount;
+    }
+    
+    public KualiDecimal getFinancialDocumentCentAmount() {
+        return financialDocumentOtherCentAmount;
+    }
+
+    public void setFinancialDocumentCentAmount(KualiDecimal financialDocumentCentAmount) {
+        this.financialDocumentOtherCentAmount = financialDocumentCentAmount;
     }
 
 

--- a/kfs-core/src/main/java/org/kuali/kfs/fp/document/CashManagementDocument.java
+++ b/kfs-core/src/main/java/org/kuali/kfs/fp/document/CashManagementDocument.java
@@ -94,7 +94,6 @@ public class CashManagementDocument extends GeneralLedgerPostingDocumentBase imp
     private KualiDecimal financialDocumentOneCentAmount;
     private KualiDecimal financialDocumentOtherCentAmount;
 
-    protected Boolean displayCashReceiptDenominationDetail;
 
     /**
      * Default constructor.
@@ -816,9 +815,5 @@ public class CashManagementDocument extends GeneralLedgerPostingDocumentBase imp
      */
     public void setFinancialDocumentOtherCentAmount(KualiDecimal financialDocumentOtherCentAmount) {
         this.financialDocumentOtherCentAmount = financialDocumentOtherCentAmount;
-    }
-
-    public Boolean getDisplayCashReceiptDenominationDetail() {
-        return SpringContext.getBean(ParameterService.class).getParameterValueAsBoolean(CashReceiptDocument.class, KFSParameterKeyConstants.FpParameterConstants.DISPLAY_CASH_RECEIPT_DENOMINATION_DETAIL_IND, true);
     }
 }

--- a/kfs-core/src/main/java/org/kuali/kfs/fp/document/CashReceiptDocument.java
+++ b/kfs-core/src/main/java/org/kuali/kfs/fp/document/CashReceiptDocument.java
@@ -119,7 +119,6 @@ public class CashReceiptDocument extends CashReceiptFamilyBase implements Copyab
 
     protected String createDate;
     
-    protected Boolean displayCashReceiptDenominationDetail;
 
     /**
      * Initializes the array lists and line incrementers.
@@ -1129,9 +1128,6 @@ public class CashReceiptDocument extends CashReceiptFamilyBase implements Copyab
         return SpringContext.getBean(DateTimeService.class).toDateString(getDocumentHeader().getWorkflowDocument().getDateCreated().toDate());
     }
     
-    public Boolean getDisplayCashReceiptDenominationDetail() {
-        return SpringContext.getBean(ParameterService.class).getParameterValueAsBoolean(CashReceiptDocument.class, KFSParameterKeyConstants.FpParameterConstants.DISPLAY_CASH_RECEIPT_DENOMINATION_DETAIL_IND, true);
-    }
 
     /**
      * Generate the primary key for a currency or coin detail related to this document

--- a/kfs-core/src/main/java/org/kuali/kfs/fp/document/web/struts/CashManagementAction.java
+++ b/kfs-core/src/main/java/org/kuali/kfs/fp/document/web/struts/CashManagementAction.java
@@ -64,7 +64,7 @@ import org.kuali.rice.krad.util.UrlFactory;
  */
 public class CashManagementAction extends KualiTransactionalDocumentActionBase {
     protected static Logger LOG = Logger.getLogger(CashManagementAction.class);
-    protected static final String CASH_MANAGEMENT_STATUS_PAGE = "/cashManagementStatus.do";
+    protected static final String CASH_MANAGEMENT_STATUS_PAGE = "cashManagementStatus.do";
 
     /**
      * Default constructor

--- a/kfs-core/src/main/java/org/kuali/kfs/fp/document/web/struts/CashManagementForm.java
+++ b/kfs-core/src/main/java/org/kuali/kfs/fp/document/web/struts/CashManagementForm.java
@@ -42,6 +42,7 @@ import org.kuali.kfs.fp.document.authorization.CashManagementDocumentPresentatio
 import org.kuali.kfs.fp.document.service.CashManagementService;
 import org.kuali.kfs.fp.document.service.CashReceiptService;
 import org.kuali.kfs.fp.service.CashDrawerService;
+import org.kuali.kfs.sys.KFSParameterKeyConstants;
 import org.kuali.kfs.sys.KFSConstants.DepositConstants;
 import org.kuali.kfs.sys.KFSConstants.DocumentStatusCodes.CashReceipt;
 import org.kuali.kfs.sys.context.SpringContext;
@@ -50,6 +51,7 @@ import org.kuali.rice.core.api.datetime.DateTimeService;
 import org.kuali.rice.core.api.util.type.KualiDecimal;
 import org.kuali.rice.core.web.format.CurrencyFormatter;
 import org.kuali.rice.core.web.format.TimestampAMPMFormatter;
+import org.kuali.rice.coreservice.framework.parameter.ParameterService;
 import org.kuali.rice.kns.service.DataDictionaryService;
 import org.kuali.rice.kns.web.struts.form.KualiDocumentFormBase;
 
@@ -1175,5 +1177,8 @@ public class CashManagementForm extends KualiDocumentFormBase {
         }
     }
 
+    public Boolean getDisplayCashReceiptDenominationDetail() {
+        return SpringContext.getBean(ParameterService.class).getParameterValueAsBoolean(CashReceiptDocument.class, KFSParameterKeyConstants.FpParameterConstants.DISPLAY_CASH_RECEIPT_DENOMINATION_DETAIL_IND, true);
+    }
 
 }

--- a/kfs-core/src/main/java/org/kuali/kfs/fp/document/web/struts/CashReceiptForm.java
+++ b/kfs-core/src/main/java/org/kuali/kfs/fp/document/web/struts/CashReceiptForm.java
@@ -35,6 +35,7 @@ import org.kuali.kfs.fp.document.service.CashManagementService;
 import org.kuali.kfs.fp.document.service.CashReceiptCoverSheetService;
 import org.kuali.kfs.fp.service.CashDrawerService;
 import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.KFSParameterKeyConstants;
 import org.kuali.kfs.sys.KFSConstants.DocumentStatusCodes.CashReceipt;
 import org.kuali.kfs.sys.KFSKeyConstants;
 import org.kuali.kfs.sys.context.SpringContext;
@@ -42,6 +43,7 @@ import org.kuali.kfs.sys.service.FinancialSystemWorkflowHelperService;
 import org.kuali.rice.core.api.config.property.ConfigurationService;
 import org.kuali.rice.core.api.util.type.KualiDecimal;
 import org.kuali.rice.core.web.format.SimpleBooleanFormatter;
+import org.kuali.rice.coreservice.framework.parameter.ParameterService;
 import org.kuali.rice.krad.util.GlobalVariables;
 
 /**
@@ -316,5 +318,9 @@ public class CashReceiptForm extends CapitalAccountingLinesFormBase implements C
         execludedMethodToCall.add("printCoverSheet");
 
         return execludedMethodToCall;
+    }
+    
+    public Boolean getDisplayCashReceiptDenominationDetail() {
+        return SpringContext.getBean(ParameterService.class).getParameterValueAsBoolean(CashReceiptDocument.class, KFSParameterKeyConstants.FpParameterConstants.DISPLAY_CASH_RECEIPT_DENOMINATION_DETAIL_IND, true);
     }
 }

--- a/kfs-core/src/main/java/org/kuali/kfs/fp/document/web/struts/DepositWizardForm.java
+++ b/kfs-core/src/main/java/org/kuali/kfs/fp/document/web/struts/DepositWizardForm.java
@@ -75,7 +75,6 @@ public class DepositWizardForm extends KualiForm {
 
     protected String noVerifiedCashErrorMessage = "";
     
-    protected Boolean displayCashReceiptDenominationDetail;
 
     /**
      * Constructs a DepositWizardForm class instance.

--- a/kfs-core/src/main/resources/org/kuali/kfs/fp/businessobject/datadictionary/CashDrawer.xml
+++ b/kfs-core/src/main/resources/org/kuali/kfs/fp/businessobject/datadictionary/CashDrawer.xml
@@ -42,6 +42,7 @@
 				<ref bean="CashDrawer-financialDocumentOneCentAmount" />
 				<ref bean="CashDrawer-oneCentCount" />
 				<ref bean="CashDrawer-financialDocumentOtherCentAmount" />
+				<ref bean="CashDrawer-financialDocumentCentAmount" />
 				<ref bean="CashDrawer-financialDocumentHundredDollarAmount" />
 				<ref bean="CashDrawer-hundredDollarCount" />
 				<ref bean="CashDrawer-financialDocumentFiftyDollarAmount" />
@@ -57,6 +58,7 @@
 				<ref bean="CashDrawer-financialDocumentOneDollarAmount" />
 				<ref bean="CashDrawer-oneDollarCount" />
 				<ref bean="CashDrawer-financialDocumentOtherDollarAmount" />
+				<ref bean="CashDrawer-financialDocumentDollarAmount" />
 				<ref bean="CashDrawer-currencyTotalAmount" />
 				<ref bean="CashDrawer-coinTotalAmount" />
 				<ref bean="CashDrawer-totalAmount" />
@@ -289,6 +291,20 @@
 				p:size="6" />
 		</property>
 	</bean>
+	<bean id="CashDrawer-financialDocumentCentAmount" parent="CashDrawer-financialDocumentCentAmount-parentBean" />
+
+	<bean id="CashDrawer-financialDocumentCentAmount-parentBean"
+		abstract="true" parent="AttributeDefinition">
+		<property name="name" value="financialDocumentCentAmount" />
+		<property name="label" value="Cent Amount" />
+		<property name="shortLabel" value="CntAmt" />
+		<property name="maxLength" value="6" />
+		<property name="required" value="false" />
+		<property name="control">
+			<bean parent="CurrencyControlDefinition" p:formattedMaxLength="8"
+				p:size="6" />
+		</property>
+	</bean>
 	<bean id="CashDrawer-financialDocumentHundredDollarAmount"
 		parent="CashDrawer-financialDocumentHundredDollarAmount-parentBean" />
 
@@ -510,6 +526,21 @@
 		<property name="name" value="financialDocumentOtherDollarAmount" />
 		<property name="label" value="Other Dollar Amount" />
 		<property name="shortLabel" value="OthrDlrAmt" />
+		<property name="maxLength" value="10" />
+		<property name="required" value="false" />
+		<property name="control">
+			<bean parent="CurrencyControlDefinition" p:formattedMaxLength="12"
+				p:size="10" />
+		</property>
+	</bean>
+	<bean id="CashDrawer-financialDocumentDollarAmount"
+		parent="CashDrawer-financialDocumentDollarAmount-parentBean" />
+
+	<bean id="CashDrawer-financialDocumentDollarAmount-parentBean"
+		abstract="true" parent="AttributeDefinition">
+		<property name="name" value="financialDocumentDollarAmount" />
+		<property name="label" value="Dollar Amount" />
+		<property name="shortLabel" value="DlrAmt" />
 		<property name="maxLength" value="10" />
 		<property name="required" value="false" />
 		<property name="control">

--- a/kfs-web/src/main/webapp/WEB-INF/tags/fp/cashDrawerCurrencyCoin.tag
+++ b/kfs-web/src/main/webapp/WEB-INF/tags/fp/cashDrawerCurrencyCoin.tag
@@ -22,6 +22,8 @@
 <%@ attribute name="readOnly" required="false" %>
 <%@ attribute name="showCashDrawerSummary" required="false" %>
 
+<c:set var="displayCashReceiptDenominationDetail" value="${KualiForm.displayCashReceiptDenominationDetail}" />
+
 <c:if test="${empty showCashDrawerSummary}">
   <c:set var="showCashDrawerSummary" value="false" />
 </c:if>
@@ -33,6 +35,8 @@
   <h3>Cash Drawer Currency/Coin</h3>
 
 <table border="0" cellspacing="0" cellpadding="0" class="datatable" width="100%">
+<c:choose>
+<c:when test="${displayCashReceiptDenominationDetail}">
   <tr>
     <th colspan="4" class="tab-subhead">Currency</th>
     <th colspan="3" class="tab-subhead">Coin</th>
@@ -168,6 +172,34 @@
           </td>
           <td colspan="3">&nbsp;</td>
         </tr>
+       </c:when>
+       <c:otherwise>
+       	<tr>
+	       	<th style="border-right: 0 none black; width: 2em">&nbsp;</th>
+	       	<th style="border-left: 0 none black">&nbsp;</th>
+	       	<th>Amount</th>
+	       	<th>&nbsp;</th>
+	       	<th>Amount</th>
+	       	<th colspan="2">&nbsp;</th>
+       	</tr>
+       	<tr>
+       	  <td>&nbsp;</td>
+          <td>
+            <kul:htmlAttributeLabel labelFor="${cashDrawerProperty}.financialDocumentDollarAmount" attributeEntry="${cashDrawerAttributes.financialDocumentDollarAmount}" />
+          </td>
+          <td>
+            $<kul:htmlControlAttribute property="${cashDrawerProperty}.financialDocumentDollarAmount" attributeEntry="${cashDrawerAttributes.financialDocumentDollarAmount}" readOnly="${readOnly}" />
+          </td>
+          <td>
+            <kul:htmlAttributeLabel labelFor="${cashDrawerProperty}.financialDocumentCentAmount" attributeEntry="${cashDrawerAttributes.financialDocumentCentAmount}" />
+          </td>
+          <td>
+            $<kul:htmlControlAttribute property="${cashDrawerProperty}.financialDocumentCentAmount" attributeEntry="${cashDrawerAttributes.financialDocumentCentAmount}" readOnly="${readOnly}" />
+          </td>
+          <td colspan="2">&nbsp;</td>
+        </tr>
+       </c:otherwise>
+       </c:choose>
         
         <%-- cash drawer summary information --%>
         <c:if test="${showCashDrawerSummary}">

--- a/kfs-web/src/main/webapp/WEB-INF/tags/fp/currencyCoinLine.tag
+++ b/kfs-web/src/main/webapp/WEB-INF/tags/fp/currencyCoinLine.tag
@@ -39,15 +39,7 @@
 <c:set var="currencyAttributes" value="${DataDictionary.CurrencyDetail.attributes}" />
 <c:set var="coinAttributes" value="${DataDictionary.CoinDetail.attributes}" />
 <c:set var="tabindexOverrideBase" value="20" />
-<c:catch var="exception">${KualiForm.displayCashReceiptDenominationDetail}</c:catch>
-<c:choose>
-	<c:when test="${not empty exception}">
-		<c:set var="displayCashReceiptDenominationDetail" value="${KualiForm.document.displayCashReceiptDenominationDetail}" />
-	</c:when>
-	<c:otherwise>
-		<c:set var="displayCashReceiptDenominationDetail" value="${KualiForm.displayCashReceiptDenominationDetail}" />
-	</c:otherwise>
-</c:choose>
+<c:set var="displayCashReceiptDenominationDetail" value="${KualiForm.displayCashReceiptDenominationDetail}" />
 
       <table border="0" cellspacing="0" cellpadding="0" class="datatable" width="100%">
         <c:if test="${showConfirm}">

--- a/kfs-web/src/main/webapp/jsp/fp/CashReceipt.jsp
+++ b/kfs-web/src/main/webapp/jsp/fp/CashReceipt.jsp
@@ -25,7 +25,7 @@
 <c:set var="readOnly" value="${!KualiForm.documentActions[Constants.KUALI_ACTION_CAN_EDIT]}" />
 <c:set var="confirmed" value="${KualiForm.document.confirmed}" />
 <c:set var="cashReceiptAttributes" value="${DataDictionary['CashReceiptDocument'].attributes}" />
-<c:set var="displayCashReceiptDenominationDetail" value="${KualiForm.document.displayCashReceiptDenominationDetail}" />
+<c:set var="displayCashReceiptDenominationDetail" value="${KualiForm.displayCashReceiptDenominationDetail}" />
 
 <%-- 
 	We should show both the original and confirmed details after CashManagerment confirmation; only that neither column would be editable.


### PR DESCRIPTION
…ument files and added them to the Form files so the same value can be used in the jsp (${KualiForm.displayCashReceiptDenominationDetail}). Before, an exception would caught in the jsp (via the <c:catch />) tag if KualiForm.displayCashReceiptDenominationDetail didn't exist and use KualiForm.document.displayCashReceiptDenominationDetail instead (because DepositWizardForm doesn't have a 'document' field). The exception was causing the CMD to open to a blank screen, showing a Blocked Mixed Content warning in the browser console. Additionally, some fields were still showing when the parameter was false and has now been corrected
