### PR TITLE
UAF-2506 In BudgetShellCode.xml changed the validation from AlphaNume…

### DIFF
--- a/kfs-core/src/main/resources/edu/arizona/kfs/coa/businessobject/datadictionary/BudgetShellCode.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/coa/businessobject/datadictionary/BudgetShellCode.xml
@@ -100,7 +100,7 @@
         <property name="required"           value="true"                                    />
         <property name="maxLength"          value="45"                                      />
         <property name="validationPattern">
-            <bean parent="AlphaNumericValidationPattern" p:allowWhitespace="true"/>
+            <bean parent="AnyCharacterValidationPattern" p:allowWhitespace="true"/>
         </property>
         <property name="control">
             <bean parent="TextControlDefinition"            p:size="50"                />
@@ -115,7 +115,7 @@
         <property name="required"           value="false"                                   />
         <property name="maxLength"          value="1000"                                    />
         <property name="validationPattern">
-            <bean parent="AlphaNumericValidationPattern" p:allowWhitespace="true"/>
+            <bean parent="AnyCharacterValidationPattern" p:allowWhitespace="true"/>
         </property>
         <property name="control">
             <bean parent="TextareaControlDefinition"            p:size="1000"               />
@@ -143,7 +143,7 @@
         <property name="required"           value="true"                                    />
         <property name="maxLength"          value="55"                                      />
         <property name="validationPattern">
-            <bean parent="AlphaNumericValidationPattern" p:allowWhitespace="true"/>
+            <bean parent="AnyCharacterValidationPattern" p:allowWhitespace="true"/>
         </property>
         <property name="control">
             <bean parent="TextControlDefinition"            p:size="60"                 />

--- a/kfs-core/src/main/resources/edu/arizona/kfs/coa/document/datadictionary/BudgetShellCodeMaintenanceDocument.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/coa/document/datadictionary/BudgetShellCodeMaintenanceDocument.xml
@@ -66,25 +66,5 @@
 
     <!-- Exported Workflow Properties -->
 
-    <bean id="BudgetShellCodeMaintenanceDocument-workflowAttributes"            class="org.kuali.rice.krad.datadictionary.WorkflowAttributes">
-        <property name="searchingTypeDefinitions">
-            <list>
-                <bean class="org.kuali.rice.krad.datadictionary.SearchingTypeDefinition">
-                    <property name="searchingAttribute">
-                        <bean class="org.kuali.rice.krad.datadictionary.SearchingAttribute">
-                            <property name="businessObjectClassName"        value="edu.arizona.kfs.coa.businessobject.BudgetShellCode"  />
-                            <property name="attributeName"                  value="budgetShellCode"                                     />
-                            <property name="showAttributeInSearchCriteria"  value="true"                                                />
-                            <property name="showAttributeInResultSet"       value="true"                                                />
-                        </bean>
-                    </property>
-                    <property name="documentValues">
-                        <list>
-                            <value>newMaintainableObject.businessObject.budgetShellCode</value>
-                        </list>
-                    </property>
-                </bean>
-            </list>
-        </property>
-    </bean>
+    <bean id="BudgetShellCodeMaintenanceDocument-workflowAttributes" class="org.kuali.rice.krad.datadictionary.WorkflowAttributes"/>
 </beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/coa/document/datadictionary/CrossOrganizationCodeMaintenanceDocument.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/coa/document/datadictionary/CrossOrganizationCodeMaintenanceDocument.xml
@@ -48,25 +48,5 @@
 
     <!-- Exported Workflow Properties -->
 
-    <bean id="CrossOrganizationCodeMaintenanceDocument-workflowAttributes"      class="org.kuali.rice.krad.datadictionary.WorkflowAttributes">
-        <property name="searchingTypeDefinitions">
-            <list>
-                <bean class="org.kuali.rice.krad.datadictionary.SearchingTypeDefinition">
-                    <property name="searchingAttribute">
-                        <bean class="org.kuali.rice.krad.datadictionary.SearchingAttribute">
-                            <property name="businessObjectClassName"        value="edu.arizona.kfs.coa.businessobject.CrossOrganizationCode"    />
-                            <property name="attributeName"                  value="crossOrganizationCode"                                       />
-                            <property name="showAttributeInSearchCriteria"  value="true"                                                        />
-                            <property name="showAttributeInResultSet"       value="true"                                                        />
-                        </bean>
-                    </property>
-                    <property name="documentValues">
-                        <list>
-                            <value>newMaintainableObject.businessObject.crossOrganizationCode</value>
-                        </list>
-                    </property>
-                </bean>
-            </list>
-        </property>
-    </bean>
+    <bean id="CrossOrganizationCodeMaintenanceDocument-workflowAttributes" class="org.kuali.rice.krad.datadictionary.WorkflowAttributes"/>
 </beans>


### PR DESCRIPTION
…ricValidationPattern to AnyCharacterValidationPattern for budget shell name, budget shell description, and group name per the requirements.  In BudgetShellCodeMaintenanceDocument.xml and CrossOrganizationCodeMaintenanceDocument.xml removed the searching attribute. This removes the second Budget Shell Code field and Cross Organization Code from a doc search where the Document Type is SHEL and CORG respectively. This also fixes the issue where a doc search by Document Type SHEL (or CORG) was returning no results when there should be.
