### PR TITLE
UAF-66 / UAF-1978 / UAF-1979 MOD-PA7000-02 US Export Controls Process Update - eCustoms (Step 3)

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/vnd/VendorConstants.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/vnd/VendorConstants.java
@@ -17,13 +17,16 @@ public class VendorConstants extends org.kuali.kfs.vnd.VendorConstants {
     public static final String ECUSTOMS_FILENAME = "eCustomsCompliance";
     public static final SimpleDateFormat ECUSTOMS_FILENAME_DATE_FORMAT = new SimpleDateFormat("yyyyMMdd_HHmmss");
     public static final String ECUSTOMS_BATCH_DAILY = "ECUSTOMS DAILY BATCH";
+    public static final String ECUSTOMS_BATCH_ANNUAL = "ECUSTOMS ANNUAL BATCH";
 
     // eCustoms uses a windows file format so enforce carriage return/line feed for new line. default is to use the server OS line terminator
     public static final String ECUSTOMS_OUTPUT_FILE_LINE_TERMINATOR = "\r\n";
     public static final String ECUSTOMS_OUTPUT_FILE_DELIMITER = "|";
     public static final String ECUSTOMS_UNDERSCORE = "_";
     public static final String ECUSTOMS_DONE_MESSAGE_DAILY = "Ecustoms Daily Step Complete";
+    public static final String ECUSTOMS_DONE_MESSAGE_ANNUAL = "Ecustoms Annual Step Complete";
     public static final String ECUSTOMS_DAILY_JOB_NAME = "DAILY";
+    public static final String ECUSTOMS_ANNUAL_JOB_NAME = "ANNUAL";
 
     // these are search string used to find new/updated vendors based on workflow note text
     public static final String ECUSTOMS_ADD_VENDOR_NOTE_TEXT = "Add vendor document ID";

--- a/kfs-core/src/main/java/edu/arizona/kfs/vnd/batch/EcustomsAnnualStep.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/vnd/batch/EcustomsAnnualStep.java
@@ -1,0 +1,42 @@
+package edu.arizona.kfs.vnd.batch;
+
+import java.util.Date;
+
+import org.apache.log4j.Logger;
+import org.kuali.kfs.sys.batch.AbstractStep;
+import org.kuali.kfs.sys.context.SpringContext;
+
+import edu.arizona.kfs.vnd.service.EcustomsService;
+
+/**
+ * UAF-66 MOD-PA7000-02 ECustoms - US Export Compliance
+ *
+ * This step generates the daily eCustoms data files.
+ *
+ * @author Adam Kost kosta@email.arizona.edu
+ */
+
+public class EcustomsAnnualStep extends AbstractStep {
+    private static final Logger LOG = Logger.getLogger(EcustomsAnnualStep.class);
+    private static transient volatile EcustomsService ecustomsService;
+
+    private EcustomsService getEcustomsService() {
+        if (ecustomsService == null) {
+            ecustomsService = SpringContext.getBean(EcustomsService.class);
+        }
+        return ecustomsService;
+    }
+
+    @Override
+    public boolean execute(String jobName, Date jobRunDate) throws InterruptedException {
+        boolean retval = false;
+        try {
+            retval = getEcustomsService().createEcustomsAnnualFile(jobName, jobRunDate);
+        } catch (Exception e) {
+            LOG.error("Error when running EcustomsAnnualStep: " + e.getMessage());
+            throw new InterruptedException(e.getMessage());
+        }
+        return retval;
+    }
+
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/vnd/service/EcustomsFileService.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/vnd/service/EcustomsFileService.java
@@ -39,6 +39,40 @@ public interface EcustomsFileService {
      */
     public void createDailyBatchDoneFile(Date jobRunDate) throws IOException;
 
+
+    /**
+     * This method creates and returns a file for output of annual results.
+     *
+     * @return File for annual batch output.
+     * @throws IOException
+     * @throws Exception
+     */
+    public File getAnnualBatchDataFile(Date jobRunDate) throws IOException;
+
+    /**
+     * This method creates and returns a File for storing the vendor count of the annual job.
+     *
+     * @return File
+     * @throws IOException
+     * @throws Exception
+     */
+    public File getAnnualBatchVendorCountFile(Date jobRunDate) throws IOException;
+
+    /**
+     * This method creates a file that indicates the annual job completed successfully.
+     *
+     * @throws IOException
+     */
+    public void createAnnualBatchDoneFile(Date jobRunDate) throws IOException;
+
+    /**
+     * This method deletes any existing done files created for annual jobs.
+     *
+     * @return false if no files were deleted, otherwise true.
+     * @throws IOException
+     */
+    public boolean deleteOldAnnualDoneFiles() throws IOException;
+
     /**
      * This method deletes existing done files
      *

--- a/kfs-core/src/main/java/edu/arizona/kfs/vnd/service/EcustomsService.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/vnd/service/EcustomsService.java
@@ -21,4 +21,14 @@ public interface EcustomsService {
      */
     public boolean createEcustomsDailyFile(String jobName, Date jobRunDate) throws Exception;
 
+    /**
+     * This method creates an eCustoms file for all vendors for annual verification.
+     *
+     * @param jobName
+     * @param jobRunDate
+     * @return true if file successfully created
+     * @throws Exception
+     */
+    public boolean createEcustomsAnnualFile(String jobName, Date jobRunDate) throws Exception;
+
 }

--- a/kfs-core/src/main/java/edu/arizona/kfs/vnd/service/impl/EcustomsFileServiceImpl.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/vnd/service/impl/EcustomsFileServiceImpl.java
@@ -67,8 +67,22 @@ public class EcustomsFileServiceImpl implements EcustomsFileService {
     }
 
     @Override
+    public File getAnnualBatchDataFile(Date jobRunDate) throws IOException {
+        String filename = getAnnualBatchDataFileName(jobRunDate);
+        File file = createFile(filename);
+        return file;
+    }
+
+    @Override
     public File getDailyBatchVendorCountFile(Date jobRunDate) throws IOException {
         String filename = getDailyBatchVendorCountFileName(jobRunDate);
+        File file = createFile(filename);
+        return file;
+    }
+
+    @Override
+    public File getAnnualBatchVendorCountFile(Date jobRunDate) throws IOException {
+        String filename = getAnnualBatchVendorCountFileName(jobRunDate);
         File file = createFile(filename);
         return file;
     }
@@ -90,10 +104,42 @@ public class EcustomsFileServiceImpl implements EcustomsFileService {
     }
 
     @Override
+    public void createAnnualBatchDoneFile(Date jobRunDate) throws IOException {
+        String filename = getAnnualBatchDoneFileName(jobRunDate);
+        File file = createFile(filename);
+        FileOutputStream fileOutputStream = new FileOutputStream(file);
+        fileOutputStream.write(VendorConstants.ECUSTOMS_DONE_MESSAGE_ANNUAL.getBytes());
+        fileOutputStream.flush();
+        fileOutputStream.close();
+    }
+
+    @Override
     public boolean deleteOldDailyDoneFiles() throws IOException {
         File outputDir = new File(getOutputFileDirectory());
         if (outputDir.exists() && outputDir.isDirectory()) {
             String filenameFilter = KFSConstants.WILDCARD_CHARACTER + VendorConstants.ECUSTOMS_DAILY_JOB_NAME + KFSConstants.WILDCARD_CHARACTER + VendorConstants.FILE_EXTENSION_DONE;
+            FileFilter filter = new SuffixFileFilter(filenameFilter);
+            File[] oldDoneFiles = outputDir.listFiles(filter);
+            if (oldDoneFiles == null) {
+                return false;
+            }
+            if (oldDoneFiles != null) {
+                for (int i = 0; i < oldDoneFiles.length; ++i) {
+                    LOG.debug("deleting file " + oldDoneFiles[i].getAbsolutePath());
+                    if (!FileUtils.deleteQuietly(oldDoneFiles[i])) {
+                        LOG.warn("unable to delete file " + oldDoneFiles[i].getAbsolutePath());
+                    }
+                }
+            }
+        }
+        return true;
+    };
+
+    @Override
+    public boolean deleteOldAnnualDoneFiles() throws IOException {
+        File outputDir = new File(getOutputFileDirectory());
+        if (outputDir.exists() && outputDir.isDirectory()) {
+            String filenameFilter = KFSConstants.WILDCARD_CHARACTER + VendorConstants.ECUSTOMS_ANNUAL_JOB_NAME + KFSConstants.WILDCARD_CHARACTER + VendorConstants.FILE_EXTENSION_DONE;
             FileFilter filter = new SuffixFileFilter(filenameFilter);
             File[] oldDoneFiles = outputDir.listFiles(filter);
             if (oldDoneFiles == null) {
@@ -133,13 +179,28 @@ public class EcustomsFileServiceImpl implements EcustomsFileService {
         return retval;
     }
 
+    private String getAnnualBatchDataFileName(Date jobRunDate) throws IOException {
+        String retval = getFileName(VendorConstants.ECUSTOMS_ANNUAL_JOB_NAME, VendorConstants.FILE_EXTENSION_DATA, jobRunDate);
+        return retval;
+    }
+
     private String getDailyBatchDoneFileName(Date jobRunDate) throws IOException {
         String retval = getFileName(VendorConstants.ECUSTOMS_DAILY_JOB_NAME, VendorConstants.FILE_EXTENSION_DONE, jobRunDate);
         return retval;
     }
 
+    private String getAnnualBatchDoneFileName(Date jobRunDate) throws IOException {
+        String retval = getFileName(VendorConstants.ECUSTOMS_ANNUAL_JOB_NAME, VendorConstants.FILE_EXTENSION_DONE, jobRunDate);
+        return retval;
+    }
+
     private String getDailyBatchVendorCountFileName(Date jobRunDate) throws IOException {
         String retval = getFileName(VendorConstants.ECUSTOMS_DAILY_JOB_NAME, VendorConstants.FILE_EXTENSION_COUNT, jobRunDate);
+        return retval;
+    }
+
+    private String getAnnualBatchVendorCountFileName(Date jobRunDate) throws IOException {
+        String retval = getFileName(VendorConstants.ECUSTOMS_ANNUAL_JOB_NAME, VendorConstants.FILE_EXTENSION_COUNT, jobRunDate);
         return retval;
     }
 

--- a/kfs-core/src/main/resources/edu/arizona/kfs/vnd/spring-vnd.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/vnd/spring-vnd.xml
@@ -31,6 +31,7 @@
         <property name="jobNames">
             <list merge="true">
                 <value>eCustomsDailyJob</value>
+                <value>eCustomsAnnualJob</value>
             </list>
         </property>
 	</bean>
@@ -66,6 +67,15 @@
         </property>
     </bean>
 
+    <bean id="eCustomsAnnualJob" parent="unscheduledJobDescriptor">
+        <property name="steps">
+            <list>
+                <ref bean="eCustomsAnnualStep" />
+            </list>
+        </property>
+    </bean>
+
     <bean id="eCustomsDailyStep" class="edu.arizona.kfs.vnd.batch.EcustomsDailyStep" parent="step" />
+    <bean id="eCustomsAnnualStep" class="edu.arizona.kfs.vnd.batch.EcustomsAnnualStep" parent="step" />
 
 </beans>


### PR DESCRIPTION
This is the third (and final) step of the modification for MOD-PA7000-02 US Export Controls Process Update - eCustoms, to create the annual batch job to process all active vendors currently in the database.

included are:  
1) a bug was discovered that null values surfaced when a Vendor has no active address that matches the Vendor Address Type.
2) a minor performance enhancement when generating the output line. While this enhancement provides a relatively insignificant performance boost during a Daily Job's 50-100 Vendors, this performance boost is significant when processing the ~62,000 active vendors currently in the database.
