### PR TITLE
UAF-1886 - Sub Account doc broken when copying

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSConstants.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSConstants.java
@@ -20,7 +20,7 @@ public class KFSConstants extends org.kuali.kfs.sys.KFSConstants {
         public static final String ACTIVE_PROFESSIONAL_EMPLOYEE_KIM_ROLE_NAME = "Active Professional Employee";
         public static final String ACTIVE_EMPLOYEE_AND_KFS_USER_KIM_ROLE_NAME = "Active Employee & Financial System User";
         public static final String ACTIVE_PROFESSIONAL_EMPLOYEE_AND_KFS_USER_KIM_ROLE_NAME = "Active Professional Employee & Financial System User";
-        public static final String CHART_MANAGER_KIM_ROLE_NAME = "Chart Manager";
+        public static final String CHART_MANAGER_KIM_ROLE_NAME = "UA Chart Manager";
         public static final String ORGANIZATION_REVIEWER_ROLE_NAMESPACECODE = CoreModuleNamespaces.KFS;
         public static final String ACCOUNTING_REVIEWER_ROLE_NAMESPACECODE = CoreModuleNamespaces.KFS;
         public static final String ACCOUNTING_REVIEWER_ROLE_NAME = "Accounting Reviewer";

--- a/kfs-core/src/main/java/org/kuali/kfs/sys/KFSConstants.java
+++ b/kfs-core/src/main/java/org/kuali/kfs/sys/KFSConstants.java
@@ -1259,7 +1259,7 @@ public class KFSConstants {
         public static final String ACTIVE_PROFESSIONAL_EMPLOYEE_KIM_ROLE_NAME = "Active Professional Employee";
         public static final String ACTIVE_EMPLOYEE_AND_KFS_USER_KIM_ROLE_NAME = "Active Employee & Financial System User";
         public static final String ACTIVE_PROFESSIONAL_EMPLOYEE_AND_KFS_USER_KIM_ROLE_NAME = "Active Professional Employee & Financial System User";
-        public static final String CHART_MANAGER_KIM_ROLE_NAME = "Chart Manager";
+        public static final String CHART_MANAGER_KIM_ROLE_NAME = "UA Chart Manager";
         public static final String ORGANIZATION_REVIEWER_ROLE_NAMESPACECODE = CoreModuleNamespaces.KFS;
         public static final String ACCOUNTING_REVIEWER_ROLE_NAMESPACECODE = CoreModuleNamespaces.KFS;
         public static final String ACCOUNTING_REVIEWER_ROLE_NAME = "Accounting Reviewer";


### PR DESCRIPTION
Correcting Chart Manager role name in constants classes:
- Change "Chart Manager" -> "UA Chart Manager"
  - kfs-core/src/main/java/edu/arizona/kfs/sys/KFSConstants.java:1262
    - CHART_MANAGER_KIM_ROLE_NAME
  - kfs-core/src/main/java/org/kuali/kfs/sys/KFSConstants.java:23
    - CHART_MANAGER_KIM_ROLE_NAME
