### PR TITLE
UAF-149 UAF-1994 Added the route node for Organization Fund Reviewer to the ACCT and GACC Documents

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/coa/businessobject/options/OrgReviewRolesValuesFinder.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/coa/businessobject/options/OrgReviewRolesValuesFinder.java
@@ -1,0 +1,27 @@
+package edu.arizona.kfs.coa.businessobject.options;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.arizona.kfs.sys.KFSConstants;
+import org.kuali.rice.core.api.util.ConcreteKeyValue;
+import org.kuali.rice.core.api.util.KeyValue;
+
+public class OrgReviewRolesValuesFinder extends org.kuali.kfs.coa.businessobject.options.OrgReviewRolesValuesFinder {
+
+	
+	/**
+     * Creates a list of {@link BasicAccountingCategory} with their code as the key and their code and description as the display
+     * value
+     */
+	@Override
+    public List getKeyValues() {
+        List<KeyValue> labels = new ArrayList<KeyValue>();
+        labels.add(new ConcreteKeyValue("", ""));
+        labels.add(new ConcreteKeyValue(KFSConstants.COAConstants.ORG_REVIEW_ROLE_ORG_ACC_ONLY_CODE, KFSConstants.COAConstants.ORG_REVIEW_ROLE_ORG_ACC_ONLY_TEXT));
+        labels.add(new ConcreteKeyValue(KFSConstants.COAConstants.ORG_REVIEW_ROLE_ORG_ONLY_CODE, KFSConstants.COAConstants.ORG_REVIEW_ROLE_ORG_ONLY_TEXT));
+        labels.add(new ConcreteKeyValue(KFSConstants.COAConstants.ORG_REVIEW_ROLE_ORG_FUND_ONLY_CODE, KFSConstants.COAConstants.ORG_REVIEW_ROLE_ORG_FUND_ONLY_TEXT));
+        labels.add(new ConcreteKeyValue(KFSConstants.COAConstants.ORG_REVIEW_ROLE_ORG_ACC_BOTH_CODE, KFSConstants.COAConstants.ORG_REVIEW_ROLE_ORG_ACC_BOTH_TEXT));
+        return labels;
+    }
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/coa/document/validation/impl/OrgReviewRoleRule.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/coa/document/validation/impl/OrgReviewRoleRule.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.coa.identity.OrgReviewRole;
+import edu.arizona.kfs.sys.KFSConstants;
 import org.kuali.rice.kim.api.KimConstants;
 import org.kuali.rice.kns.document.MaintenanceDocument;
 
@@ -27,6 +28,51 @@ public class OrgReviewRoleRule extends org.kuali.kfs.coa.document.validation.imp
 		}
 		return valid;
 	}
+	
+	@Override
+    protected boolean validateRoleMember(OrgReviewRole orr){
+        boolean valid = true;
+        if(StringUtils.isNotEmpty(orr.getPrincipalMemberPrincipalName())){
+            if (orr.getPerson() == null) {
+                putFieldError(OrgReviewRole.PRINCIPAL_NAME_FIELD_NAME, "error.document.orgReview.invalidPrincipal"
+                        , getDataDictionaryService().getAttributeLabel(OrgReviewRole.class, OrgReviewRole.PRINCIPAL_NAME_FIELD_NAME) );
+                valid = false;
+            }
+        }
+        if(StringUtils.isNotEmpty(orr.getRoleMemberRoleName())){
+            if ( StringUtils.equals( KFSConstants.SysKimApiConstants.ACCOUNTING_REVIEWER_ROLE_NAME, orr.getRoleMemberRoleName())
+                    || StringUtils.equals( KFSConstants.SysKimApiConstants.ORGANIZATION_REVIEWER_ROLE_NAME, orr.getRoleMemberRoleName() ) ) {
+                putFieldError(OrgReviewRole.ROLE_NAME_FIELD_NAME, "error.document.orgReview.recursiveRole" );
+            } else {
+                if(orr.getRole() == null){
+                    putFieldError(OrgReviewRole.ROLE_NAME_FIELD_NAME, "error.document.orgReview.invalidRole"
+                            , new String[] {
+                                      getDataDictionaryService().getAttributeLabel(OrgReviewRole.class, OrgReviewRole.ROLE_NAME_FIELD_NAME)
+                                    , getDataDictionaryService().getAttributeLabel(OrgReviewRole.class, OrgReviewRole.ROLE_NAME_FIELD_NAMESPACE_CODE)
+                                    } );
+                    valid = false;
+                }
+            }
+        }
+        if(StringUtils.isNotEmpty(orr.getGroupMemberGroupName())){
+            if( orr.getGroup() == null ){
+                putFieldError(OrgReviewRole.GROUP_NAME_FIELD_NAME, "error.document.orgReview.invalidGroup"
+                        , new String[] {
+                                  getDataDictionaryService().getAttributeLabel(OrgReviewRole.class, OrgReviewRole.GROUP_NAME_FIELD_NAME)
+                                , getDataDictionaryService().getAttributeLabel(OrgReviewRole.class, OrgReviewRole.GROUP_NAME_FIELD_NAMESPACE_CODE)
+                                } );
+                valid = false;
+            }
+        }
+        for(String roleName : orr.getRoleNamesToConsider()) {
+        	if(StringUtils.equals(roleName, KFSConstants.SysKimApiConstants.ORGANIZATION_FUND_REVIEWER_ROLE_NAME) && StringUtils.isBlank(orr.getFundGroupCode()) && StringUtils.isBlank(orr.getSubFundGroupCode())) {
+        		putFieldError(KfsKimAttributes.SUB_FUND_GROUP_CODE, "error.member.fundgroup.subfundgroup.onerequired");
+        		valid = false;
+        	}
+        }
+        
+        return valid;
+    }
 	
 	@Override
 	protected boolean doAttributesMatch(OrgReviewRole orr, Map<String,String> attributeSet){

--- a/kfs-core/src/main/java/edu/arizona/kfs/coa/document/validation/impl/OrgReviewRoleRule.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/coa/document/validation/impl/OrgReviewRoleRule.java
@@ -26,6 +26,13 @@ public class OrgReviewRoleRule extends org.kuali.kfs.coa.document.validation.imp
 			putFieldError(OrgReviewRole.SUB_FUND_GROUP_FIELD_NAME, "error.member.fundgroup.subfundgroup.bothentered");
 			valid = false;
 		}
+		
+		for(String roleName : orr.getRoleNamesToConsider()) {
+			if(StringUtils.equals(roleName, KFSConstants.SysKimApiConstants.ORGANIZATION_FUND_REVIEWER_ROLE_NAME) && StringUtils.isBlank(orr.getFundGroupCode()) && StringUtils.isBlank(orr.getSubFundGroupCode())) {
+				putFieldError(KfsKimAttributes.SUB_FUND_GROUP_CODE, "error.member.fundgroup.subfundgroup.onerequired");
+				valid = false;
+			}
+		}
 		return valid;
 	}
 	
@@ -41,7 +48,8 @@ public class OrgReviewRoleRule extends org.kuali.kfs.coa.document.validation.imp
         }
         if(StringUtils.isNotEmpty(orr.getRoleMemberRoleName())){
             if ( StringUtils.equals( KFSConstants.SysKimApiConstants.ACCOUNTING_REVIEWER_ROLE_NAME, orr.getRoleMemberRoleName())
-                    || StringUtils.equals( KFSConstants.SysKimApiConstants.ORGANIZATION_REVIEWER_ROLE_NAME, orr.getRoleMemberRoleName() ) ) {
+                    || StringUtils.equals( KFSConstants.SysKimApiConstants.ORGANIZATION_REVIEWER_ROLE_NAME, orr.getRoleMemberRoleName() )
+                    || StringUtils.equals(KFSConstants.SysKimApiConstants.ORGANIZATION_FUND_REVIEWER_ROLE_NAME, orr.getRoleMemberRoleName())) {
                 putFieldError(OrgReviewRole.ROLE_NAME_FIELD_NAME, "error.document.orgReview.recursiveRole" );
             } else {
                 if(orr.getRole() == null){
@@ -63,12 +71,6 @@ public class OrgReviewRoleRule extends org.kuali.kfs.coa.document.validation.imp
                                 } );
                 valid = false;
             }
-        }
-        for(String roleName : orr.getRoleNamesToConsider()) {
-        	if(StringUtils.equals(roleName, KFSConstants.SysKimApiConstants.ORGANIZATION_FUND_REVIEWER_ROLE_NAME) && StringUtils.isBlank(orr.getFundGroupCode()) && StringUtils.isBlank(orr.getSubFundGroupCode())) {
-        		putFieldError(KfsKimAttributes.SUB_FUND_GROUP_CODE, "error.member.fundgroup.subfundgroup.onerequired");
-        		valid = false;
-        	}
         }
         
         return valid;

--- a/kfs-core/src/main/java/edu/arizona/kfs/coa/identity/OrganizationFundReviewRoleTypeServiceImpl.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/coa/identity/OrganizationFundReviewRoleTypeServiceImpl.java
@@ -94,10 +94,6 @@ public class OrganizationFundReviewRoleTypeServiceImpl extends OrganizationHiera
         return this.documentTypeService;
     }
     
-    public void setDocumentTypeService(DocumentTypeService documentTypeService) {
-        this.documentTypeService = documentTypeService;
-    }
-
     @Override
     public List<KimAttributeField> getAttributeDefinitions(String kimTypeId) {
     	List<KimAttributeField> fields = super.getAttributeDefinitions(kimTypeId);

--- a/kfs-core/src/main/java/edu/arizona/kfs/coa/identity/OrganizationFundReviewRoleTypeServiceImpl.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/coa/identity/OrganizationFundReviewRoleTypeServiceImpl.java
@@ -1,0 +1,119 @@
+package edu.arizona.kfs.coa.identity;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.coa.identity.OrganizationHierarchyAwareRoleTypeServiceBase;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.rice.core.api.uif.RemotableAttributeField;
+import org.kuali.rice.kew.api.doctype.DocumentTypeService;
+import org.kuali.rice.kim.api.KimConstants;
+import org.kuali.rice.kim.api.type.KimAttributeField;
+import org.kuali.rice.kim.util.KimCommonUtils;
+
+import edu.arizona.kfs.sys.identity.KfsKimAttributes;
+
+public class OrganizationFundReviewRoleTypeServiceImpl extends OrganizationHierarchyAwareRoleTypeServiceBase {
+
+	private DocumentTypeService documentTypeService;
+
+    /**
+     * Attributes: Chart Code (required) Organization Code Document Type Name Requirement and either the Fund or SubFund - 
+     * Traverse the org hierarchy but not the document type hierarchy
+     */
+    @Override
+    protected boolean performMatch(Map<String, String> qualification, Map<String, String> roleQualifier) {
+        if (isParentOrg(qualification.get(KfsKimAttributes.CHART_OF_ACCOUNTS_CODE), qualification.get(KfsKimAttributes.ORGANIZATION_CODE), roleQualifier.get(KfsKimAttributes.CHART_OF_ACCOUNTS_CODE), roleQualifier.get(KfsKimAttributes.ORGANIZATION_CODE), true)) {
+            if (doesFundGroupMatch(qualification, roleQualifier) && doesSubFundGroupMatch(qualification, roleQualifier)) {
+                Set<String> potentialParentDocumentTypeNames = new HashSet<String>();
+                if (roleQualifier.containsKey(KimConstants.AttributeConstants.DOCUMENT_TYPE_NAME)) {
+                    potentialParentDocumentTypeNames.add(roleQualifier.get(KimConstants.AttributeConstants.DOCUMENT_TYPE_NAME));
+                }
+                return potentialParentDocumentTypeNames.isEmpty() 
+                        || StringUtils.equalsIgnoreCase( qualification.get(KimConstants.AttributeConstants.DOCUMENT_TYPE_NAME), roleQualifier.get(KimConstants.AttributeConstants.DOCUMENT_TYPE_NAME)) 
+                        || (KimCommonUtils.getClosestParentDocumentTypeName(getDocumentTypeService().getDocumentTypeByName(qualification.get(KimConstants.AttributeConstants.DOCUMENT_TYPE_NAME)), potentialParentDocumentTypeNames) != null);
+            }             
+        }
+        return false;
+    }
+    
+    /**
+     * comparison for role FG vs. document FG
+     */
+    protected boolean doesFundGroupMatch(Map<String, String> qualification, Map<String, String> roleQualifier) {
+        if (roleQualifier == null || StringUtils.isBlank(roleQualifier.get(KfsKimAttributes.FUND_GROUP_CODE))) {
+            return true;
+        }
+
+        String roleFundGroup = roleQualifier.get(KfsKimAttributes.FUND_GROUP_CODE);        
+
+        if (qualification == null) {
+            return false;
+        }
+        String documentFundGroup = qualification.get(KfsKimAttributes.FUND_GROUP_CODE);
+
+        // check for an exact match
+        return StringUtils.equals(roleFundGroup, documentFundGroup);
+    }
+
+    /**
+     * comparison for role SFG vs. document SFG
+     */
+    protected boolean doesSubFundGroupMatch(Map<String, String> qualification, Map<String, String> roleQualifier) {
+        if (roleQualifier == null || StringUtils.isBlank(roleQualifier.get(KfsKimAttributes.SUB_FUND_GROUP_CODE))) {
+            return true;
+        }
+        String roleSubFund = roleQualifier.get(KfsKimAttributes.SUB_FUND_GROUP_CODE);        
+        
+        if (qualification == null) {
+            return false;
+        }
+        String documentSubFund = qualification.get(KfsKimAttributes.SUB_FUND_GROUP_CODE);
+
+        // check for an exact match
+        if ( StringUtils.equals(roleSubFund, documentSubFund) ) {
+            return true;
+        } else {
+        	// if contains an "*", convert to regex and compare again
+            if (StringUtils.contains(roleSubFund, '*')) {
+                String subFundPattern = StringUtils.replace(roleSubFund, "*", ".*");
+                return documentSubFund.matches(subFundPattern);
+            }
+        }        
+        return false;
+    }
+    
+    public DocumentTypeService getDocumentTypeService() {
+        if (documentTypeService == null) {
+            documentTypeService = SpringContext.getBean(DocumentTypeService.class);
+        }
+        return this.documentTypeService;
+    }
+    
+    public void setDocumentTypeService(DocumentTypeService documentTypeService) {
+        this.documentTypeService = documentTypeService;
+    }
+
+    @Override
+    public List<KimAttributeField> getAttributeDefinitions(String kimTypeId) {
+    	List<KimAttributeField> fields = super.getAttributeDefinitions(kimTypeId);
+    	List<KimAttributeField> updatedFields = new ArrayList<KimAttributeField>(fields.size());
+    	
+        for (KimAttributeField definition : fields) {      	
+        	//if field is organization code, fund group code, sub fund group code or object sub type code
+            if (KfsKimAttributes.ORGANIZATION_CODE.equals(definition.getAttributeField().getName()) || StringUtils.equals(definition.getAttributeField().getName(), KfsKimAttributes.FUND_GROUP_CODE)
+                    || StringUtils.equals(definition.getAttributeField().getName(), KfsKimAttributes.SUB_FUND_GROUP_CODE) || StringUtils.equals(definition.getAttributeField().getName(), KfsKimAttributes.OBJECT_SUB_TYPE_CODE)) {
+            	KimAttributeField.Builder updatedField = KimAttributeField.Builder.create(definition);
+            	updatedField.getAttributeField().setRequired(false);
+            	updatedFields.add(updatedField.build());
+            } else {
+            	updatedFields.add(definition);
+            }
+        }
+        return fields;
+    }
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/coa/service/impl/OrgReviewRoleServiceImpl.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/coa/service/impl/OrgReviewRoleServiceImpl.java
@@ -8,11 +8,85 @@ import java.util.Map;
 import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.coa.identity.KfsKimDocumentAttributeData;
 import org.kuali.kfs.coa.identity.OrgReviewRole;
+import edu.arizona.kfs.sys.KFSConstants;
+
 import edu.arizona.kfs.sys.identity.KfsKimAttributes;
 import org.kuali.rice.kim.api.KimConstants;
+import org.kuali.rice.krad.exception.ValidationException;
+import org.springframework.cache.annotation.Cacheable;
 
 public class OrgReviewRoleServiceImpl extends org.kuali.kfs.coa.service.impl.OrgReviewRoleServiceImpl {
 
+	/**
+     *  1. Check WorkflowInfo.hasNode(documentTypeName, nodeName) to see if the document type selected has
+     *  OrganizationHierarchy and/or AccountingOrganizationHierarchy - if it has either or both,
+     *  set the Review Types radio group appropriately and make it read only.
+     *  2. Else, if KFS is the document type selected, set the Review Types radio group to both and leave it editable.
+     *  3. Else, if FinancialSystemTransactionalDocument is the closest parent (per KimCommonUtils.getClosestParent),
+     *  set the Review Types radio group to Organization Accounting Only and leave it editable.
+     *  4. Else, if FinancialSystemComplexMaintenanceDocument is the closest parent (per KimCommonUtils.getClosestParent),
+     *  set the Review Types radio group to Organization Only and make read-only.
+     *  5. Else, if FinancialSystemSimpleMaintenanceDocument is the closest parent (per KimCommonUtils.getClosestParent),
+     *  this makes no sense and should generate an error.
+     * @param documentTypeName
+     * @param hasOrganizationHierarchy
+     * @param hasOrganizationFundReview
+     * @param hasAccountingOrganizationHierarchy
+     * @param closestParentDocumentTypeName
+     * @return
+     */
+    @Override
+    @Cacheable(value=OrgReviewRole.CACHE_NAME,key="'{getRolesToConsider}'+#p0")
+    public List<String> getRolesToConsider(String documentTypeName) throws ValidationException {
+        List<String> rolesToConsider = new ArrayList<String>();
+        if(StringUtils.isBlank(documentTypeName) || KFSConstants.ROOT_DOCUMENT_TYPE.equals(documentTypeName) ){
+            rolesToConsider.add(KFSConstants.SysKimApiConstants.ORGANIZATION_REVIEWER_ROLE_NAME);
+            rolesToConsider.add(KFSConstants.SysKimApiConstants.ACCOUNTING_REVIEWER_ROLE_NAME);
+            rolesToConsider.add(KFSConstants.SysKimApiConstants.ORGANIZATION_FUND_REVIEWER_ROLE_NAME);
+        } else {
+            String closestParentDocumentTypeName = getClosestOrgReviewRoleParentDocumentTypeName(documentTypeName);
+            if(documentTypeName.equals(KFSConstants.FINANCIAL_SYSTEM_TRANSACTIONAL_DOCUMENT)
+                    || KFSConstants.FINANCIAL_SYSTEM_TRANSACTIONAL_DOCUMENT.equals(closestParentDocumentTypeName)) {
+                rolesToConsider.add(KFSConstants.SysKimApiConstants.ACCOUNTING_REVIEWER_ROLE_NAME);
+            } else {
+            	boolean hasOrganizationFundReview = hasOrganizationFundReview(documentTypeName);
+                if(hasOrganizationFundReview) {
+                	rolesToConsider.add(KFSConstants.SysKimApiConstants.ORGANIZATION_FUND_REVIEWER_ROLE_NAME);
+                } else {
+                	boolean hasOrganizationHierarchy = hasOrganizationHierarchy(documentTypeName);
+                	boolean hasAccountingOrganizationHierarchy = hasAccountingOrganizationHierarchy(documentTypeName);
+                	if(hasOrganizationHierarchy || documentTypeName.equals(KFSConstants.FINANCIAL_SYSTEM_COMPLEX_MAINTENANCE_DOCUMENT)
+                			|| KFSConstants.FINANCIAL_SYSTEM_COMPLEX_MAINTENANCE_DOCUMENT.equals(closestParentDocumentTypeName) ) {
+                		rolesToConsider.add(KFSConstants.SysKimApiConstants.ORGANIZATION_REVIEWER_ROLE_NAME);
+                	}
+                	if(hasAccountingOrganizationHierarchy) {
+                		rolesToConsider.add(KFSConstants.SysKimApiConstants.ACCOUNTING_REVIEWER_ROLE_NAME);
+                	}
+                }
+            }
+        }
+        return rolesToConsider;
+    }
+    
+    @Override
+    protected List<String> getRolesToSaveFor(List<String> roleNamesToConsider, String reviewRolesIndicator){
+        if(roleNamesToConsider!=null){
+            List<String> roleToSaveFor = new ArrayList<String>();
+            if(KFSConstants.COAConstants.ORG_REVIEW_ROLE_ORG_ACC_ONLY_CODE.equals(reviewRolesIndicator)){
+                roleToSaveFor.add(KFSConstants.SysKimApiConstants.ACCOUNTING_REVIEWER_ROLE_NAME);
+            } else if(KFSConstants.COAConstants.ORG_REVIEW_ROLE_ORG_ONLY_CODE.equals(reviewRolesIndicator)){
+                roleToSaveFor.add(KFSConstants.SysKimApiConstants.ORGANIZATION_REVIEWER_ROLE_NAME);
+            } else if(KFSConstants.COAConstants.ORG_REVIEW_ROLE_ORG_FUND_ONLY_CODE.equals(reviewRolesIndicator)) {
+            	roleToSaveFor.add(KFSConstants.SysKimApiConstants.ORGANIZATION_FUND_REVIEWER_ROLE_NAME);
+            } else{
+                roleToSaveFor.addAll(roleNamesToConsider);
+            }
+            return roleToSaveFor;
+        } else {
+            return Collections.emptyList();
+        }
+    }
+    
 	@Override
 	protected Map<String,String> getAttributes(OrgReviewRole orr, String kimTypeId){
         if( StringUtils.isBlank(kimTypeId) ) {

--- a/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSConstants.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSConstants.java
@@ -1,8 +1,60 @@
 package edu.arizona.kfs.sys;
 
+import org.kuali.kfs.sys.KFSConstants.CoreModuleNamespaces;
+
 public class KFSConstants extends org.kuali.kfs.sys.KFSConstants {
 
     public static final String INVOICE_NUMBER = "Invoice Number";
     public static final String DUPLICATE_INVOICE_QUESTION_ID = "DVDuplicateInvoice";
+    
+    public static class SysKimApiConstants{
+        public static final String ACCOUNT_SUPERVISOR_KIM_ROLE_NAME = "Account Supervisor";
+        public static final String CONTRACTS_AND_GRANTS_PROJECT_DIRECTOR = "Contracts & Grants Project Director";
+        public static final String FISCAL_OFFICER_KIM_ROLE_NAME = "Fiscal Officer";
+        public static final String FISCAL_OFFICER_PRIMARY_DELEGATE_KIM_ROLE_NAME = "Fiscal Officer Primary Delegate";
+        public static final String FISCAL_OFFICER_SECONDARY_DELEGATE_KIM_ROLE_NAME = "Fiscal Officer Secondary Delegate";
+        public static final String AWARD_SECONDARY_DIRECTOR_KIM_ROLE_NAME = "Award Project Director";
+        public static final String ACTIVE_FACULTY_OR_STAFF_KIM_ROLE_NAME = "Active Faculty or Staff";
+        public static final String ACTIVE_PROFESSIONAL_EMPLOYEE_KIM_ROLE_NAME = "Active Professional Employee";
+        public static final String ACTIVE_EMPLOYEE_AND_KFS_USER_KIM_ROLE_NAME = "Active Employee & Financial System User";
+        public static final String ACTIVE_PROFESSIONAL_EMPLOYEE_AND_KFS_USER_KIM_ROLE_NAME = "Active Professional Employee & Financial System User";
+        public static final String CHART_MANAGER_KIM_ROLE_NAME = "Chart Manager";
+        public static final String ORGANIZATION_REVIEWER_ROLE_NAMESPACECODE = CoreModuleNamespaces.KFS;
+        public static final String ACCOUNTING_REVIEWER_ROLE_NAMESPACECODE = CoreModuleNamespaces.KFS;
+        public static final String ACCOUNTING_REVIEWER_ROLE_NAME = "Accounting Reviewer";
+        public static final String ORGANIZATION_REVIEWER_ROLE_NAME = "Organization Reviewer";
+        public static final String ACCOUNTS_RECEIVABLE_COLLECTOR = "CGB Collector";
+        public static final String KFS_USER_ROLE_NAME = "User";
+        public static final String CONTRACTS_AND_GRANTS_PROCESSOR = "Contracts & Grants Processor";
+        public static final String SUB_FUND_REVIEWER = "Sub-Fund Reviewer";
+        public static final String ORGANIZATION_FUND_REVIEWER_ROLE_NAME = "Organization Fund Reviewer";
+    }
+    
+    public class RouteLevelNames {
+        public static final String ACCOUNT = "Account";
+        public static final String ACCOUNTING_ORGANIZATION_HIERARCHY = "AccountingOrganizationHierarchy";
+        public static final String ACCOUNT_REVIEW_FULL_EDIT = "AccountFullEdit";
+        public static final String PROJECT_MANAGEMENT = "ProjectManagement";
+        public static final String ORGANIZATION_HIERARCHY = "OrganizationHierarchy";
+        public static final String PAYMENT_METHOD = "PaymentMethod";
+        public static final String ORGANIZATION_FUND_REVIEW = "OrganizationFundReview";   
+    }
+    
+    public static class COAConstants{
+        public static final String ORG_REVIEW_ROLE_ORG_ACC_ONLY_CODE = "A";
+        public static final String ORG_REVIEW_ROLE_ORG_ACC_ONLY_TEXT = "Organization Accounting Only";
+        public static final String ORG_REVIEW_ROLE_ORG_ONLY_CODE = "O";
+        public static final String ORG_REVIEW_ROLE_ORG_ONLY_TEXT = "Organization Only";
+        public static final String ORG_REVIEW_ROLE_ORG_FUND_ONLY_CODE = "F";
+        public static final String ORG_REVIEW_ROLE_ORG_FUND_ONLY_TEXT = "Organization Fund Only";
+        public static final String ORG_REVIEW_ROLE_ORG_ACC_BOTH_CODE = "B";
+        public static final String ORG_REVIEW_ROLE_ORG_ACC_BOTH_TEXT = "Both";
+        public static final String ORG_REVIEW_ROLE_CREATE_DELEGATION_DISPLAY_TEXT = "create delegation";
+
+        public final static String DEFAULT_CHART_METHOD = "1";
+        public final static String DEFAULT_PRIMARY_DEPT_METHOD = "2";
+        public final static String DEFAULT_PRIMARY_DEPT_CHART_METHOD = "3"; 
+
+    }
 
 }

--- a/kfs-core/src/main/java/org/kuali/kfs/coa/identity/OrgReviewRole.java
+++ b/kfs-core/src/main/java/org/kuali/kfs/coa/identity/OrgReviewRole.java
@@ -35,7 +35,7 @@ import org.kuali.kfs.coa.businessobject.SubFundGroup;
 import org.kuali.kfs.coa.service.ChartService;
 import org.kuali.kfs.coa.service.OrgReviewRoleService;
 import org.kuali.kfs.coa.service.OrganizationService;
-import org.kuali.kfs.sys.KFSConstants;
+import edu.arizona.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.kfs.sys.context.SpringContext;
 import edu.arizona.kfs.sys.identity.KfsKimAttributes;
@@ -557,6 +557,8 @@ public class OrgReviewRole extends PersistableBusinessObjectBase implements Muta
                 setReviewRolesIndicatorOnDocTypeChange(KFSConstants.COAConstants.ORG_REVIEW_ROLE_ORG_ACC_ONLY_CODE);
             } else if(isOrgReviewRoleIndicator()) {
                 setReviewRolesIndicatorOnDocTypeChange(KFSConstants.COAConstants.ORG_REVIEW_ROLE_ORG_ONLY_CODE);
+            } else if(isOrgFundReviewRoleIndicator()) {
+            	setReviewRolesIndicatorOnDocTypeChange(KFSConstants.COAConstants.ORG_REVIEW_ROLE_ORG_FUND_ONLY_CODE);
             }
         }
     }
@@ -701,6 +703,7 @@ public class OrgReviewRole extends PersistableBusinessObjectBase implements Muta
     public boolean isBothReviewRolesIndicator() {
         return getRoleNamesToConsider()!=null &&
             getRoleNamesToConsider().contains(KFSConstants.SysKimApiConstants.ORGANIZATION_REVIEWER_ROLE_NAME) &&
+            getRoleNamesToConsider().contains(KFSConstants.SysKimApiConstants.ORGANIZATION_FUND_REVIEWER_ROLE_NAME) &&
             getRoleNamesToConsider().contains(KFSConstants.SysKimApiConstants.ACCOUNTING_REVIEWER_ROLE_NAME);
     }
     /**
@@ -710,6 +713,15 @@ public class OrgReviewRole extends PersistableBusinessObjectBase implements Muta
     public boolean isOrgReviewRoleIndicator() {
         return getRoleNamesToConsider()!=null &&
             getRoleNamesToConsider().contains(KFSConstants.SysKimApiConstants.ORGANIZATION_REVIEWER_ROLE_NAME);
+    }
+    
+    /**
+     * Gets the orgFundReviewRoleIndicator attribute.
+     * @return Returns the orgFundReviewRoleIndicator
+     */
+    public boolean isOrgFundReviewRoleIndicator() {
+    	return getRoleNamesToConsider() != null &&
+    			getRoleNamesToConsider().contains(KFSConstants.SysKimApiConstants.ORGANIZATION_FUND_REVIEWER_ROLE_NAME);
     }
     /**
      * Gets the actionTypeCode attribute.

--- a/kfs-core/src/main/java/org/kuali/kfs/coa/service/OrgReviewRoleService.java
+++ b/kfs-core/src/main/java/org/kuali/kfs/coa/service/OrgReviewRoleService.java
@@ -36,6 +36,7 @@ public interface OrgReviewRoleService {
 
     boolean hasAccountingOrganizationHierarchy(final String documentTypeName);
     boolean hasOrganizationHierarchy(final String documentTypeName);
+    boolean hasOrganizationFundReview(final String documentTypeName);
     String getClosestOrgReviewRoleParentDocumentTypeName(final String documentTypeName);
 
     RoleMember getRoleMemberFromKimRoleService( String roleMemberId );

--- a/kfs-core/src/main/java/org/kuali/kfs/coa/service/impl/OrgReviewRoleServiceImpl.java
+++ b/kfs-core/src/main/java/org/kuali/kfs/coa/service/impl/OrgReviewRoleServiceImpl.java
@@ -33,7 +33,7 @@ import org.kuali.kfs.coa.identity.KfsKimDocRoleMember;
 import org.kuali.kfs.coa.identity.KfsKimDocumentAttributeData;
 import org.kuali.kfs.coa.identity.OrgReviewRole;
 import org.kuali.kfs.coa.service.OrgReviewRoleService;
-import org.kuali.kfs.sys.KFSConstants;
+import edu.arizona.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.identity.KfsKimAttributes;
 import org.kuali.rice.core.api.criteria.PredicateUtils;
 import org.kuali.rice.core.api.criteria.QueryByCriteria;
@@ -163,6 +163,15 @@ public class OrgReviewRoleServiceImpl implements OrgReviewRoleService {
         return getDocumentTypeService().hasRouteNodeForDocumentTypeName(KFSConstants.RouteLevelNames.ACCOUNTING_ORGANIZATION_HIERARCHY, documentTypeName);
     }
 
+    @Override
+    @Cacheable(value=OrgReviewRole.CACHE_NAME,key="'{hasOrganizationFundReview}'+#p0")
+    public boolean hasOrganizationFundReview(final String documentTypeName) {
+    	  if(StringUtils.isBlank(documentTypeName)) {
+              return false;
+          }
+          return getDocumentTypeService().hasRouteNodeForDocumentTypeName(KFSConstants.RouteLevelNames.ORGANIZATION_FUND_REVIEW, documentTypeName);
+    }
+    
     @Override
     @Cacheable(value=OrgReviewRole.CACHE_NAME,key="'{ClosestOrgReviewRoleParentDocumentTypeName}'+#p0")
     public String getClosestOrgReviewRoleParentDocumentTypeName(final String documentTypeName){

--- a/kfs-core/src/main/resources/edu/arizona/kfs/coa/businessobject/datadictionary/OrgReviewRole.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/coa/businessobject/datadictionary/OrgReviewRole.xml
@@ -42,18 +42,13 @@
 	</property>    
   </bean>
 
-  <bean id="OrgReviewRole-reviewRolesIndicator" parent="OrgReviewRole-reviewRolesIndicator-parentBean" />
-  <bean id="OrgReviewRole-reviewRolesIndicator-parentBean" abstract="true" parent="AttributeDefinition">
-		<property name="name" value="reviewRolesIndicator" />
-		<property name="label" value="Review Types" />
-		<property name="shortLabel" value="Review Types" />
-		<property name="required" value="true" />
+  <bean id="OrgReviewRole-reviewRolesIndicator" parent="OrgReviewRole-reviewRolesIndicator-parentBean">
 		<property name="control">
 			<bean parent="RadioControlDefinition"
 				p:valuesFinderClass="edu.arizona.kfs.coa.businessobject.options.OrgReviewRolesValuesFinder"
 				p:includeKeyInLabel="true" />
 		</property>
-	</bean>
+  </bean>
 			
   <bean id="OrgReviewRole-fundGroupCode" parent="OrgReviewRole-fundGroupCode-parentBean"/>
   <bean id="OrgReviewRole-fundGroupCode-parentBean" parent="KfsKimAttributes-fundGroupCode" abstract="true" p:name="fundGroupCode" p:required="false"/>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/coa/businessobject/datadictionary/OrgReviewRole.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/coa/businessobject/datadictionary/OrgReviewRole.xml
@@ -41,7 +41,20 @@
       </list>
 	</property>    
   </bean>
-		
+
+  <bean id="OrgReviewRole-reviewRolesIndicator" parent="OrgReviewRole-reviewRolesIndicator-parentBean" />
+  <bean id="OrgReviewRole-reviewRolesIndicator-parentBean" abstract="true" parent="AttributeDefinition">
+		<property name="name" value="reviewRolesIndicator" />
+		<property name="label" value="Review Types" />
+		<property name="shortLabel" value="Review Types" />
+		<property name="required" value="true" />
+		<property name="control">
+			<bean parent="RadioControlDefinition"
+				p:valuesFinderClass="edu.arizona.kfs.coa.businessobject.options.OrgReviewRolesValuesFinder"
+				p:includeKeyInLabel="true" />
+		</property>
+	</bean>
+			
   <bean id="OrgReviewRole-fundGroupCode" parent="OrgReviewRole-fundGroupCode-parentBean"/>
   <bean id="OrgReviewRole-fundGroupCode-parentBean" parent="KfsKimAttributes-fundGroupCode" abstract="true" p:name="fundGroupCode" p:required="false"/>
 	

--- a/kfs-core/src/main/resources/edu/arizona/kfs/coa/coa-resources.properties
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/coa/coa-resources.properties
@@ -1,2 +1,5 @@
 #OrgReview Document Error Messages UAF-50
 error.member.fundgroup.subfundgroup.bothentered=Fund group and Sub-Fund Group may not both be specified on a single organization review record.
+
+#Organization Fund Reviewer Error Message UAF-1994 
+error.member.fundgroup.subfundgroup.onerequired=For this organization review role, either a Fund group or a Sub-Fund group must be specified.

--- a/kfs-core/src/main/resources/edu/arizona/kfs/coa/document/datadictionary/AccountGlobalMaintenanceDocument.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/coa/document/datadictionary/AccountGlobalMaintenanceDocument.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" 
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xmlns:p="http://www.springframework.org/schema/p" 
+	xmlns:dd="http://rice.kuali.org/dd" 
+	xsi:schemaLocation="http://www.springframework.org/schema/beans         
+		http://www.springframework.org/schema/beans/spring-beans-2.0.xsd         
+		http://rice.kuali.org/dd         
+		http://rice.kuali.org/dd/dd.xsd">
+		
+		
+	<!-- workflow attributes -->
+	<bean id="AccountGlobalMaintenanceDocument-workflowAttributes" parent="AccountGlobalMaintenanceDocument-workflowAttributes-parentBean">
+		<property name="routingTypeDefinitions">
+    		<map>
+	    		<entry key="Chart" value-ref="AccountGlobalMaintenanceDocument-RoutingType-Chart"/>
+	    		<entry key="OrganizationFundReview" value-ref="AccountGlobalMaintenanceDocument-RoutingType-OrganizationFundReview"/>
+    		</map>
+		</property>
+	</bean>
+	
+	<bean id="AccountGlobalMaintenanceDocument-DocumentValuePathGroup-ChartOrganizationFund" class="org.kuali.rice.krad.datadictionary.DocumentValuePathGroup">
+		<property name="documentCollectionPath">
+			<bean parent="AccountGlobalMaintenanceDocument-DocumentCollectionPath-chartOrganizationFund">
+				<property name="collectionPath" value="newMaintainableObject.businessObject.accountGlobalDetails"/>
+			</bean>
+		</property>
+	</bean>
+	
+	<bean id="AccountGlobalMaintenanceDocument-DocumentCollectionPath-chartOrganizationFund" class="org.kuali.rice.krad.datadictionary.DocumentCollectionPath" abstract="true">
+		<property name="documentValues">
+			<list>
+				<value>chartOfAccountsCode</value>
+				<value>account.organizationCode</value>
+				<value>account.subFundGroup.fundGroupCode</value>
+				<value>account.subFundGroupCode</value>
+			</list>
+		</property>
+	</bean>
+	
+	<bean id="AccountGlobalMaintenanceDocument-RoutingType-OrganizationFundReview" class="org.kuali.rice.krad.datadictionary.RoutingTypeDefinition">
+		<property name="routingAttributes">
+			<list>
+				<ref bean="RoutingAttribute-Chart"/>
+				<ref bean="RoutingAttribute-Organization"/>
+				<ref bean="RoutingAttribute-fundGroupCode"/>
+				<ref bean="RoutingAttribute-SubFund"/>
+			</list>
+		</property>
+		<property name="documentValuePathGroups">
+			<list>
+				<ref bean="AccountGlobalMaintenanceDocument-DocumentValuePathGroup-ChartOrganizationFund"/>
+			</list>
+		</property>
+	</bean>
+	
+</beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/coa/document/datadictionary/AccountMaintenanceDocument.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/coa/document/datadictionary/AccountMaintenanceDocument.xml
@@ -33,4 +33,45 @@
             </list>
         </property>
     </bean>
+    
+    <!-- workflow attributes -->
+    <bean id="AccountMaintenanceDocument-workflowAttributes" parent="AccountMaintenanceDocument-workflowAttributes-parentBean">
+    	<property name="routingTypeDefinitions">
+    		<map>
+    			<entry key="Account" value-ref="AccountMaintenanceDocument-RoutingType-Account"/>
+    			<entry key="OrganizationFundReview" value-ref="AccountMaintenanceDocument-RoutingType-OrganizationFundReview"/>
+    			<entry key="Chart" value-ref="RoutingType-MaintenanceDocument-Chart"/>
+    			<entry key="AccountSupervisor" value-ref="AccountMaintenanceDocument-RoutingType-Account"/>
+    			<entry key="Award" value-ref="AccountMaintenanceDocument-RoutingType-Award"/>
+    			<entry key="SubFund" value-ref="RoutingType-MaintenanceDocument-SubFund"/>
+    		</map>
+		</property>
+    </bean>
+    
+    <bean id="AccountMaintenanceDocument-DocumentValuePathGroup-ChartOrganizationFund" class="org.kuali.rice.krad.datadictionary.DocumentValuePathGroup">
+    	<property name="documentValues">
+    		<list>
+    			<value>newMaintainableObject.businessObject.chartOfAccountsCode</value>
+    			<value>newMaintainableObject.businessObject.organizationCode</value>
+    			<value>newMaintainableObject.businessObject.subFundGroup.fundGroupCode</value>
+    			<value>newMaintainableObject.businessObject.subFundGroupCode</value>
+    		</list>
+    	</property>
+    </bean>
+    
+    <bean id="AccountMaintenanceDocument-RoutingType-OrganizationFundReview" class="org.kuali.rice.krad.datadictionary.RoutingTypeDefinition">
+    	<property name="routingAttributes">
+    		<list>
+    			<ref bean="RoutingAttribute-Chart"/>
+    			<ref bean="RoutingAttribute-Organization"/>
+    			<ref bean="RoutingAttribute-fundGroupCode"/>
+    			<ref bean="RoutingAttribute-SubFund"/>
+    		</list>
+    	</property>
+    	<property name="documentValuePathGroups">
+    		<list>
+    			<ref bean="AccountMaintenanceDocument-DocumentValuePathGroup-ChartOrganizationFund"/>
+    		</list>
+    	</property>
+    </bean>
 </beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/coa/spring-coa.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/coa/spring-coa.xml
@@ -41,4 +41,7 @@
 	<bean id="orgReviewRoleService" parent="orgReviewRoleService-parentBean" />
 	<bean id="orgReviewRoleService-parentBean" class="edu.arizona.kfs.coa.service.impl.OrgReviewRoleServiceImpl" abstract="true" />
 	
+	<bean id="organizationFundReviewRoleTypeService" parent="organizationFundReviewRoleTypeService-parentBean"/>
+	<bean id="organizationFundReviewRoleTypeService-parentBean" parent="organizationHierarchyAwareRoleTypeService" class="edu.arizona.kfs.coa.identity.OrganizationFundReviewRoleTypeServiceImpl" abstract="true"/>
+	
 </beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/workflow/AccountGlobalMaintenanceDocument.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/workflow/AccountGlobalMaintenanceDocument.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<data xmlns="ns:workflow" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="ns:workflow resource:WorkflowData">
+  <documentTypes xmlns="ns:workflow/DocumentType" xsi:schemaLocation="ns:workflow/DocumentType resource:DocumentType">
+    <documentType>
+      <name>GACC</name>
+      <parent>COA</parent>
+      <label>Account Global</label>
+      <helpDefinitionURL>default.htm?turl=WordDocuments%2Faccountglobal.htm</helpDefinitionURL>
+      <active>true</active>
+      <routingVersion>2</routingVersion>
+      <routePaths>
+        <routePath>
+          <start name="AdHoc" nextNode="OrganizationFundReview" />
+          <role name="OrganizationFundReview" nextNode="Chart" />
+          <role name="Chart" />
+        </routePath>
+      </routePaths>
+      <routeNodes>
+        <start name="AdHoc" />
+        <role name="OrganizationFundReview">
+          <qualifierResolverClass>org.kuali.rice.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+          <activationType>P</activationType>
+        </role>
+        <role name="Chart">
+          <qualifierResolverClass>org.kuali.rice.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+          <activationType>P</activationType>
+        </role>
+      </routeNodes>
+    </documentType>
+  </documentTypes>
+</data>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/workflow/AccountMaintenanceDocument.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/workflow/AccountMaintenanceDocument.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<data xmlns="ns:workflow" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="ns:workflow resource:WorkflowData">
+  <documentTypes xmlns="ns:workflow/DocumentType" xsi:schemaLocation="ns:workflow/DocumentType resource:DocumentType">
+    <documentType>
+      <name>ACCT</name>
+      <parent>COA</parent>
+      <label>Account</label>
+      <helpDefinitionURL>default.htm?turl=WordDocuments%2Faccount.htm</helpDefinitionURL>
+      <active>true</active>
+      <routingVersion>2</routingVersion>
+      <routePaths>
+        <routePath>
+          <start name="AdHoc" nextNode="Account" />
+          <role name="Account" nextNode="OrganizationFundReview" />
+          <role name="OrganizationFundReview" nextNode="SubFund" />
+          <role name="SubFund" nextNode="Award" />
+          <role name="Award" nextNode="Chart" />
+          <role name="Chart" />
+        </routePath>
+      </routePaths>
+      <routeNodes>
+        <start name="AdHoc" />
+        <role name="Account">
+          <qualifierResolverClass>org.kuali.rice.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+          <activationType>P</activationType>
+        </role>
+        <role name="OrganizationFundReview">
+          <qualifierResolverClass>org.kuali.rice.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+          <activationType>P</activationType>
+        </role>
+        <role name="SubFund">
+          <qualifierResolverClass>org.kuali.rice.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+          <activationType>P</activationType>
+        </role>
+        <role name="Award">
+          <qualifierResolverClass>org.kuali.rice.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+          <activationType>P</activationType>
+        </role>
+        <role name="Chart">
+          <qualifierResolverClass>org.kuali.rice.krad.workflow.attribute.DataDictionaryQualifierResolver</qualifierResolverClass>
+          <activationType>P</activationType>
+        </role>
+      </routeNodes>
+    </documentType>
+  </documentTypes>
+</data>

--- a/kfs-core/src/main/resources/org/kuali/kfs/coa/spring-coa-bus-exports.xml
+++ b/kfs-core/src/main/resources/org/kuali/kfs/coa/spring-coa-bus-exports.xml
@@ -62,5 +62,8 @@
 		
 	<bean parent="roleTypeServiceCallback" 
 		p:callbackService-ref="contractsAndGrantsResponsibilityRoleTypeService" p:localServiceName="contractsAndGrantsResponsibilityRoleTypeService" />
+		
+	<bean parent="roleTypeServiceCallback" 
+		p:callbackService-ref="organizationFundReviewRoleTypeService" p:localServiceName="organizationFundReviewRoleTypeService" />
                            	 
 </beans>


### PR DESCRIPTION
spring-coa.xml
- Added the bean definition for the organizationFundReviewRoleTypeService and pointed it to the new OrganizationFundReviewRoleTypeServiceImpl.java that was created.

coa-resources.properties
- Added the error message that for the org review role, either Fund Group Code or Sub Fund Group Code must be specified.

AccountMaintenanceDocument.xml (DataDictionary)
- Added the routingTypeDefinition for the OrganizationFundReview to the workflow attributes.
- Added the bean definition for the Routing Attribute Fund with the qualificationAttributeName of fundGroupCode
- Added the bean definition for the DocumentValuePathGroup ChartOrganizationFund
- Added the bean definition for the routingtype OrganizationFundReview specifying the routingAttributes (including the new one added for Fund) and the new documentValuePathGroup that was created for ChartOrganizationFund

AccountMaintenanceDocument.xml (workflow)
- Added the workflow document to be ingested to the project.

AccountGlobalMaintenanceDocument.xml (DataDictionary)
- Added the workflow attribute routingTypeDefinition for the OrganizationFundReview
- Added the bean definition for the DocumentValuePathGroup ChartOrganizationFund
- Added the DocumentCollectionPath chartOrganizationFund
- Added the bean definition for the routingtype OrganizationFundReview specifying the routingAttributes (including the new one added for Fund) and the new documentValuePathGroup that was created for ChartOrganizationFund

AccountGlobalMaintenanceDocument.xml (workflow)
- Added the workflow document to be ingested to the project.

OrgReviewRolesValueFinder.java
- Created class to override the getKeyValues method to add in the org fund only code and text to the drop down list.

OrgReviewRole.xml
- Added override for the OrgReviewRole-reviewRolesIndicator to point to the OrgReviewRolesValuesFinder that was created.

KFSConstants.java
- Added the constant for the node OrganizationFundReview. Note: From KFS3 to KFS6 there were some changes, The route node names are now in a class called "RouteLevelNames" I added the constant there with the others.  I updated the name of the constant to match the other route node names.
- Added the constants for the drop down list: Code and description text

OrgReviewRole.java
- Added the method isOrgFundReviewRoleIndicator to get the orgFundReviewRoleIndicator attribute.
- Added the condition to return the role names for the Org Fund Reviewer in the isBothReviewRolesIndicator method
- Added the condition to the setRoleNamesAndReviewIndicator method if the isOrgFundReviewRoleIndicator is true to set the indicator on the document for the OrgFund Code

OrgReviewRoleServiceImpl.java
*\* In KFS3 this code was in the OrgReviewRoleLookupableHelperServiceImpl.java
- Added the method hasOrganizationFundReview to check to see if the document has the route node of OrganizationFundReview.  I had to add this method to the org.kuali version of the file because it would not compile from the edu.arizona package.
- Added the call to the new method hasOrganizationFundReview to the getRolesToConsider that checks to see if the document type selected has the route node.
- (EDU ARIZONA) Added code to getRolesToConsider method to add the OrganizationFundReview to the list of rolesToConsider.
- (EDU ARIZONA) Added code to the getRolesToSaveFor method as another statement that if the org fund code equals the review roles indicator to add the Org Fund Review role name to the list of roles to save for. *_This method was previously in the OrgReviewRoleMaintainableImpl.java in KFS3
  *_Part of the modification was an addition to a method called "parentAndChildrenHaveZeroOrgAndAccountReviewRoles", but this method seems to be non-existant in KFS6

OrgReviewRoleRule.java
- Added if statement to check if the role name matched Organization Fund Reviewer and check if the fund group code and sub fund group code were blank. If so, it would display an error that one of the fields were required for the org review role.

OrgReviewRoleMaintainableImpl.java
- Added override for the getSections method.  Added line of code to get back if the document has OrganziationFundReview indicator. Added two more conditions (hasOrganizationFundReview and hasAccountingOrganizationHierarchy) to the determine if Review type fields should be read only.
  **The method "shouldReviewTypesFieldBeReadOnly" doesn't exist in KFS6, but did in KFS3.  Looks like the method was rolled up into the getSections method in KFS6.
- Removed the prepareFieldsCommon method, this was causing the Fund Group Code, Sub-Fund Group Code and Object Sub-Type Code read only after returning a value from the Document Type search. (Not sure why I added this to this file for UAF-542 as I don't see it in the commits)

OrganizationFundReviewRoleTypeServiceImpl.java
- Created OrganizationFundReviewRoleTypeServiceImpl file
- Added the performMatch method which traverses the org hierarchy not the document type hierarchy
- Added the doesFundGroupMatch method to compare the role fund group code to the document fund group code
- Added the doesFundGroupMatch method to compare the role sub-fund group code to the document sub-fund group code
- Added the DocumentTypeService to be used to pull the document type name for the perform match method
- Added the getAttributeDefinition method

OrgReviewRoleService.java
- Added method signature to the interface for the new method added called hasOrganizationFundReview (was added to the OrgReviewRoleServiceImpl.java class in the org.kuali package)

spring-coa-bus-exports.xml
- added the bean for the roleTypeServiceCallback for the OrganizationFundReviewRoleTypeService.  This replaces the KSBServiceExporter that was used in the spring-coa.xml in KFS3 when defining the bean for the role type service.
