### PR TITLE
UAF-2303 - Rice LDAP and EDS functionality Needs to be Re-Factored and Re-Wired

### DIFF
--- a/kfs-core/src/main/resources/spring-rice-kim-overrides.xml
+++ b/kfs-core/src/main/resources/spring-rice-kim-overrides.xml
@@ -39,15 +39,11 @@
        p:kimTypeInfoService-ref="kimTypeInfoService"
        p:roleService-ref="kimRoleService"
        p:cacheManager-ref="kimLocalCacheManager">
-        <property name="identityService" ref="kimIdentityDelegateService"/>
+        <property name="identityService" ref="kimIdentityService"/>
     </bean>
 
     <bean id="kimRoleTypeService" class=" edu.arizona.kfs.sys.identity.UaEmployeeDerivedRoleTypeServiceImpl">
         <property name="edsConstants" ref="edsConstants"/>
     </bean>
 
-     <bean id="kimIdentityService" class="edu.arizona.kim.identity.impl.UaIdentityCurrentAndArchivedServiceImpl">
-        <constructor-arg ref="kimIdentityArchiveService"/>
-        <constructor-arg ref="kimIdentityDelegateService"/>
-    </bean>
 </beans>


### PR DESCRIPTION
Removing IdentityService et. al. overrides, since this is now sorted out by changes made in Rice under this ticket.
