### PR TITLE
UAF-259 / UAF-1782 DV Payee lookup unable to search employees

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/lookup/UaDisbursementPayeeLookupableHelperServiceImpl.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/lookup/UaDisbursementPayeeLookupableHelperServiceImpl.java
@@ -24,7 +24,6 @@ import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.fp.businessobject.DisbursementPayee;
 import org.kuali.kfs.fp.businessobject.lookup.DisbursementPayeeLookupableHelperServiceImpl;
 import org.kuali.kfs.fp.document.DisbursementVoucherDocument;
-import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.rice.coreservice.framework.CoreFrameworkServiceLocator;
@@ -38,17 +37,25 @@ import edu.arizona.kfs.sys.UaKFSConstants;
 public class UaDisbursementPayeeLookupableHelperServiceImpl extends DisbursementPayeeLookupableHelperServiceImpl {
 	private static final long serialVersionUID = 1L;
 
+	private static volatile PersonService personService;
+
+	private PersonService getPersonService() {
+		if (personService == null) {
+			personService = SpringContext.getBean(PersonService.class);
+		}
+		return personService;
+	}
+
+
 	/**
 	 * @see org.kuali.kfs.fp.businessobject.lookup.DisbursementPayeeLookupableHelperServiceImpl#getPersonAsPayees(java.util.Map)
 	 */
-	@SuppressWarnings("deprecation")
 	protected List<DisbursementPayee> getPersonAsPayees(Map<String, String> fieldValues) {
 		List<DisbursementPayee> payeeList = new ArrayList<DisbursementPayee>();
 
 		ArrayList<String> employeeStatusCodes = new ArrayList<String>(CoreFrameworkServiceLocator.getParameterService().getParameterValuesAsString(DisbursementVoucherDocument.class, UaKFSConstants.ACTIVE_EMPLOYEE_STATUS_CODES_PARAM_NAME));
 		if (ObjectUtils.isNull(employeeStatusCodes) || employeeStatusCodes.isEmpty()) {
-			employeeStatusCodes = new ArrayList<String>();
-			employeeStatusCodes.add(KFSConstants.EMPLOYEE_ACTIVE_STATUS);
+			throw new RuntimeException("The ACTIVE_EMPLOYEE_STATUS_CODES parameter has no values.");
 		}
 
 		for (String statusCode : employeeStatusCodes) {
@@ -81,15 +88,6 @@ public class UaDisbursementPayeeLookupableHelperServiceImpl extends Disbursement
 		}
 
 		return payeeList;
-	}
-
-	private static volatile PersonService personService;
-
-	private PersonService getPersonService() {
-		if (personService == null) {
-			personService = SpringContext.getBean(PersonService.class);
-		}
-		return personService;
 	}
 
 	@Override

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/lookup/UaDisbursementPayeeLookupableHelperServiceImpl.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/lookup/UaDisbursementPayeeLookupableHelperServiceImpl.java
@@ -16,15 +16,20 @@
 package edu.arizona.kfs.fp.businessobject.lookup;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.fp.businessobject.DisbursementPayee;
 import org.kuali.kfs.fp.businessobject.lookup.DisbursementPayeeLookupableHelperServiceImpl;
 import org.kuali.kfs.fp.document.DisbursementVoucherDocument;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.rice.coreservice.framework.CoreFrameworkServiceLocator;
 import org.kuali.rice.kim.api.identity.Person;
-import org.kuali.rice.kim.api.services.KimApiServiceLocator;
+import org.kuali.rice.kim.api.identity.PersonService;
 import org.kuali.rice.kim.impl.KIMPropertyConstants;
 import org.kuali.rice.krad.util.ObjectUtils;
 
@@ -36,17 +41,18 @@ public class UaDisbursementPayeeLookupableHelperServiceImpl extends Disbursement
 	/**
 	 * @see org.kuali.kfs.fp.businessobject.lookup.DisbursementPayeeLookupableHelperServiceImpl#getPersonAsPayees(java.util.Map)
 	 */
+	@SuppressWarnings("deprecation")
 	protected List<DisbursementPayee> getPersonAsPayees(Map<String, String> fieldValues) {
 		List<DisbursementPayee> payeeList = new ArrayList<DisbursementPayee>();
 
-		List<String> employeeStatusCodes = (List<String>) CoreFrameworkServiceLocator.getParameterService().getParameterValuesAsString(DisbursementVoucherDocument.class, UaKFSConstants.ACTIVE_EMPLOYEE_STATUS_CODES_PARAM_NAME);
+		ArrayList<String> employeeStatusCodes = new ArrayList<String>(CoreFrameworkServiceLocator.getParameterService().getParameterValuesAsString(DisbursementVoucherDocument.class, UaKFSConstants.ACTIVE_EMPLOYEE_STATUS_CODES_PARAM_NAME));
 		if (ObjectUtils.isNull(employeeStatusCodes) || employeeStatusCodes.isEmpty()) {
-			return super.getPersonAsPayees(fieldValues);
+			employeeStatusCodes = new ArrayList<String>();
+			employeeStatusCodes.add(KFSConstants.EMPLOYEE_ACTIVE_STATUS);
 		}
 
 		for (String statusCode : employeeStatusCodes) {
 			List<DisbursementPayee> payeesByEmployeeStatusCode = this.getPersonAsPayeesByEmployeeStatusCode(fieldValues, statusCode);
-
 			payeeList.addAll(payeesByEmployeeStatusCode);
 		}
 
@@ -65,15 +71,47 @@ public class UaDisbursementPayeeLookupableHelperServiceImpl extends Disbursement
 	protected List<DisbursementPayee> getPersonAsPayeesByEmployeeStatusCode(Map<String, String> fieldValues, String employeeStatusCode) {
 		List<DisbursementPayee> payeeList = new ArrayList<DisbursementPayee>();
 
-		fieldValues.put(KIMPropertyConstants.Person.EMPLOYEE_STATUS_CODE, employeeStatusCode);
-		List<? extends Person> persons = KimApiServiceLocator.getPersonService().findPeople(fieldValues);
+		Map<String, String> personFieldValues = this.getPersonFieldValues(fieldValues);
+		personFieldValues.put(KIMPropertyConstants.Person.EMPLOYEE_STATUS_CODE, employeeStatusCode);
+		List<? extends Person> persons = getPersonService().findPeople(personFieldValues);
 
 		for (Person personDetail : persons) {
-			DisbursementPayee payee = getPayeeFromPerson(personDetail, fieldValues);
+			DisbursementPayee payee = getPayeeFromPerson(personDetail, personFieldValues);
 			payeeList.add(payee);
 		}
 
 		return payeeList;
+	}
+
+	private static volatile PersonService personService;
+
+	private PersonService getPersonService() {
+		if (personService == null) {
+			personService = SpringContext.getBean(PersonService.class);
+		}
+		return personService;
+	}
+
+	@Override
+	protected Map<String, String> getPersonFieldValues(Map<String, String> fieldValues) {
+		Map<String, String> personFieldValues = new HashMap<String, String>();
+		String firstName = fieldValues.get(KFSPropertyConstants.PERSON_FIRST_NAME);
+		String lastName = fieldValues.get(KFSPropertyConstants.PERSON_LAST_NAME);
+		String employeeID = fieldValues.get(KFSPropertyConstants.EMPLOYEE_ID);
+		String active = fieldValues.get(KFSPropertyConstants.ACTIVE);
+		if (StringUtils.isNotBlank(firstName)) {
+			personFieldValues.put(KFSPropertyConstants.PERSON_FIRST_NAME, firstName);
+		}
+		if (StringUtils.isNotBlank(lastName)) {
+			personFieldValues.put(KFSPropertyConstants.PERSON_LAST_NAME, lastName);
+		}
+		if (StringUtils.isNotBlank(employeeID)) {
+			personFieldValues.put(KFSPropertyConstants.EMPLOYEE_ID, employeeID);
+		}
+		if (StringUtils.isNotBlank(active)) {
+			personFieldValues.put(KFSPropertyConstants.ACTIVE, active);
+		}
+		return personFieldValues;
 	}
 
 }

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/spring-fp.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/spring-fp.xml
@@ -33,4 +33,7 @@
     <import resource="document/validation/configuration/DisbursementVoucherValidation.xml" />
 
     <bean id="disbursementVoucherInvoiceService" class="edu.arizona.kfs.fp.service.impl.DisbursementVoucherInvoiceServiceImpl" />
+
+    <bean id="disbursementPayeeLookupableHelperService" scope="prototype" parent="disbursementPayeeLookupableHelperService-parentBean" class="edu.arizona.kfs.fp.businessobject.lookup.UaDisbursementPayeeLookupableHelperServiceImpl" />
+
 </beans>


### PR DESCRIPTION
Turns out UaDisbursementPayeeLookupableHelperServiceImpl was not being used by the initial EDS modification. Created an override bean for disbursementPayeeLookupableHelperService to point to this class, and now the class is being used. After this, it was discovered that an employee search uses the 3 fields Person First Name, Person Last Name, and Employee ID with all 3 fields being required. If a field is blank ("") in the search, the field must be blank in the database. Added logic so that it will only use the fields in the search if there is something entered into the fields. Wildcard functionality was maintained.
