### PR TITLE
UAF-2378 Changes to use rice.version 2.1.10-ua-release1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <oracle.artifactId>ojdbc6</oracle.artifactId>
     <oracle.version>11.2.0.3</oracle.version>
     <p6spy.version>1.3-patched</p6spy.version>
-    <rice.version>2.1.10</rice.version>
+    <rice.version>2.1.10-ua-release1-SNAPSHOT</rice.version>
     <servlet-api.version>2.5</servlet-api.version>
     <velocity.version>1.5</velocity.version>
     <wss4j.version>1.6.18</wss4j.version>
@@ -160,12 +160,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
           <version>2.6</version>
-          <configuration>
-            <packagingExcludes>
-              WEB-INF/lib/rice-kim-impl-${rice.version}.jar,
-              WEB-INF/lib/rice-impl-${rice.version}.jar
-             </packagingExcludes>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.tomcat.maven</groupId>
@@ -500,8 +494,7 @@
     <dependency>
       <groupId>org.kuali.rice</groupId>
       <artifactId>rice-kim-impl</artifactId>
-      <version>${project.version}</version>
-      <classifier>ua-ksd</classifier>
+      <version>${rice.version}</version>
       <exclusions>
         <exclusion>
           <groupId>xapool</groupId>
@@ -512,8 +505,7 @@
     <dependency>
       <groupId>org.kuali.rice</groupId>
       <artifactId>rice-kim-ldap</artifactId>
-      <version>${project.version}</version>
-      <classifier>ua-ksd</classifier>
+      <version>${rice.version}</version>
     </dependency>
     <dependency>
       <groupId>org.kuali.rice</groupId>
@@ -688,8 +680,7 @@
     <dependency>
       <groupId>org.kuali.rice</groupId>
       <artifactId>rice-impl</artifactId>
-      <version>${project.version}</version>
-      <classifier>ua-ksd</classifier>
+      <version>${rice.version}</version>
       <exclusions>
         <exclusion>
           <groupId>javax.resource</groupId>


### PR DESCRIPTION
Removed the section excluding the non-UA rice jars, removed the previous UA changes for the rice-kim-impl, rice-kim-ldap, and rice-impl .jar files, and updated the rice.version to a 2.1.10-release1-SNAPSHOT.
