### PR TITLE
UAF-36 / UAF-1790 / UAF-1791 GEC Step 1 (Lookup & Validation)

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/GeneralErrorCorrectionDocument.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/GeneralErrorCorrectionDocument.java
@@ -1,0 +1,15 @@
+package edu.arizona.kfs.fp.document;
+
+/**
+ * This is the business object that represents the UA modifications for the GeneralErrorCorrectionDocument. This is a transactional document that
+ * will eventually post transactions to the G/L. It integrates with workflow and also contains two groupings of accounting lines:
+ * from and to. From lines are the source lines, to lines are the target lines.
+ *
+ * @author Adam Kost <kosta@email.arizona.edu> with some code adapted from UCI
+ */
+
+public class GeneralErrorCorrectionDocument extends org.kuali.kfs.fp.document.GeneralErrorCorrectionDocument {
+
+    private static final long serialVersionUID = 3559591546723165167L;
+
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/authorization/GeneralErrorCorrectionDocumentPresentationController.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/authorization/GeneralErrorCorrectionDocumentPresentationController.java
@@ -1,0 +1,32 @@
+package edu.arizona.kfs.fp.document.authorization;
+
+import java.util.Set;
+
+import org.kuali.rice.kew.api.WorkflowDocument;
+import org.kuali.rice.krad.document.Document;
+
+import edu.arizona.kfs.sys.KFSConstants;
+
+/**
+ * This is the UA modifications for the GeneralErrorCorrectionDocumentPresentationController.
+ *
+ * @author Adam Kost <kosta@email.arizona.edu> with some code adapted from UCI
+ */
+
+public class GeneralErrorCorrectionDocumentPresentationController extends org.kuali.kfs.fp.document.authorization.GeneralErrorCorrectionDocumentPresentationController {
+
+    private static final long serialVersionUID = 686769123687866738L;
+
+    @Override
+    public Set<String> getEditModes(Document document) {
+        Set<String> editModes = super.getEditModes(document);
+
+        WorkflowDocument workflowDocument = document.getDocumentHeader().getWorkflowDocument();
+        if (workflowDocument.isInitiated() || workflowDocument.isSaved()) {
+            editModes.add(KFSConstants.GL_ENTRY_IMPORTING);
+        }
+
+        return editModes;
+    }
+
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/validation/impl/GeneralErrorCorrectionDocumentRuleConstants.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/validation/impl/GeneralErrorCorrectionDocumentRuleConstants.java
@@ -1,0 +1,13 @@
+package edu.arizona.kfs.fp.document.validation.impl;
+
+/**
+ * Holds constants for <code>{@link edu.arizona.kfs.fp.document.GeneralErrorCorrectionDocument}</code> business rules.
+ *
+ * @author Adam Kost <kosta@email.arizona.edu> with some code adapted from UCI
+ */
+public class GeneralErrorCorrectionDocumentRuleConstants implements org.kuali.kfs.fp.document.validation.impl.GeneralErrorCorrectionDocumentRuleConstants {
+
+    public static final String DOCUMENT_TYPES = "DOCUMENT_TYPES";
+    public static final String ORIGIN_CODES = "ORIGIN_CODES";
+
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/web/struts/GeneralErrorCorrectionAction.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/web/struts/GeneralErrorCorrectionAction.java
@@ -1,0 +1,207 @@
+package edu.arizona.kfs.fp.document.web.struts;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Properties;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.kuali.kfs.sys.businessobject.SourceAccountingLine;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.kfs.sys.document.service.DebitDeterminerService;
+import org.kuali.kfs.sys.service.SegmentedLookupResultsService;
+import org.kuali.kfs.sys.web.struts.KualiAccountingDocumentFormBase;
+import org.kuali.rice.kns.web.struts.form.KualiForm;
+import org.kuali.rice.krad.service.BusinessObjectService;
+import org.kuali.rice.krad.util.GlobalVariables;
+import org.kuali.rice.krad.util.KRADConstants;
+import org.kuali.rice.krad.util.UrlFactory;
+
+import edu.arizona.kfs.gl.businessobject.Entry;
+import edu.arizona.kfs.sys.KFSConstants;
+
+/**
+ * This class is the UA modification of the GeneralErrorCorrectionAction.
+ *
+ * @author Adam Kost <kosta@email.arizona.edu> with some code adapted from UCI
+ */
+@SuppressWarnings("deprecation")
+public class GeneralErrorCorrectionAction extends org.kuali.kfs.fp.document.web.struts.GeneralErrorCorrectionAction {
+
+    private static transient volatile SegmentedLookupResultsService segmentedLookupResultsService;
+    private static transient volatile DebitDeterminerService debitDeterminerService;
+    private static transient volatile BusinessObjectService businessObjectService;
+
+    private static SegmentedLookupResultsService getSegmentedLookupResultsService() {
+        if (segmentedLookupResultsService == null) {
+            segmentedLookupResultsService = SpringContext.getBean(SegmentedLookupResultsService.class);
+        }
+        return segmentedLookupResultsService;
+    }
+
+    protected static DebitDeterminerService getDebitDeterminerService() {
+        if (debitDeterminerService == null) {
+            debitDeterminerService = SpringContext.getBean(DebitDeterminerService.class);
+        }
+        return debitDeterminerService;
+    }
+
+    protected BusinessObjectService getBusinessObjectService() {
+        if (businessObjectService == null) {
+            businessObjectService = SpringContext.getBean(BusinessObjectService.class);
+        }
+        return businessObjectService;
+    }
+
+    @Override
+    public ActionForward performLookup(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        // parse out the important strings from our methodToCall parameter
+        String fullParameter = (String) request.getAttribute(KFSConstants.METHOD_TO_CALL_ATTRIBUTE);
+
+        // determine what the action path is
+        String actionPath = StringUtils.substringBetween(fullParameter, KFSConstants.METHOD_TO_CALL_PARM4_LEFT_DEL, KFSConstants.METHOD_TO_CALL_PARM4_RIGHT_DEL);
+        if (StringUtils.isBlank(actionPath)) {
+            return super.performLookup(mapping, form, request, response);
+        }
+
+        GeneralErrorCorrectionForm financialDocumentForm = (GeneralErrorCorrectionForm) form;
+
+        // when we return from the lookup, our next request's method to call is going to be refresh
+        financialDocumentForm.registerEditableProperty(KRADConstants.DISPATCH_REQUEST_PARAMETER);
+
+        String basePath = request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort() + request.getContextPath();
+
+        // parse out business object class name for lookup
+        String boClassName = StringUtils.substringBetween(fullParameter, KFSConstants.METHOD_TO_CALL_BOPARM_LEFT_DEL, KFSConstants.METHOD_TO_CALL_BOPARM_RIGHT_DEL);
+        if (StringUtils.isBlank(boClassName)) {
+            throw new RuntimeException("Illegal call to perform lookup, no business object class name specified.");
+        }
+
+        // build the parameters for the lookup url
+        Properties parameters = new Properties();
+        String conversionFields = StringUtils.substringBetween(fullParameter, KFSConstants.METHOD_TO_CALL_PARM1_LEFT_DEL, KFSConstants.METHOD_TO_CALL_PARM1_RIGHT_DEL);
+        if (StringUtils.isNotBlank(conversionFields)) {
+            parameters.put(KFSConstants.CONVERSION_FIELDS_PARAMETER, conversionFields);
+        }
+
+        // pass values from form that should be pre-populated on lookup search
+        String parameterFields = StringUtils.substringBetween(fullParameter, KFSConstants.METHOD_TO_CALL_PARM2_LEFT_DEL, KFSConstants.METHOD_TO_CALL_PARM2_RIGHT_DEL);
+        if (StringUtils.isNotBlank(parameterFields)) {
+            String[] lookupParams = parameterFields.split(KFSConstants.FIELD_CONVERSIONS_SEPERATOR);
+
+            for (int i = 0; i < lookupParams.length; i++) {
+                String[] keyValue = lookupParams[i].split(KFSConstants.FIELD_CONVERSION_PAIR_SEPERATOR);
+
+                // hard-coded passed value
+                if (StringUtils.contains(keyValue[0], KRADConstants.SINGLE_QUOTE)) {
+                    parameters.put(keyValue[1], StringUtils.replace(keyValue[0], KRADConstants.SINGLE_QUOTE, KRADConstants.EMPTY_STRING));
+                }
+                // passed value should come from property
+                else if (StringUtils.isNotBlank(request.getParameter(keyValue[0]))) {
+                    parameters.put(keyValue[1], request.getParameter(keyValue[0]));
+                }
+            }
+        }
+
+        // grab whether or not the "return value" link should be hidden or not
+        String hideReturnLink = StringUtils.substringBetween(fullParameter, KFSConstants.METHOD_TO_CALL_PARM3_LEFT_DEL, KFSConstants.METHOD_TO_CALL_PARM3_RIGHT_DEL);
+        if (StringUtils.isNotBlank(hideReturnLink)) {
+            parameters.put(KFSConstants.HIDE_LOOKUP_RETURN_LINK, hideReturnLink);
+        }
+
+        // anchor, if it exists
+        if (form instanceof KualiForm && StringUtils.isNotEmpty(((KualiForm) form).getAnchor())) {
+            parameters.put(KFSConstants.LOOKUP_ANCHOR, ((KualiForm) form).getAnchor());
+        }
+
+        // now add required parameters
+        parameters.put(KFSConstants.DISPATCH_REQUEST_PARAMETER, KFSConstants.SEARCH_METHOD);
+        parameters.put(KFSConstants.DOC_FORM_KEY, GlobalVariables.getUserSession().addObjectWithGeneratedKey(form));
+        parameters.put(KFSConstants.BUSINESS_OBJECT_CLASS_ATTRIBUTE, boClassName);
+        parameters.put(KFSConstants.RETURN_LOCATION_PARAMETER, basePath + mapping.getPath() + KFSConstants.ACTION_EXTENSION_DOT_DO);
+
+        String lookupUrl = UrlFactory.parameterizeUrl(basePath + KFSConstants.PATH_SEPERATOR + actionPath, parameters);
+
+        return new ActionForward(lookupUrl, true);
+    }
+
+    @Override
+    public ActionForward refresh(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        super.refresh(mapping, form, request, response);
+
+        GeneralErrorCorrectionForm gecForm = (GeneralErrorCorrectionForm) form;
+        Collection<Entry> rawValues = null;
+
+        // If multiple asset lookup was used to select the assets, then....
+        if (StringUtils.equals(KFSConstants.MULTIPLE_VALUE, gecForm.getRefreshCaller())) {
+            String lookupResultsSequenceNumber = gecForm.getLookupResultsSequenceNumber();
+
+            if (StringUtils.isNotBlank(lookupResultsSequenceNumber)) {
+                // actually returning from a multiple value lookup
+                Set<String> entryIds = getSegmentedLookupResultsService().retrieveSetOfSelectedObjectIds(lookupResultsSequenceNumber, GlobalVariables.getUserSession().getPerson().getPrincipalId());
+
+                // Retrieving selected data from table.
+                rawValues = retrieveSelectedResultBOs(entryIds);
+
+                if (rawValues == null || rawValues.isEmpty()) {
+                    return mapping.findForward(KFSConstants.MAPPING_BASIC);
+                }
+
+                for (Entry entry : rawValues) {
+                    SourceAccountingLine line = copyEntryToAccountingLine(entry);
+                    insertAccountingLine(true, (KualiAccountingDocumentFormBase) form, line);
+                }
+            }
+        }
+
+        return mapping.findForward(KFSConstants.MAPPING_BASIC);
+    }
+
+    private SourceAccountingLine copyEntryToAccountingLine(Entry entry) {
+        SourceAccountingLine retval = new SourceAccountingLine();
+        retval.setChartOfAccountsCode(entry.getChartOfAccountsCode());
+        retval.setAccountNumber(entry.getAccountNumber());
+        retval.setSubAccountNumber(entry.getSubAccountNumber());
+        retval.setFinancialObjectCode(entry.getFinancialObjectCode());
+        retval.setFinancialSubObjectCode(entry.getFinancialSubObjectCode());
+        retval.setProjectCode(entry.getProjectCode());
+        retval.setOrganizationReferenceId(entry.getOrganizationReferenceId());
+        retval.setAmount(entry.getTransactionLedgerEntryAmount());
+        retval.setReferenceOriginCode(entry.getFinancialSystemOriginationCode());
+        retval.setReferenceNumber(entry.getDocumentNumber());
+        retval.setFinancialDocumentLineDescription(entry.getTransactionLedgerEntryDescription());
+        retval.setDebitCreditCode(entry.getTransactionDebitCreditCode());
+        retval.setBalanceTypeCode(entry.getFinancialBalanceTypeCode());
+        return retval;
+    }
+
+    /**
+     * Custom retrieve for Entry - using entryId instead of objectId since Entry does not have an objectId
+     *
+     * @param setOfSelectedEntryIds
+     * @return
+     */
+    private Collection<Entry> retrieveSelectedResultBOs(Set<String> setOfSelectedEntryIds) {
+        ArrayList<Entry> retvals = new ArrayList<Entry>();
+
+        for (String selectedEntryId : setOfSelectedEntryIds) {
+            if (selectedEntryId == null || selectedEntryId.equals(KFSConstants.NULL_STRING)) {
+                continue;
+            }
+
+            Entry result = Entry.getEntry(selectedEntryId);
+            if (result != null) {
+                retvals.add(result);
+            }
+        }
+
+        return retvals;
+    }
+
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/web/struts/GeneralErrorCorrectionForm.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/web/struts/GeneralErrorCorrectionForm.java
@@ -1,0 +1,45 @@
+package edu.arizona.kfs.fp.document.web.struts;
+
+/**
+ * This class is the UA Modification to the Struts specific form object that works in conjunction with the pojo utilities to build the UI.
+ *
+ * @author Adam Kost <kosta@email.arizona.edu> with some code adapted from UCI
+ */
+public class GeneralErrorCorrectionForm extends org.kuali.kfs.fp.document.web.struts.GeneralErrorCorrectionForm {
+
+    private static final long serialVersionUID = 2589170663827583574L;
+
+    private Integer universityFiscalYear;
+    private String glDocId;
+    protected String lookupResultsSequenceNumber;
+    private final String universityFiscalPeriodCodeLookupOverride = "*";
+
+    public Integer getUniversityFiscalYear() {
+        return universityFiscalYear;
+    }
+
+    public void setUniversityFiscalYear(Integer universityFiscalYear) {
+        this.universityFiscalYear = universityFiscalYear;
+    }
+
+    public String getGlDocId() {
+        return glDocId;
+    }
+
+    public void setGlDocId(String glDocId) {
+        this.glDocId = glDocId;
+    }
+
+    public String getLookupResultsSequenceNumber() {
+        return lookupResultsSequenceNumber;
+    }
+
+    public void setLookupResultsSequenceNumber(String lookupResultsSequenceNumber) {
+        this.lookupResultsSequenceNumber = lookupResultsSequenceNumber;
+    }
+
+    public String getUniversityFiscalPeriodCodeLookupOverride() {
+        return universityFiscalPeriodCodeLookupOverride;
+    }
+
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/gl/businessobject/Entry.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/gl/businessobject/Entry.java
@@ -1,0 +1,146 @@
+package edu.arizona.kfs.gl.businessobject;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.kuali.kfs.sec.SecConstants;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.businessobject.AccountingLine;
+import org.kuali.kfs.sys.businessobject.SourceAccountingLine;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.rice.kew.routeheader.DocumentRouteHeaderValue;
+import org.kuali.rice.krad.service.BusinessObjectService;
+
+import edu.arizona.kfs.sys.KFSPropertyConstants;
+
+/**
+ * This class is the UA Modification to the Entry BO class.
+ *
+ * @author Adam Kost <kosta@email.arizona.edu> with some code adapted from UCI
+ */
+
+@SuppressWarnings("deprecation")
+public class Entry extends org.kuali.kfs.gl.businessobject.Entry {
+
+    private static final long serialVersionUID = 7915615641174612210L;
+
+    private transient String gecDocumentNumber;
+    private transient String entryId;
+
+    private static transient volatile BusinessObjectService businessObjectService;
+
+    private static BusinessObjectService getBusinessObjectService() {
+        if (businessObjectService == null) {
+            businessObjectService = SpringContext.getBean(BusinessObjectService.class);
+        }
+        return businessObjectService;
+    }
+
+    public String getGecDocumentNumber() {
+        if (gecDocumentNumber == null) {
+            gecDocumentNumber = generateGecDocumentNumber();
+        }
+        return gecDocumentNumber;
+    }
+
+    public void setGecDocumentNumber(String gecDocumentNumber) {
+        this.gecDocumentNumber = gecDocumentNumber;
+    }
+
+    public String getEntryId() {
+        if (entryId == null) {
+            entryId = generateEntryId();
+        }
+        return entryId;
+    }
+
+    private String generateGecDocumentNumber() {
+        Map<String, String> fieldValues = new HashMap<String, String>();
+        fieldValues.put(KFSPropertyConstants.REFERENCE_NUMBER, getDocumentNumber());
+        Collection<SourceAccountingLine> accountingLineList = getBusinessObjectService().findMatching(SourceAccountingLine.class, fieldValues);
+
+        for (AccountingLine accountingLine : accountingLineList) {
+            String documentNumber = accountingLine.getDocumentNumber();
+            DocumentRouteHeaderValue docHeader = getBusinessObjectService().findBySinglePrimaryKey(DocumentRouteHeaderValue.class, documentNumber);
+            if (docHeader != null) {
+                String docTypeName = docHeader.getDocumentType().getName();
+                if (docTypeName.equals(KFSConstants.FinancialDocumentTypeCodes.GENERAL_ERROR_CORRECTION)) {
+                    return documentNumber;
+                }
+            }
+        }
+        return KFSConstants.EMPTY_STRING;
+    }
+
+    private String generateEntryId() {
+        StringBuilder retval = new StringBuilder();
+        retval.append(getUniversityFiscalYear());
+        retval.append(SecConstants.SecurityValueSpecialCharacters.MULTI_VALUE_SEPERATION_CHARACTER);
+        retval.append(getChartOfAccountsCode());
+        retval.append(SecConstants.SecurityValueSpecialCharacters.MULTI_VALUE_SEPERATION_CHARACTER);
+        retval.append(getAccountNumber());
+        retval.append(SecConstants.SecurityValueSpecialCharacters.MULTI_VALUE_SEPERATION_CHARACTER);
+        retval.append(getSubAccountNumber());
+        retval.append(SecConstants.SecurityValueSpecialCharacters.MULTI_VALUE_SEPERATION_CHARACTER);
+        retval.append(getFinancialObjectCode());
+        retval.append(SecConstants.SecurityValueSpecialCharacters.MULTI_VALUE_SEPERATION_CHARACTER);
+        retval.append(getFinancialSubObjectCode());
+        retval.append(SecConstants.SecurityValueSpecialCharacters.MULTI_VALUE_SEPERATION_CHARACTER);
+        retval.append(getFinancialBalanceTypeCode());
+        retval.append(SecConstants.SecurityValueSpecialCharacters.MULTI_VALUE_SEPERATION_CHARACTER);
+        retval.append(getFinancialObjectTypeCode());
+        retval.append(SecConstants.SecurityValueSpecialCharacters.MULTI_VALUE_SEPERATION_CHARACTER);
+        retval.append(getUniversityFiscalPeriodCode());
+        retval.append(SecConstants.SecurityValueSpecialCharacters.MULTI_VALUE_SEPERATION_CHARACTER);
+        retval.append(getFinancialDocumentTypeCode());
+        retval.append(SecConstants.SecurityValueSpecialCharacters.MULTI_VALUE_SEPERATION_CHARACTER);
+        retval.append(getFinancialSystemOriginationCode());
+        retval.append(SecConstants.SecurityValueSpecialCharacters.MULTI_VALUE_SEPERATION_CHARACTER);
+        retval.append(getDocumentNumber());
+        retval.append(SecConstants.SecurityValueSpecialCharacters.MULTI_VALUE_SEPERATION_CHARACTER);
+        retval.append(getTransactionLedgerEntrySequenceNumber());
+        return retval.toString();
+    }
+
+    /**
+     * Generates a Map of fieldValues for a Primary Key lookup based on the given entryId.
+     *
+     * @param entryId
+     * @return
+     */
+    public static Entry getEntry(String entryId) {
+        String[] primaryKeyFields = entryId.split(SecConstants.SecurityValueSpecialCharacters.MULTI_VALUE_SEPERATION_CHARACTER);
+        String universityFiscalYear = primaryKeyFields[0];
+        String chartOfAccountsCode = primaryKeyFields[1];
+        String accountNumber = primaryKeyFields[2];
+        String subAccountNumber = primaryKeyFields[3];
+        String financialObjectCode = primaryKeyFields[4];
+        String financialSubObjectCode = primaryKeyFields[5];
+        String financialBalanceTypeCode = primaryKeyFields[6];
+        String financialObjectTypeCode = primaryKeyFields[7];
+        String universityFiscalPeriodCode = primaryKeyFields[8];
+        String financialDocumentTypeCode = primaryKeyFields[9];
+        String financialSystemOriginationCode = primaryKeyFields[10];
+        String documentNumber = primaryKeyFields[11];
+        String transactionLedgerEntrySequenceNumber = primaryKeyFields[12];
+
+        Map<String, String> fieldValues = new HashMap<String, String>();
+        fieldValues.put(KFSPropertyConstants.UNIVERSITY_FISCAL_YEAR, universityFiscalYear);
+        fieldValues.put(KFSPropertyConstants.CHART_OF_ACCOUNTS_CODE, chartOfAccountsCode);
+        fieldValues.put(KFSPropertyConstants.ACCOUNT_NUMBER, accountNumber);
+        fieldValues.put(KFSPropertyConstants.SUB_ACCOUNT_NUMBER, subAccountNumber);
+        fieldValues.put(KFSPropertyConstants.FINANCIAL_OBJECT_CODE, financialObjectCode);
+        fieldValues.put(KFSPropertyConstants.FINANCIAL_SUB_OBJECT_CODE, financialSubObjectCode);
+        fieldValues.put(KFSPropertyConstants.FINANCIAL_BALANCE_TYPE_CODE, financialBalanceTypeCode);
+        fieldValues.put(KFSPropertyConstants.FINANCIAL_OBJECT_TYPE_CODE, financialObjectTypeCode);
+        fieldValues.put(KFSPropertyConstants.UNIVERSITY_FISCAL_PERIOD_CODE, universityFiscalPeriodCode);
+        fieldValues.put(KFSPropertyConstants.FINANCIAL_DOCUMENT_TYPE_CODE, financialDocumentTypeCode);
+        fieldValues.put(KFSPropertyConstants.FINANCIAL_SYSTEM_ORIGINATION_CODE, financialSystemOriginationCode);
+        fieldValues.put(KFSPropertyConstants.DOCUMENT_NUMBER, documentNumber);
+        fieldValues.put(KFSPropertyConstants.TRANSACTION_ENTRY_SEQUENCE_NUMBER, transactionLedgerEntrySequenceNumber);
+
+        Entry entry = getBusinessObjectService().findByPrimaryKey(Entry.class, fieldValues);
+        return entry;
+    }
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/gl/web/struts/GecEntryLookupAction.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/gl/web/struts/GecEntryLookupAction.java
@@ -1,0 +1,332 @@
+package edu.arizona.kfs.gl.web.struts;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.kuali.kfs.coa.businessobject.ObjectCode;
+import org.kuali.kfs.coa.service.ObjectCodeService;
+import org.kuali.kfs.fp.document.GeneralErrorCorrectionDocument;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.businessobject.Bank;
+import org.kuali.kfs.sys.businessobject.SystemOptions;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.kfs.sys.service.OptionsService;
+import org.kuali.rice.core.api.parameter.ParameterEvaluatorService;
+import org.kuali.rice.kew.api.KewApiConstants;
+import org.kuali.rice.kew.routeheader.DocumentRouteHeaderValue;
+import org.kuali.rice.kns.lookup.HtmlData;
+import org.kuali.rice.kns.web.struts.action.KualiMultipleValueLookupAction;
+import org.kuali.rice.kns.web.struts.form.MultipleValueLookupForm;
+import org.kuali.rice.kns.web.ui.Column;
+import org.kuali.rice.kns.web.ui.ResultRow;
+import org.kuali.rice.krad.service.BusinessObjectService;
+import org.kuali.rice.krad.service.LookupService;
+import org.kuali.rice.krad.util.KRADConstants;
+import org.kuali.rice.krad.util.UrlFactory;
+
+import edu.arizona.kfs.fp.document.validation.impl.GeneralErrorCorrectionDocumentRuleConstants;
+import edu.arizona.kfs.gl.businessobject.Entry;
+import edu.arizona.kfs.sys.KFSPropertyConstants;
+
+/**
+ * This class serves as the struts action for implementing GEC Entry lookups
+ *
+ * @author Adam Kost <kosta@email.arizona.edu> with some code adapted from UCI
+ */
+
+@SuppressWarnings("deprecation")
+public class GecEntryLookupAction extends KualiMultipleValueLookupAction {
+
+    private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(GecEntryLookupAction.class);
+
+    private static transient volatile ObjectCodeService objectCodeService;
+    private static transient volatile ParameterEvaluatorService parameterEvaluatorService;
+    private static transient volatile LookupService lookupService;
+    private static transient volatile SystemOptions systemOptions;
+    private static transient volatile BusinessObjectService businessObjectService;
+
+    private static ParameterEvaluatorService getParameterEvaluatorService() {
+        if (parameterEvaluatorService == null) {
+            parameterEvaluatorService = SpringContext.getBean(ParameterEvaluatorService.class);
+        }
+        return parameterEvaluatorService;
+    }
+
+    private static ObjectCodeService getObjectCodeService() {
+        if (objectCodeService == null) {
+            objectCodeService = SpringContext.getBean(ObjectCodeService.class);
+        }
+        return objectCodeService;
+    }
+
+    private static LookupService getLookupService() {
+        if (lookupService == null) {
+            lookupService = SpringContext.getBean(LookupService.class);
+        }
+        return lookupService;
+    }
+
+    private static SystemOptions getSystemOptions() {
+        if (systemOptions == null) {
+            systemOptions = SpringContext.getBean(OptionsService.class).getCurrentYearOptions();
+        }
+        return systemOptions;
+    }
+
+    private static BusinessObjectService getBusinessObjectService() {
+        if (businessObjectService == null) {
+            businessObjectService = SpringContext.getBean(BusinessObjectService.class);
+        }
+        return businessObjectService;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected Collection<Entry> performMultipleValueLookup(MultipleValueLookupForm multipleValueLookupForm, List<ResultRow> resultTable, int maxRowsPerPage, boolean bounded) {
+        Collection<Entry> c = super.performMultipleValueLookup(multipleValueLookupForm, resultTable, maxRowsPerPage, bounded);
+        if (c == null || c.isEmpty()) {
+            LOG.debug("No results found.");
+            return new ArrayList<Entry>();
+        }
+
+        List<Entry> entries = new ArrayList<Entry>(c);
+        List<Entry> entriesToRemove = new ArrayList<Entry>();
+        List<Entry> entriesToDisable = new ArrayList<Entry>();
+
+        for (Entry e : entries) {
+            boolean removeEntry = removeEntry(e);
+            boolean disableEntry = disableEntry(e);
+            if (removeEntry) {
+                entriesToRemove.add(e);
+            }
+            if (disableEntry) {
+                entriesToDisable.add(e);
+            }
+        }
+
+        removeRecords(entriesToRemove, entries, resultTable, multipleValueLookupForm);
+        disableRecords(entriesToDisable, resultTable, multipleValueLookupForm);
+        multipleValueLookupForm.jumpToFirstPage(resultTable.size(), maxRowsPerPage);
+
+        Map<String, String> displayedEntryIds = generateEntryIdMap(entries);
+        multipleValueLookupForm.setCompositeObjectIdMap(displayedEntryIds);
+        return entries;
+    }
+
+    private Map<String, String> generateEntryIdMap(List<Entry> entries) {
+        Map<String, String> retval = new HashMap<String, String>();
+        for (Entry entry : entries) {
+            retval.put(entry.getEntryId(), entry.getEntryId());
+        }
+        return retval;
+    }
+
+    @Override
+    public ActionForward prepareToReturnSelectedResults(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        MultipleValueLookupForm multipleValueLookupForm = (MultipleValueLookupForm) form;
+        if (StringUtils.isBlank(multipleValueLookupForm.getLookupResultsSequenceNumber())) {
+            // no search was executed
+            return prepareToReturnNone(mapping, form, request, response);
+        }
+
+        prepareToReturnSelectedResultBOs(multipleValueLookupForm);
+
+        // build the parameters for the refresh url
+        Properties parameters = new Properties();
+        parameters.put(KRADConstants.LOOKUP_RESULTS_BO_CLASS_NAME, multipleValueLookupForm.getBusinessObjectClassName());
+        parameters.put(KRADConstants.LOOKUP_RESULTS_SEQUENCE_NUMBER, multipleValueLookupForm.getLookupResultsSequenceNumber());
+        parameters.put(KRADConstants.DOC_FORM_KEY, multipleValueLookupForm.getFormKey());
+        parameters.put(KRADConstants.DISPATCH_REQUEST_PARAMETER, KRADConstants.RETURN_METHOD_TO_CALL);
+        parameters.put(KRADConstants.REFRESH_CALLER, KRADConstants.MULTIPLE_VALUE);
+        parameters.put(KRADConstants.ANCHOR, multipleValueLookupForm.getLookupAnchor());
+        if (multipleValueLookupForm.getDocNum() != null) {
+            parameters.put(KRADConstants.DOC_NUM, multipleValueLookupForm.getDocNum());
+        }
+
+        String backUrl = UrlFactory.parameterizeUrl(multipleValueLookupForm.getBackLocation(), parameters);
+        return new ActionForward(backUrl, true);
+    }
+
+    /**
+     * Exclude the entry selection base on custom logic.
+     *
+     * @param entry
+     * @return
+     */
+    private boolean removeEntry(Entry entry) {
+        LOG.debug("Determining if entry should be removed: " + entry.toString());
+        ObjectCode code = getObjectCodeService().getByPrimaryId(entry.getUniversityFiscalYear(), entry.getChartOfAccountsCode(), entry.getFinancialObjectCode());
+
+        // GEC Validation
+        boolean objectTypeValid = getParameterEvaluatorService().getParameterEvaluator(GeneralErrorCorrectionDocument.class, GeneralErrorCorrectionDocumentRuleConstants.RESTRICTED_OBJECT_TYPE_CODES, entry.getFinancialObjectTypeCode()).evaluationSucceeds();
+        boolean objectTypeValidBySubType = getParameterEvaluatorService().getParameterEvaluator(GeneralErrorCorrectionDocument.class, GeneralErrorCorrectionDocumentRuleConstants.VALID_OBJECT_SUB_TYPES_BY_OBJECT_TYPE, GeneralErrorCorrectionDocumentRuleConstants.INVALID_OBJECT_SUB_TYPES_BY_OBJECT_TYPE, code.getFinancialObjectTypeCode(), code.getFinancialObjectSubTypeCode()).evaluationSucceeds();
+        boolean objectSubTypeValid = getParameterEvaluatorService().getParameterEvaluator(GeneralErrorCorrectionDocument.class, GeneralErrorCorrectionDocumentRuleConstants.RESTRICTED_OBJECT_SUB_TYPE_CODES, code.getFinancialObjectSubTypeCode()).evaluationSucceeds();
+        boolean documentTypeValid = getParameterEvaluatorService().getParameterEvaluator(GeneralErrorCorrectionDocument.class, GeneralErrorCorrectionDocumentRuleConstants.DOCUMENT_TYPES, entry.getFinancialDocumentTypeCode()).evaluationSucceeds();
+        boolean originationCodeValid = getParameterEvaluatorService().getParameterEvaluator(GeneralErrorCorrectionDocument.class, GeneralErrorCorrectionDocumentRuleConstants.ORIGIN_CODES, entry.getFinancialSystemOriginationCode()).evaluationSucceeds();
+
+        if (!objectTypeValid || !objectTypeValidBySubType || !objectSubTypeValid || !documentTypeValid || !originationCodeValid) {
+            LOG.debug("objectTypeValid=" + objectTypeValid + "; objectTypeValidBySubType=" + objectTypeValidBySubType + "; objectSubTypeValid=" + objectSubTypeValid + "; documentTypeValid=" + documentTypeValid + "; originationCodeValid=" + originationCodeValid);
+            return true;
+        }
+
+        // Exclude offset entries.
+        List<Bank> bankAccountList = (List<Bank>) getLookupService().findCollectionBySearchUnbounded(Bank.class, new HashMap<String, String>());
+        boolean isOffsetDescription = KFSConstants.GL_PE_OFFSET_STRING.equalsIgnoreCase(entry.getTransactionLedgerEntryDescription());
+        boolean isOffsetAccountEntry = isOffsetAccountEntry(bankAccountList, entry);
+        if (isOffsetDescription || isOffsetAccountEntry) {
+            LOG.debug("offsetDescription=[" + isOffsetDescription + ", " + entry.getTransactionLedgerEntryDescription() + "]; isOffsetAccountEntry=[" + isOffsetAccountEntry + ", " + entry.getAccountNumber()+"]");
+            return true;
+        }
+
+        // Entry lookup criteria
+        boolean balanceTypeValid = getSystemOptions().getActualFinancialBalanceTypeCd().equals(entry.getFinancialBalanceTypeCode());
+        boolean entryAmoutIsZero = entry.getTransactionLedgerEntryAmount().isZero();
+        if (!balanceTypeValid || entryAmoutIsZero) {
+            LOG.debug("balanceTypeValid=" + balanceTypeValid + "; entryAmoutIsZero=" + entryAmoutIsZero);
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean isOffsetAccountEntry(List<Bank> bankAccountList, Entry entry) {
+        for (Bank bankAccount : bankAccountList) {
+            if (bankAccount.getBankAccountNumber().equals(entry.getAccountNumber())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Disable the entry selection based on custom logic
+     *
+     * @param entry
+     * @return
+     */
+    private boolean disableEntry(Entry entry) {
+        LOG.debug("Determining if entry should be disabled: " + entry.toString());
+        String gecDocumentNumber = entry.getGecDocumentNumber();
+        if (StringUtils.isBlank(gecDocumentNumber)) {
+            return false;
+        }
+
+        String docStatusCode = getDocumentStatusCode(gecDocumentNumber);
+        if (docStatusCode.equals(KewApiConstants.ROUTE_HEADER_FINAL_CD)) {
+            return true;
+        }
+        if (docStatusCode.equals(KewApiConstants.ROUTE_HEADER_ENROUTE_CD)) {
+            return true;
+        }
+        if (docStatusCode.equals(KewApiConstants.ROUTE_HEADER_INITIATED_CD)) {
+            return true;
+        }
+        if (docStatusCode.equals(KewApiConstants.ROUTE_HEADER_PROCESSED_CD)) {
+            return true;
+        }
+        if (docStatusCode.equals(KewApiConstants.ROUTE_HEADER_SAVED_CD)) {
+            return true;
+        }
+        if (docStatusCode.equals(KewApiConstants.ROUTE_HEADER_INITIATED_CD)) {
+            return true;
+        }
+        return false;
+    }
+
+    private String getDocumentStatusCode(String documentNumber) {
+        DocumentRouteHeaderValue docHeader = getBusinessObjectService().findBySinglePrimaryKey(DocumentRouteHeaderValue.class, documentNumber);
+        if (docHeader == null) {
+            return KFSConstants.EMPTY_STRING;
+        }
+        return docHeader.getDocRouteStatus();
+    }
+
+    private void removeRecords(List<Entry> entriesToRemove, List<Entry> entries, List<ResultRow> resultTable, MultipleValueLookupForm multipleValueLookupForm) {
+        for (Entry entryToRemove : entriesToRemove) {
+            entries.remove(entryToRemove);
+            Iterator<ResultRow> iter = resultTable.iterator();
+            while (iter.hasNext()) {
+                ResultRow currentRow = iter.next();
+                boolean isSameEntry = compareEntryToRow(entryToRemove, currentRow);
+                if (isSameEntry) {
+                    iter.remove();
+                }
+            }
+        }
+    }
+
+    private void disableRecords(List<Entry> entriesToDisable, List<ResultRow> resultTable, MultipleValueLookupForm multipleValueLookupForm) {
+        if (entriesToDisable.isEmpty()) {
+            LOG.debug("entriesToRemove is Empty");
+            return;
+        }
+        for (Entry entryToDisable : entriesToDisable) {
+            for (ResultRow row : resultTable) {
+                boolean isSameEntry = compareEntryToRow(entryToDisable, row);
+                if (isSameEntry) {
+                    row.setReturnUrl(StringUtils.EMPTY);
+                    row.setRowReturnable(false);
+                    int col = getColumnIndexByProperty(row.getColumns(), KFSPropertyConstants.GEC_DOCUMENT_NUMBER);
+                    row.getColumns().get(col).setPropertyValue(entryToDisable.getGecDocumentNumber());
+                    row.getColumns().get(col).setPropertyURL(KewApiConstants.Namespaces.MODULE_NAME + KRADConstants.DOCHANDLER_DO_URL + entryToDisable.getGecDocumentNumber() + KRADConstants.DOCHANDLER_URL_CHUNK);
+                    LOG.debug("gecDocumentNumber=" + entryToDisable.getGecDocumentNumber());
+                    HtmlData columnAnchor = new HtmlData.AnchorHtmlData(KewApiConstants.Namespaces.MODULE_NAME + KRADConstants.DOCHANDLER_DO_URL + entryToDisable.getGecDocumentNumber() + KRADConstants.DOCHANDLER_URL_CHUNK, KRADConstants.EMPTY_STRING);
+                    row.getColumns().get(col).setColumnAnchor(columnAnchor);
+                }
+            }
+        }
+    }
+
+    private boolean compareEntryToRow(Entry entry, ResultRow row) {
+        List<Column> columnList = row.getColumns();
+        boolean isSameEntry = true;
+
+        isSameEntry &= isPropertyEqual(entry.getUniversityFiscalYear().toString(), KFSPropertyConstants.UNIVERSITY_FISCAL_YEAR, columnList);
+        isSameEntry &= isPropertyEqual(entry.getChartOfAccountsCode(), KFSPropertyConstants.CHART_OF_ACCOUNTS_CODE, columnList);
+        isSameEntry &= isPropertyEqual(entry.getAccountNumber(), KFSPropertyConstants.ACCOUNT_NUMBER, columnList);
+        isSameEntry &= isPropertyEqual(entry.getSubAccountNumber(), KFSPropertyConstants.SUB_ACCOUNT_NUMBER, columnList);
+        isSameEntry &= isPropertyEqual(entry.getFinancialObjectCode(), KFSPropertyConstants.FINANCIAL_OBJECT_CODE, columnList);
+        isSameEntry &= isPropertyEqual(entry.getFinancialSubObjectCode(), KFSPropertyConstants.FINANCIAL_SUB_OBJECT_CODE, columnList);
+        isSameEntry &= isPropertyEqual(entry.getFinancialBalanceTypeCode(), KFSPropertyConstants.FINANCIAL_BALANCE_TYPE_CODE, columnList);
+        isSameEntry &= isPropertyEqual(entry.getFinancialObjectTypeCode(), KFSPropertyConstants.FINANCIAL_OBJECT_TYPE_CODE, columnList);
+        isSameEntry &= isPropertyEqual(entry.getUniversityFiscalPeriodCode(), KFSPropertyConstants.UNIVERSITY_FISCAL_PERIOD_CODE, columnList);
+        isSameEntry &= isPropertyEqual(entry.getFinancialDocumentTypeCode(), KFSPropertyConstants.FINANCIAL_DOCUMENT_TYPE_CODE, columnList);
+        isSameEntry &= isPropertyEqual(entry.getFinancialSystemOriginationCode(), KFSPropertyConstants.FINANCIAL_SYSTEM_ORIGINATION_CODE, columnList);
+        isSameEntry &= isPropertyEqual(entry.getDocumentNumber(), KFSPropertyConstants.DOCUMENT_NUMBER, columnList);
+        isSameEntry &= isPropertyEqual(entry.getTransactionLedgerEntrySequenceNumber().toString(), KFSPropertyConstants.TRANSACTION_ENTRY_SEQUENCE_NUMBER, columnList);
+
+        return isSameEntry;
+    }
+
+    private boolean isPropertyEqual(String entryPropertyValue, String propertyName, List<Column> columnList) {
+        int col = getColumnIndexByProperty(columnList, propertyName);
+        if (col == -1) {
+            return true;
+        }
+        String columnValue = columnList.get(col).getPropertyValue();
+        boolean isEqual = StringUtils.equals(entryPropertyValue, columnValue);
+        return isEqual;
+    }
+
+    private int getColumnIndexByProperty(List<Column> columnList, String propertyName) {
+        for (int i = 0; i < columnList.size(); i++) {
+            if (StringUtils.equals(propertyName, columnList.get(i).getPropertyName())) {
+                return i;
+            }
+        }
+        return -1;// not in the list
+    }
+
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSConstants.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSConstants.java
@@ -1,13 +1,15 @@
 package edu.arizona.kfs.sys;
 
-import org.kuali.kfs.sys.KFSConstants.CoreModuleNamespaces;
-
 public class KFSConstants extends org.kuali.kfs.sys.KFSConstants {
 
     public static final String INVOICE_NUMBER = "Invoice Number";
     public static final String DUPLICATE_INVOICE_QUESTION_ID = "DVDuplicateInvoice";
-    
-    public static class SysKimApiConstants{
+
+    public static final String GL_ENTRY_IMPORTING = "glEntryImporting";
+    public static final String NULL_STRING = "null";
+    public static final String PATH_SEPERATOR = "/";
+
+    public static class SysKimApiConstants {
         public static final String ACCOUNT_SUPERVISOR_KIM_ROLE_NAME = "Account Supervisor";
         public static final String CONTRACTS_AND_GRANTS_PROJECT_DIRECTOR = "Contracts & Grants Project Director";
         public static final String FISCAL_OFFICER_KIM_ROLE_NAME = "Fiscal Officer";
@@ -29,7 +31,7 @@ public class KFSConstants extends org.kuali.kfs.sys.KFSConstants {
         public static final String SUB_FUND_REVIEWER = "Sub-Fund Reviewer";
         public static final String ORGANIZATION_FUND_REVIEWER_ROLE_NAME = "Organization Fund Reviewer";
     }
-    
+
     public class RouteLevelNames {
         public static final String ACCOUNT = "Account";
         public static final String ACCOUNTING_ORGANIZATION_HIERARCHY = "AccountingOrganizationHierarchy";
@@ -37,10 +39,10 @@ public class KFSConstants extends org.kuali.kfs.sys.KFSConstants {
         public static final String PROJECT_MANAGEMENT = "ProjectManagement";
         public static final String ORGANIZATION_HIERARCHY = "OrganizationHierarchy";
         public static final String PAYMENT_METHOD = "PaymentMethod";
-        public static final String ORGANIZATION_FUND_REVIEW = "OrganizationFundReview";   
+        public static final String ORGANIZATION_FUND_REVIEW = "OrganizationFundReview";
     }
-    
-    public static class COAConstants{
+
+    public static class COAConstants {
         public static final String ORG_REVIEW_ROLE_ORG_ACC_ONLY_CODE = "A";
         public static final String ORG_REVIEW_ROLE_ORG_ACC_ONLY_TEXT = "Organization Accounting Only";
         public static final String ORG_REVIEW_ROLE_ORG_ONLY_CODE = "O";
@@ -53,7 +55,7 @@ public class KFSConstants extends org.kuali.kfs.sys.KFSConstants {
 
         public final static String DEFAULT_CHART_METHOD = "1";
         public final static String DEFAULT_PRIMARY_DEPT_METHOD = "2";
-        public final static String DEFAULT_PRIMARY_DEPT_CHART_METHOD = "3"; 
+        public final static String DEFAULT_PRIMARY_DEPT_CHART_METHOD = "3";
 
     }
 

--- a/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSPropertyConstants.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSPropertyConstants.java
@@ -12,4 +12,6 @@ public class KFSPropertyConstants extends org.kuali.kfs.sys.KFSPropertyConstants
     public static final String BATCH_FILE_UPLOADS_BATCH_FILE_NAME = "batchFileName";
     public static final String BATCH_FILE_UPLOADS_FILE_PROCESS_TIMESTAMP = "fileProcessTimestamp";
 
+    public static final String GEC_DOCUMENT_NUMBER = "gecDocumentNumber";
+
 }

--- a/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/changesets/db.changelog-UAF-1790.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/changesets/db.changelog-UAF-1790.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="UAF-1790-1" author="Adam Kost">
+        <preConditions onError="MARK_RAN" onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM KRCR_PARM_T
+                    WHERE parm_nm='DOCUMENT_TYPES'
+            </sqlCheck>
+        </preConditions>
+        <comment>
+            UAF-1790 General Error Correction Step 1 (Lookup and Validation) Parameter DOCUMENT_TYPES
+        </comment>
+        <insert tableName="KRCR_PARM_T">
+            <column name="NMSPC_CD" value="KFS-FP"/>
+            <column name="CMPNT_CD" value="GeneralErrorCorrection"/>
+            <column name="PARM_NM" value="DOCUMENT_TYPES"/>
+            <column name="OBJ_ID" value="UAF-1790-1"/>
+            <column name="VER_NBR" value="1"/>
+            <column name="PARM_TYP_CD" value="VALID"/>
+            <column name="VAL" value="JV;SET;ICA"/>
+            <column name="PARM_DESC_TXT" value="List of document types that cannot have their ledger entries be corrected using GEC."/>
+            <column name="EVAL_OPRTR_CD" value="D"/>
+            <column name="APPL_ID" value="KFS"/>
+        </insert>
+        <rollback>
+            <delete tableName="KRCR_PARM_T">
+                <where>parm_nm='DOCUMENT_TYPES'</where>
+            </delete>
+        </rollback>
+    </changeSet>
+
+    <changeSet id="UAF-1790-2" author="Adam Kost">
+        <preConditions onError="MARK_RAN" onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM KRCR_PARM_T
+                    WHERE parm_nm='ORIGIN_CODES'
+            </sqlCheck>
+        </preConditions>
+        <comment>
+            UAF-1790 General Error Correction Step 1 (Lookup and Validation) Parameter ORIGIN_CODES
+        </comment>
+        <insert tableName="KRCR_PARM_T">
+            <column name="NMSPC_CD" value="KFS-FP"/>
+            <column name="CMPNT_CD" value="GeneralErrorCorrection"/>
+            <column name="PARM_NM" value="ORIGIN_CODES"/>
+            <column name="OBJ_ID" value="UAF-1790-2"/>
+            <column name="VER_NBR" value="1"/>
+            <column name="PARM_TYP_CD" value="VALID"/>
+            <column name="VAL" value="UE;SW;SP;NC;EP"/>
+            <column name="PARM_DESC_TXT" value="List of origination codes that are not valid for use with GEC."/>
+            <column name="EVAL_OPRTR_CD" value="D"/>
+            <column name="APPL_ID" value="KFS"/>
+        </insert>
+        <rollback>
+            <delete tableName="KRCR_PARM_T">
+                <where>parm_nm='ORIGIN_CODES'</where>
+            </delete>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/GeneralErrorCorrectionDocument.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/GeneralErrorCorrectionDocument.xml
@@ -5,6 +5,9 @@
  xmlns:dd="http://rice.kuali.org/dd" 
  xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd         http://rice.kuali.org/dd         http://rice.kuali.org/dd/dd.xsd">
 
+    <bean id="GeneralErrorCorrectionDocument" parent="GeneralErrorCorrectionDocument-parentBean">
+        <property name="documentPresentationControllerClass" value="edu.arizona.kfs.fp.document.authorization.GeneralErrorCorrectionDocumentPresentationController"/>
+    </bean>
   
   <!-- workflow attributes for routing -->
   <bean id="GeneralErrorCorrectionDocument-workflowAttributes" parent="GeneralErrorCorrectionDocument-workflowAttributes-parentBean">

--- a/kfs-core/src/main/resources/edu/arizona/kfs/gl/businessobject/datadictionary/Entry.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/gl/businessobject/datadictionary/Entry.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+    <bean id="Entry" parent="Entry-parentBean">
+        <property name="businessObjectClass" value="edu.arizona.kfs.gl.businessobject.Entry" />
+        <property name="attributes">
+            <list merge="true">
+                <ref bean="Entry-gecDocumentNumber" />
+                <ref bean="Entry-entryId" />
+            </list>
+        </property>
+    </bean>
+
+    <bean id="Entry-gecDocumentNumber" parent="DocumentHeader-documentNumber">
+        <property name="name" value="gecDocumentNumber" />
+        <property name="label" value="GEC Document Number" />
+        <property name="shortLabel" value="GEC Doc Num" />
+    </bean>
+
+    <bean id="Entry-entryId" parent="AttributeReferenceDummy-genericBigText">
+        <property name="name" value="entryId" />
+        <property name="label" value="Entry Id" />
+        <property name="shortLabel" value="Entry Id" />
+    </bean>
+
+    <bean id="Entry-lookupDefinition" parent="Entry-lookupDefinition-parentBean">
+        <property name="resultFields">
+            <list>
+                <bean parent="FieldDefinition" p:attributeName="gecDocumentNumber" />
+                <bean parent="FieldDefinition" p:attributeName="universityFiscalYear" />
+                <bean parent="FieldDefinition" p:attributeName="chartOfAccountsCode" />
+                <bean parent="FieldDefinition" p:attributeName="accountNumber" />
+                <bean parent="FieldDefinition" p:attributeName="subAccountNumber" />
+                <bean parent="FieldDefinition" p:attributeName="financialObjectCode" />
+                <bean parent="FieldDefinition" p:attributeName="financialSubObjectCode" />
+                <bean parent="FieldDefinition" p:attributeName="financialBalanceTypeCode" />
+                <bean parent="FieldDefinition" p:attributeName="financialObjectTypeCode" />
+                <bean parent="FieldDefinition" p:attributeName="universityFiscalPeriodCode" />
+                <bean parent="FieldDefinition" p:attributeName="financialDocumentTypeCode" />
+                <bean parent="FieldDefinition" p:attributeName="financialSystemOriginationCode" />
+                <bean parent="FieldDefinition" p:attributeName="documentNumber" />
+                <bean parent="FieldDefinition" p:attributeName="transactionLedgerEntryDescription" />
+                <bean parent="FieldDefinition" p:attributeName="transactionLedgerEntryAmount" />
+                <bean parent="FieldDefinition" p:attributeName="transactionDebitCreditCode" />
+                <bean parent="FieldDefinition" p:attributeName="transactionDate" />
+                <bean parent="FieldDefinition" p:attributeName="organizationDocumentNumber" />
+                <bean parent="FieldDefinition" p:attributeName="projectCode" />
+                <bean parent="FieldDefinition" p:attributeName="organizationReferenceId" />
+                <bean parent="FieldDefinition" p:attributeName="referenceFinancialDocumentTypeCode" />
+                <bean parent="FieldDefinition" p:attributeName="referenceFinancialSystemOriginationCode" />
+                <bean parent="FieldDefinition" p:attributeName="referenceFinancialDocumentNumber" />
+                <bean parent="FieldDefinition" p:attributeName="dummyBusinessObject.pendingEntryOption" />
+            </list>
+        </property>
+    </bean>
+
+</beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/gl/ojb-gl.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/gl/ojb-gl.xml
@@ -1,0 +1,92 @@
+<descriptor-repository version="1.0">
+<class-descriptor class="edu.arizona.kfs.gl.businessobject.Entry" table="GL_ENTRY_T">
+    <field-descriptor name="universityFiscalYear" column="UNIV_FISCAL_YR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="chartOfAccountsCode" column="FIN_COA_CD" jdbc-type="VARCHAR" primarykey="true" index="true" />
+    <field-descriptor name="accountNumber" column="ACCOUNT_NBR" jdbc-type="VARCHAR" primarykey="true" index="true" />
+    <field-descriptor name="subAccountNumber" column="SUB_ACCT_NBR" jdbc-type="VARCHAR" primarykey="true" index="true" />
+    <field-descriptor name="financialObjectCode" column="FIN_OBJECT_CD" jdbc-type="VARCHAR" primarykey="true" index="true" />
+    <field-descriptor name="financialSubObjectCode" column="FIN_SUB_OBJ_CD" jdbc-type="VARCHAR" primarykey="true" index="true" />
+    <field-descriptor name="financialBalanceTypeCode" column="FIN_BALANCE_TYP_CD" jdbc-type="VARCHAR" primarykey="true" index="true" />
+    <field-descriptor name="financialObjectTypeCode" column="FIN_OBJ_TYP_CD" jdbc-type="VARCHAR" primarykey="true" index="true" />
+    <field-descriptor name="universityFiscalPeriodCode" column="UNIV_FISCAL_PRD_CD" jdbc-type="VARCHAR" primarykey="true" index="true" />
+    <field-descriptor name="financialDocumentTypeCode" column="FDOC_TYP_CD" jdbc-type="VARCHAR" primarykey="true" index="true" />
+    <field-descriptor name="financialSystemOriginationCode" column="FS_ORIGIN_CD" jdbc-type="VARCHAR" primarykey="true" index="true" />
+    <field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" index="true" />
+    <field-descriptor name="transactionLedgerEntrySequenceNumber" column="TRN_ENTR_SEQ_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="transactionLedgerEntryDescription" column="TRN_LDGR_ENTR_DESC" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionLedgerEntryAmount" column="TRN_LDGR_ENTR_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="transactionDebitCreditCode" column="TRN_DEBIT_CRDT_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionDate" column="TRANSACTION_DT" jdbc-type="DATE" />
+    <field-descriptor name="organizationDocumentNumber" column="ORG_DOC_NBR" jdbc-type="VARCHAR" />
+    <field-descriptor name="projectCode" column="PROJECT_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="organizationReferenceId" column="ORG_REFERENCE_ID" jdbc-type="VARCHAR" />
+    <field-descriptor name="referenceFinancialDocumentTypeCode" column="FDOC_REF_TYP_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="referenceFinancialSystemOriginationCode" column="FS_REF_ORIGIN_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="referenceFinancialDocumentNumber" column="FDOC_REF_NBR" jdbc-type="VARCHAR" />
+    <field-descriptor name="financialDocumentReversalDate" column="FDOC_REVERSAL_DT" jdbc-type="DATE" />
+    <field-descriptor name="transactionEncumbranceUpdateCode" column="TRN_ENCUM_UPDT_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionPostingDate" column="TRN_POST_DT" jdbc-type="DATE" />
+    <field-descriptor name="transactionDateTimeStamp" column="TIMESTAMP" jdbc-type="TIMESTAMP" index="true" />
+    <reference-descriptor name="account" class-ref="org.kuali.kfs.coa.businessobject.Account" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" >
+        <foreignkey field-ref="chartOfAccountsCode" />
+        <foreignkey field-ref="accountNumber" />
+    </reference-descriptor>
+
+    <reference-descriptor name="chart" class-ref="org.kuali.kfs.coa.businessobject.Chart" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" >
+        <foreignkey field-ref="chartOfAccountsCode" />
+    </reference-descriptor>
+
+    <reference-descriptor name="financialObject" class-ref="org.kuali.kfs.coa.businessobject.ObjectCode" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" >
+        <foreignkey field-ref="universityFiscalYear" />
+        <foreignkey field-ref="chartOfAccountsCode" />
+        <foreignkey field-ref="financialObjectCode" />
+    </reference-descriptor>
+
+    <reference-descriptor name="subAccount" class-ref="org.kuali.kfs.coa.businessobject.SubAccount" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" >
+        <foreignkey field-ref="chartOfAccountsCode" />
+        <foreignkey field-ref="accountNumber" />
+        <foreignkey field-ref="subAccountNumber" />
+    </reference-descriptor>
+
+    <reference-descriptor name="balanceType" class-ref="org.kuali.kfs.coa.businessobject.BalanceType" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" >
+        <foreignkey field-ref="financialBalanceTypeCode" />
+    </reference-descriptor>
+
+    <reference-descriptor name="financialSubObject" class-ref="org.kuali.kfs.coa.businessobject.SubObjectCode" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" >
+        <foreignkey field-ref="universityFiscalYear" />
+        <foreignkey field-ref="chartOfAccountsCode" />
+        <foreignkey field-ref="accountNumber" />
+        <foreignkey field-ref="financialObjectCode" />
+        <foreignkey field-ref="financialSubObjectCode" />
+    </reference-descriptor>
+
+    <reference-descriptor name="objectType" class-ref="org.kuali.kfs.coa.businessobject.ObjectType" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" >
+        <foreignkey field-ref="financialObjectTypeCode" />
+    </reference-descriptor>
+
+    <reference-descriptor name="project" class-ref="org.kuali.kfs.coa.businessobject.ProjectCode" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" >
+        <foreignkey field-ref="projectCode" />
+    </reference-descriptor>
+    
+    <reference-descriptor name="option" class-ref="org.kuali.kfs.sys.businessobject.SystemOptions" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" >
+        <foreignkey field-ref="universityFiscalYear" />
+    </reference-descriptor>
+
+    <reference-descriptor name="accountingPeriod" class-ref="org.kuali.kfs.coa.businessobject.AccountingPeriod" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" >
+        <foreignkey field-ref="universityFiscalYear" />
+        <foreignkey field-ref="universityFiscalPeriodCode" />
+    </reference-descriptor>
+
+    <reference-descriptor name="reversalDate" class-ref="org.kuali.kfs.sys.businessobject.UniversityDate" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" >
+        <foreignkey field-ref="financialDocumentReversalDate" />
+    </reference-descriptor>
+
+    <reference-descriptor name="originationCode" class-ref="org.kuali.kfs.sys.businessobject.OriginationCode" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" >
+        <foreignkey field-ref="financialSystemOriginationCode" />
+    </reference-descriptor>
+
+    <reference-descriptor name="referenceOriginationCode" class-ref="org.kuali.kfs.sys.businessobject.OriginationCode" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" >
+        <foreignkey field-ref="referenceFinancialSystemOriginationCode" />
+    </reference-descriptor>
+</class-descriptor>
+</descriptor-repository>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/gl/spring-gl.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/gl/spring-gl.xml
@@ -12,6 +12,21 @@
                            http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
     <bean id="glModuleConfiguration" parent="glModuleConfiguration-parentBean" >
+        <property name="packagePrefixes">
+            <list merge="true">
+                <value>edu.arizona.kfs.gl</value>
+            </list>
+        </property>
+        <property name="dataDictionaryPackages">
+            <list merge="true">
+                <value>classpath:edu/arizona/kfs/gl/businessobject/datadictionary/*.xml</value>
+            </list>
+        </property>
+        <property name="databaseRepositoryFilePaths">
+            <list merge="true">
+                <value>edu/arizona/kfs/gl/ojb-gl.xml</value>
+            </list>
+        </property>
     </bean>
 
     <bean id="collectorJob" parent="unscheduledJobDescriptor">

--- a/kfs-web/src/main/webapp/WEB-INF/struts-config.xml
+++ b/kfs-web/src/main/webapp/WEB-INF/struts-config.xml
@@ -66,7 +66,7 @@
 		<form-bean name="YearEndTransferOfFundsForm"
 			type="org.kuali.kfs.fp.document.web.struts.YearEndTransferOfFundsForm" />
 		<form-bean name="GeneralErrorCorrectionForm"
-			type="org.kuali.kfs.fp.document.web.struts.GeneralErrorCorrectionForm" />
+			type="edu.arizona.kfs.fp.document.web.struts.GeneralErrorCorrectionForm" />
 		<form-bean name="YearEndGeneralErrorCorrectionForm"
 			type="org.kuali.kfs.fp.document.web.struts.YearEndGeneralErrorCorrectionForm" />
 		<form-bean name="DistributionOfIncomeAndExpenseForm"
@@ -369,6 +369,29 @@
 	</global-forwards>
 
 	<action-mappings>
+        <action path="/financialGeneralErrorCorrection"
+            name="GeneralErrorCorrectionForm"
+            input="/jsp/fp/GeneralErrorCorrection.jsp"
+            type="edu.arizona.kfs.fp.document.web.struts.GeneralErrorCorrectionAction"
+            scope="request"
+            parameter="methodToCall"
+            validate="true" 
+            attribute="KualiForm">
+            <set-property property="cancellable" value="true" />
+            <forward name="basic" path="/jsp/fp/GeneralErrorCorrection.jsp" />
+        </action>
+
+        <action path="/gecEntryLookup" 
+            name="MultipleValueLookupForm"
+            type="edu.arizona.kfs.gl.web.struts.GecEntryLookupAction"
+            scope="request"
+            input="/jsp/gl/gecEntryMultipleValueLookup.jsp"
+            parameter="methodToCall"
+            attribute="KualiForm">
+            <set-property property="cancellable" value="true" />
+            <forward name="basic" path="/jsp/gl/gecEntryMultipleValueLookup.jsp" />
+        </action>
+
 		<!-- Core Action Mappings -->
 		<action path="/portal" name="KualiForm"
 			type="org.kuali.rice.kns.web.struts.action.KualiPortalAction">

--- a/kfs-web/src/main/webapp/WEB-INF/tags/gl/gecEntryLookup.tag
+++ b/kfs-web/src/main/webapp/WEB-INF/tags/gl/gecEntryLookup.tag
@@ -1,0 +1,24 @@
+<%@ include file="/jsp/sys/kfsTldHeader.jsp"%>
+
+<%@ attribute name="boClassName" required="true" %>
+<%@ attribute name="actionPath" required="true" %>
+<%@ attribute name="fieldConversions" required="false" %>
+<%@ attribute name="lookupParameters" required="false" %>
+<%@ attribute name="hideReturnLink" required="false" %>
+<%@ attribute name="tabindexOverride" required="false" %>
+<%@ attribute name="image" required="false"%>
+
+<c:set var="imageName" value="${empty image ? 'searchicon.gif' : image}"/>
+
+<c:choose>
+    <c:when test="${!empty tabindexOverride}">
+        <c:set var="tabindex" value="${tabindexOverride}"/>
+    </c:when>
+    <c:otherwise>
+        <c:set var="tabindex" value="${KualiForm.nextArbitrarilyHighIndex}"/>
+    </c:otherwise>
+</c:choose>
+
+<c:set var="epMethodToCallAttribute" value="methodToCall.performLookup.(!!${boClassName}!!).(((${fieldConversions}))).((#${lookupParameters}#)).((<${hideReturnLink}>)).(([${actionPath}]))" />
+${kfunc:registerEditableProperty(KualiForm, epMethodToCallAttribute)}
+<input type="image" tabindex="${tabindex}" name="${epMethodToCallAttribute}" src="${ConfigProperties.kr.externalizable.images.url}${imageName}" alt="search" title="search" border="0" class="tinybutton" valign="middle"/>

--- a/kfs-web/src/main/webapp/jsp/fp/GeneralErrorCorrection.jsp
+++ b/kfs-web/src/main/webapp/jsp/fp/GeneralErrorCorrection.jsp
@@ -18,13 +18,51 @@
 --%>
 <%@ include file="/jsp/sys/kfsTldHeader.jsp"%>
 
+<c:set var="EntryAttributes" value="${DataDictionary.Entry.attributes}" />
+<c:set var="readOnly" value="${!KualiForm.documentActions[Constants.KUALI_ACTION_CAN_EDIT]}" />
+<c:set var="glEntryImporting" value="${!readOnly && KualiForm.editingMode['glEntryImporting']}"/>
+
 <kul:documentPage showDocumentInfo="true"
 	documentTypeName="GeneralErrorCorrectionDocument"
 	htmlFormAction="financialGeneralErrorCorrection" renderMultipart="true"
 	showTabButtons="true">
 
 	<sys:documentOverview editingMode="${KualiForm.editingMode}" />
-	
+
+    <c:if test="${glEntryImporting}">
+    <kul:tab tabTitle="GL Entry Importing" defaultOpen="true" tabErrorKey="universityFiscalYear,glDocId">
+        <div class="tab-container" align=center>
+        <h3>GL Entry Importing</h3>
+        <table cellpadding="0" cellspacing="0" class="datatable" summary="GL Entry Importing">
+            <tr>
+                <kul:htmlAttributeHeaderCell attributeEntry="${EntryAttributes.universityFiscalYear}" horizontal="true" width="35%"  labelFor="universityFiscalYear" forceRequired="true" useShortLabel="false" />
+                <td class="datacell-nowrap"><kul:htmlControlAttribute attributeEntry="${EntryAttributes.universityFiscalYear}" property="universityFiscalYear" forceRequired="true" readOnly="${readOnly}" /></td>
+            </tr>
+            <tr>
+                <kul:htmlAttributeHeaderCell attributeEntry="${EntryAttributes.documentNumber}" horizontal="true" width="35%"  labelFor="glDocId" forceRequired="true" useShortLabel="false" />
+                <td class="datacell-nowrap"><kul:htmlControlAttribute attributeEntry="${EntryAttributes.documentNumber}" property="glDocId" forceRequired="true" readOnly="${readOnly}" /></td>
+            </tr>
+
+             <tr>
+                <td height="30" class="infoline">&nbsp;</td>
+                <td height="30" class="infoline">
+                    <c:if test="${!readOnly}">
+                        <input type="hidden" name="universityFiscalPeriodCodeLookupOverride" value="${KualiForm.universityFiscalPeriodCodeLookupOverride}" />
+                        <gl:gecEntryLookup
+                            boClassName="edu.arizona.kfs.gl.businessobject.Entry"
+                            actionPath="gecEntryLookup.do"
+                            lookupParameters="universityFiscalYear:universityFiscalYear,glDocId:documentNumber,universityFiscalPeriodCodeLookupOverride:universityFiscalPeriodCode"
+                            tabindexOverride="KualiForm.currentTabIndex"
+                            hideReturnLink="false"
+                            image="buttonsmall_search.gif"/>
+                    </c:if>
+                </td>
+            </tr>
+        </table>
+        </div>
+    </kul:tab>
+    </c:if>
+
 	<kul:tab tabTitle="Accounting Lines" defaultOpen="true" tabErrorKey="${KFSConstants.ACCOUNTING_LINE_ERRORS}">
 		<sys-java:accountingLines>
 			<sys-java:accountingLineGroup newLinePropertyName="newSourceLine" collectionPropertyName="document.sourceAccountingLines" collectionItemPropertyName="document.sourceAccountingLine" attributeGroupName="source" />
@@ -32,7 +70,6 @@
 		</sys-java:accountingLines>
 	</kul:tab>
 	
-	<c:set var="readOnly" value="${!KualiForm.documentActions[Constants.KUALI_ACTION_CAN_EDIT]}" />
   	<fp:capitalAccountingLines readOnly="${readOnly}"/>
   	
 	<c:if test="${KualiForm.capitalAccountingLine.canCreateAsset}">

--- a/kfs-web/src/main/webapp/jsp/gl/gecEntryMultipleValueLookup.jsp
+++ b/kfs-web/src/main/webapp/jsp/gl/gecEntryMultipleValueLookup.jsp
@@ -1,0 +1,97 @@
+<%@ include file="/jsp/sys/kfsTldHeader.jsp"%>
+
+<%@ page buffer = "16kb" %>
+
+<%--NOTE: DO NOT FORMAT THIS FILE, DISPLAY:COLUMN WILL NOT WORK CORRECTLY IF IT CONTAINS LINE BREAKS --%>
+
+<kul:page lookup="true" showDocumentInfo="false"
+    htmlFormAction="gecEntryLookup"
+    headerMenuBar="${KualiForm.lookupable.createNewUrl}   ${KualiForm.lookupable.htmlMenuBar}"
+    headerTitle="Lookup"
+    docTitle=""
+    transactionalDocument="false">
+
+
+    <SCRIPT type="text/javascript">
+    var kualiForm = document.forms['KualiForm'];
+    var kualiElements = kualiForm.elements;
+  </SCRIPT>
+
+    <div class="headerarea-small" id="headerarea-small">
+    <h1><c:out value="${KualiForm.lookupable.title}" /><kul:help
+        lookupBusinessObjectClassName="${KualiForm.lookupable.businessObjectClass.name}" altText="lookup help" /></h1>
+    </div>
+    <kul:enterKey methodToCall="search" />
+
+    <html-el:hidden name="KualiForm" property="backLocation" />
+    <html-el:hidden name="KualiForm" property="formKey" />
+    <html-el:hidden name="KualiForm" property="lookupableImplServiceName" />
+    <html-el:hidden name="KualiForm" property="businessObjectClassName" />
+    <html-el:hidden name="KualiForm" property="conversionFields" />
+    <html-el:hidden name="KualiForm" property="hideReturnLink" />
+    <html-el:hidden name="KualiForm" property="suppressActions" />
+    <html-el:hidden name="KualiForm" property="extraButtonSource" />
+    <html-el:hidden name="KualiForm" property="extraButtonParams" />
+    <html-el:hidden name="KualiForm" property="multipleValues" />
+    <html-el:hidden name="KualiForm" property="lookupAnchor" />
+    <html-el:hidden name="KualiForm" property="readOnlyFields" />
+    <html-el:hidden name="KualiForm" property="lookupResultsSequenceNumber" />
+    <html-el:hidden name="KualiForm" property="lookedUpCollectionName" />
+    <html-el:hidden name="KualiForm" property="viewedPageNumber" />
+    <html-el:hidden name="KualiForm" property="resultsActualSize" />
+    <html-el:hidden name="KualiForm" property="resultsLimitedSize" />
+    <html-el:hidden name="KualiForm" property="hasReturnableRow" />
+    <html-el:hidden name="KualiForm" property="docNum" />
+    <html-el:hidden name="KualiForm" property="fieldNameToFocusOnAfterSubmit"/>
+
+    <kul:errors errorTitle="Errors found in Search Criteria:" />
+    <kul:messages/>
+    <div class="right">
+        <div class="excol">* required field</div>
+    </div>
+    <table width="100%">
+        <tr>
+            <td width="1%"><img src="${ConfigProperties.kr.externalizable.images.url}pixel_clear.gif" alt="" width="20" height="20"></td>
+            <td>
+                <div id="lookup" align="center">
+                    <br /><br />
+                    <table align="center" cellpadding=0 cellspacing=0 class="datatable-100">
+                        <c:set var="FormName" value="KualiForm" scope="request" />
+                        <c:set var="FieldRows" value="${KualiForm.lookupable.rows}" scope="request" />
+                        <c:set var="ActionName" value="gecEntryLookup.do" scope="request" />
+                        <c:set var="IsLookupDisplay" value="true" scope="request" />
+                        <c:set var="cellWidth" value="50%" scope="request" />
+
+                        <kul:rowDisplay rows="${FieldRows}" numberOfColumns="4" />
+
+                        <tr align=center>
+                            <td height="30" colspan=4 class="infoline"><html:image
+                                property="methodToCall.search" value="search"
+                                src="${ConfigProperties.kr.externalizable.images.url}buttonsmall_search.gif" styleClass="tinybutton"
+                                alt="search" title="search" border="0" /> <html:image
+                                property="methodToCall.clearValues" value="clearValues"
+                                src="${ConfigProperties.kr.externalizable.images.url}buttonsmall_clear.gif" styleClass="tinybutton"
+                                alt="clear" title="clear" border="0" /> <c:if test="${KualiForm.formKey!=''}">
+                                <a
+                                    href='<c:out value="${KualiForm.backLocation}?methodToCall=refresh&docFormKey=${KualiForm.formKey}&anchor=${KualiForm.lookupAnchor}&docNum=${KualiForm.docNum}" />'  title="cancel"><img
+                                    src="${ConfigProperties.kr.externalizable.images.url}buttonsmall_cancel.gif" class="tinybutton" alt="cancel" title="cancel" 
+                                    border="0" /></a>
+                            </c:if> <!-- Optional extra button --> <c:if
+                                test="${! empty KualiForm.extraButtonSource && extraButtonSource != ''}">
+                                <a
+                                    href='<c:out value="${KualiForm.backLocation}?methodToCall=refresh&refreshCaller=kualiLookupable&docFormKey=${KualiForm.formKey}&anchor=${KualiForm.lookupAnchor}&docNum=${KualiForm.docNum}" /><c:out value="${KualiForm.extraButtonParams}" />'><img
+                                    src='<c:out value="${KualiForm.extraButtonSource}" />'
+                                    class="tinybutton" border="0" /></a>
+                            </c:if>
+
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+                <br /><br />
+                <kul:displayMultipleValueLookupResults resultsList="${requestScope.reqSearchResults}" />
+            </td>
+            <td width="1%"><img src="${ConfigProperties.kr.externalizable.images.url}pixel_clear.gif" alt="" width="20" height="20"></td>
+        </tr>
+    </table>
+</kul:page>


### PR DESCRIPTION
Includes:
1) Liquibase script to insert 2 new parameters 'DOCUMENT_TYPES' and 'ORIGIN_CODES' with the General Error Correction component into the database.
1a) This has been tested using the Jenkins Liquibase Testing project, results can be view on build #108.
2) The Entry BO has been modified to have 2 additional fields: gecDocumentNumber and entryId. These fields are not persisted to the database. Instead, they are dynamically generated pieces of information.
3) GL Entry Lookup tab on the General Error Correction document.
4) Fiscal Year and Document Number fields with a Search button within GL Entry Lookup tab.
5) A MultiValue lookup page to provide search options.
6) Struts connections to provide linkage between the GL Entry Multivalue Lookup page and the GEC document.
7) The ability to return multiple general ledger entries to the GEC.
7a) When a document has been corrected by a GEC, the document number of the GEC will be listed and the option to select that Entry is disabled and cannot be returned.
8) On the GEC, when a general ledger entry has been returned from the lookup feature, it will be inserted as a "From" Accounting line. The fields are currently editable, this is to be addressed in GEC Step 2 (UAF-2354)
9) Spring wiring and global java constants to make it all work.
