### PR TITLE
UAF-59 UAF-2118 Missing Invoice Number (DV to PREQ Validation)

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/validation/impl/DisbursementVoucherDocumentPreRules.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/validation/impl/DisbursementVoucherDocumentPreRules.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.fp.businessobject.DisbursementVoucherPayeeDetail;
 import org.kuali.kfs.fp.document.DisbursementVoucherConstants;
 import org.kuali.kfs.fp.document.DisbursementVoucherDocument;
+import org.kuali.kfs.integration.purap.PurchasingAccountsPayableModuleService;
 import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.rice.core.api.config.property.ConfigurationService;
 import org.kuali.rice.kew.api.WorkflowDocument;
@@ -25,6 +26,7 @@ public class DisbursementVoucherDocumentPreRules extends org.kuali.kfs.fp.docume
 
     private static transient volatile DisbursementVoucherInvoiceService disbursementVoucherInvoiceService;
     private static transient volatile ConfigurationService configurationService;
+    private static transient volatile PurchasingAccountsPayableModuleService purapModuleService;
 
     private static DisbursementVoucherInvoiceService getDisbursementVoucherInvoiceService() {
         if (disbursementVoucherInvoiceService == null) {
@@ -45,7 +47,7 @@ public class DisbursementVoucherDocumentPreRules extends org.kuali.kfs.fp.docume
         boolean result = super.doPrompts(document);
 
         result &= checkDisbursementVoucherInvoiceNumberRequired((DisbursementVoucherDocument) document);
-        result &= checkDisbursementVoucherInvoiceNumberDuplicate((DisbursementVoucherDocument) document);
+        result &= checkInvoiceNumberDuplicate((DisbursementVoucherDocument) document);
 
         return result;
     }
@@ -68,14 +70,36 @@ public class DisbursementVoucherDocumentPreRules extends org.kuali.kfs.fp.docume
     }
 
     @SuppressWarnings("deprecation")
-    private boolean checkDisbursementVoucherInvoiceNumberDuplicate(DisbursementVoucherDocument document) {
+    private boolean checkInvoiceNumberDuplicate(DisbursementVoucherDocument document) {
 
-        ArrayList<String> matchingDvs = findDVsWithMatchingInvoice(document);
-
-        if (!matchingDvs.isEmpty()) {
+        ArrayList<String> matchingDVs = new ArrayList<String>();
+        ArrayList<String> matchingPreqs = new ArrayList<String>();
+        for (DisbursementVoucherSourceAccountingLine sourceAccountingLine : (List<DisbursementVoucherSourceAccountingLine>) document.getSourceAccountingLines()) {
+            DisbursementVoucherSourceAccountingLineExtension extension = sourceAccountingLine.getExtension();
+            String invoiceNumber = extension.getInvoiceNumber();
+            if (StringUtils.isNotBlank(invoiceNumber)) {
+                ArrayList<String> listDisbursementVouchers = findDisbursementVouchersWithInvoiceNumber(document, invoiceNumber);
+                for (String documentNumber : listDisbursementVouchers) {
+                    if (!documentNumber.equals(document.getDocumentNumber()) && !matchingDVs.contains(documentNumber)) {
+                        matchingDVs.add(documentNumber);
+                    }
+                }
+                
+                List<String> listPaymentRequests = findPaymentRequestsWithInvoiceNumber(document, invoiceNumber);
+                if (listPaymentRequests != null && listPaymentRequests.size() > 0) {
+                	for(String documentNumber : listPaymentRequests) {
+                		if(!documentNumber.equals(document.getDocumentNumber()) && !matchingPreqs.contains(documentNumber)) {
+                			matchingPreqs.add(documentNumber);
+                		}
+                	}
+                }
+            }
+        }
+        
+        if (!matchingDVs.isEmpty() || !matchingPreqs.isEmpty()) {
             String questionText = getConfigurationService().getPropertyValueAsString(KFSKeyConstants.MESSAGE_DV_DUPLICATE_INVOICE);
 
-            Object[] args = { toCommaDelimitedString(matchingDvs) };
+            Object[] args = { toCommaDelimitedString(matchingDVs), toCommaDelimitedString(matchingPreqs) };
             questionText = MessageFormat.format(questionText, args);
 
             boolean okToProceed = super.askOrAnalyzeYesNoQuestion(KFSConstants.DUPLICATE_INVOICE_QUESTION_ID, questionText);
@@ -87,29 +111,11 @@ public class DisbursementVoucherDocumentPreRules extends org.kuali.kfs.fp.docume
         return true;
     }
 
-    private String toCommaDelimitedString(ArrayList<String> matchingDvs) {
-        if (matchingDvs == null || matchingDvs.isEmpty()) {
+    private String toCommaDelimitedString(ArrayList<String> documentIds) {
+        if (documentIds == null || documentIds.isEmpty()) {
             return KFSConstants.NOT_AVAILABLE_STRING;
         }
-        return StringUtils.join(matchingDvs, KFSConstants.COMMA);
-    }
-
-    @SuppressWarnings("unchecked")
-    private ArrayList<String> findDVsWithMatchingInvoice(DisbursementVoucherDocument document) {
-        ArrayList<String> matchingDVs = new ArrayList<String>();
-        for (DisbursementVoucherSourceAccountingLine sourceAccountingLine : (List<DisbursementVoucherSourceAccountingLine>) document.getSourceAccountingLines()) {
-            DisbursementVoucherSourceAccountingLineExtension extension = sourceAccountingLine.getExtension();
-            String invoiceNumber = extension.getInvoiceNumber();
-            if (StringUtils.isNotBlank(invoiceNumber)) {
-                ArrayList<String> listDisbursementVouchers = findDisbursementVouchersWithInvoiceNumber(document, invoiceNumber);
-                for (String documentNumber : listDisbursementVouchers) {
-                    if (!documentNumber.equals(document.getDocumentNumber()) && !matchingDVs.contains(documentNumber)) {
-                        matchingDVs.add(documentNumber);
-                    }
-                }
-            }
-        }
-        return matchingDVs;
+        return StringUtils.join(documentIds, KFSConstants.COMMA);
     }
 
     private ArrayList<String> findDisbursementVouchersWithInvoiceNumber(DisbursementVoucherDocument document, String invoiceNumber) {
@@ -117,4 +123,20 @@ public class DisbursementVoucherDocumentPreRules extends org.kuali.kfs.fp.docume
         ArrayList<String> listDisbursementVouchers = (ArrayList<String>) getDisbursementVoucherInvoiceService().findDisbursementVouchersWithInvoiceNumber(payeeDetail.getDisbVchrPayeeIdNumber(), payeeDetail.getDisbursementVoucherPayeeTypeCode(), invoiceNumber);
         return listDisbursementVouchers;
     }
+    
+    private List<String> findPaymentRequestsWithInvoiceNumber(DisbursementVoucherDocument document, String invoiceNumber) {
+    	DisbursementVoucherPayeeDetail payeeDetail = document.getDvPayeeDetail();
+    	List<String> listPaymentRequests = (List<String>) getPurchasingAccountsPayableModuleService().findPaymentRequestsByVendorNumberInvoiceNumber(payeeDetail.getDisbVchrVendorHeaderIdNumberAsInteger(), payeeDetail.getDisbVchrVendorDetailAssignedIdNumberAsInteger(), invoiceNumber);
+    	return listPaymentRequests;
+    }
+    
+    
+    public static PurchasingAccountsPayableModuleService getPurchasingAccountsPayableModuleService() {
+    	if(purapModuleService == null) {
+    		purapModuleService = SpringContext.getBean(PurchasingAccountsPayableModuleService.class);
+    	}
+    	
+    	return purapModuleService;
+    }
+    	
 }

--- a/kfs-core/src/main/java/org/kuali/kfs/integration/purap/PurchasingAccountsPayableModuleService.java
+++ b/kfs-core/src/main/java/org/kuali/kfs/integration/purap/PurchasingAccountsPayableModuleService.java
@@ -91,4 +91,5 @@ public interface PurchasingAccountsPayableModuleService {
      */
     public KualiDecimal getTotalPaidAmountToRequisitions(List<String> documentNumbers);
 
+    public List<String> findPaymentRequestsByVendorNumberInvoiceNumber(Integer vendorHeaderGeneratedId, Integer vendorDetailAssignedId, String invoiceNumber);
 }

--- a/kfs-core/src/main/java/org/kuali/kfs/integration/purap/PurchasingAccountsPayableModuleServiceNoOp.java
+++ b/kfs-core/src/main/java/org/kuali/kfs/integration/purap/PurchasingAccountsPayableModuleServiceNoOp.java
@@ -79,4 +79,10 @@ public class PurchasingAccountsPayableModuleServiceNoOp implements PurchasingAcc
         LOG.warn( "Using No-Op " + getClass().getSimpleName() + " service." );
         return null;
     }
+    
+    @Override
+    public List<String> findPaymentRequestsByVendorNumberInvoiceNumber(Integer vendorHeaderGeneratedId, Integer vendorDetailAssignedId, String invoiceNumber) {
+    	LOG.warn( "Using No-op " + getClass().getSimpleName() + " service. " );
+    	return Collections.emptyList();
+    }
 }

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/fp-resources.properties
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/fp-resources.properties
@@ -1,5 +1,5 @@
 #UAF-59 / UAF-1668 Invoice Number on DV
-message.dv.duplicate.invoice=Warning: A disbursement voucher for the specified invoice number and payee already exists.  Do you want to continue?[br][br]Disbursement Voucher(s): {0}
+message.dv.duplicate.invoice=Warning: A disbursement voucher and/or payment request for the specified invoice number and payee already exists.  Do you want to continue?[br][br]Disbursement Voucher(s): {0}[br]Payment Request(s): {1}
 
 # Payment Method Document - UAF-1639
 error.document.paymentmethod.effectivedate.inpast=The dates for new charts must be tomorrow or later.  (Can't retroactively change today's payment method information.)

--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/web/struts/PaymentRequestAction.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/web/struts/PaymentRequestAction.java
@@ -59,7 +59,6 @@ public class PaymentRequestAction extends org.kuali.kfs.module.purap.document.we
         if (PurapConstants.PREQ_DUPLICATE_DV_QUESTION.equals(question)) {
             if (ConfirmationQuestion.NO.equals(buttonClicked)) {
                 paymentRequestDocument.getFinancialSystemDocumentHeader().setWorkflowDocumentStatusCode(PurapConstants.PaymentRequestStatuses.APPDOC_INITIATE);
-                GlobalVariables.getMessageMap().putError(PurapPropertyConstants.INVOICE_NUMBER, PurapKeyConstants.MESSAGE_PREQ_DUPLICATE_DV_INVOICE);
                 return mapping.findForward(KFSConstants.MAPPING_BASIC);
             } else {
                 return null;
@@ -69,7 +68,7 @@ public class PaymentRequestAction extends org.kuali.kfs.module.purap.document.we
         PaymentRequestDocument preq = ((PaymentRequestForm) form).getPaymentRequestDocument();
         ArrayList<String> matchingDVs = findMatchingDisbursementVouchersWithInvoiceNumber(preq);
         if (matchingDVs != null && !matchingDVs.isEmpty()) {
-            String questionText = getConfigurationService().getPropertyValueAsString(KFSKeyConstants.MESSAGE_DV_DUPLICATE_INVOICE);
+            String questionText = getConfigurationService().getPropertyValueAsString(PurapKeyConstants.MESSAGE_PREQ_DUPLICATE_DV_INVOICE);
 
             String args = toCommaDelimitedString(matchingDVs);
             questionText = MessageFormat.format(questionText, args);

--- a/kfs-purap/src/main/java/org/kuali/kfs/module/purap/document/service/impl/PurchasingAccountsPayableModuleServiceImpl.java
+++ b/kfs-purap/src/main/java/org/kuali/kfs/module/purap/document/service/impl/PurchasingAccountsPayableModuleServiceImpl.java
@@ -58,7 +58,19 @@ public class PurchasingAccountsPayableModuleServiceImpl implements PurchasingAcc
     protected PurapService purapService;
     protected DocumentService documentService;
     protected BusinessObjectService businessObjectService;
+    protected PaymentRequestService paymentRequestService;
 
+	public List<String> findPaymentRequestsByVendorNumberInvoiceNumber(Integer vendorHeaderGeneratedId, Integer vendorDetailAssignedId, String invoiceNumber) {
+		List<String> preqDocumentNumbers = new ArrayList<String>();
+		List<PaymentRequestDocument> preqDocuments = getPaymentRequestService().getPaymentRequestsByVendorNumberInvoiceNumber(vendorHeaderGeneratedId, vendorDetailAssignedId, invoiceNumber);
+		
+		for(PaymentRequestDocument preqDocument : preqDocuments) {
+			preqDocumentNumbers.add(preqDocument.getDocumentNumber());
+		}
+		
+		return preqDocumentNumbers;
+	}
+    
     /**
      * @see org.kuali.kfs.integration.service.PurchasingAccountsPayableModuleService#addAssignedAssetNumbers(java.lang.Integer,
      *      java.util.List)
@@ -256,5 +268,14 @@ public class PurchasingAccountsPayableModuleServiceImpl implements PurchasingAcc
     public void setBusinessObjectService(BusinessObjectService businessObjectService) {
         this.businessObjectService = businessObjectService;
     }
+    
+    public PaymentRequestService getPaymentRequestService() {
+		if(paymentRequestService == null) {
+			paymentRequestService = SpringContext.getBean(PaymentRequestService.class);
+		}
+		
+		return paymentRequestService;
+	}
+
 }
 

--- a/kfs-purap/src/main/resources/edu/arizona/kfs/module/purap/purap-resources.properties
+++ b/kfs-purap/src/main/resources/edu/arizona/kfs/module/purap/purap-resources.properties
@@ -1,1 +1,1 @@
-message.preq.duplicate.dv.invoice=A disbursement voucher for the specified invoice number and payee already exists.
+message.preq.duplicate.dv.invoice=Warning: A disbursement voucher for the specified invoice number and vendor already exists.  Do you want to continue?[br][br]Disbursement Voucher(s): {0}


### PR DESCRIPTION
Per the description and file added to the Jira:  (PurchasingAccountsPayableModuleService changes were made in the baseline per Julie)

**Added new method findPaymentRequestsByVendorNumberInvoiceNumber to PurchasingAccountsPayableModuleService.java.

**Added new method findPaymentRequestsByVendorNumberInvoiceNumber to PurchasingAccountsPayableModuleServiceNoOp.java 

**Added the following for implementation:   (PurchasingAccountsPayableModuleServiceImpl.java) 
- Add import: org.kuali.kfs.module.purap.document.PaymentRequestDocument;
- Add import: org.kuali.kfs.module.purap.document.service.PaymentRequestService;
- Add Service property: protected PaymentRequestService paymentRequestService;
- Add new methods findPaymentRequestsByVendorNumberInvoiceNumber and getPaymentRequestService

Here are the changes needed to the Disbursement Voucher Validation class:

**Added the following to DisbursementVoucherDocumentPreRules.java 
- Add import: org.kuali.kfs.integration.purap.PurchasingAccountsPayableModuleService;
- Add Service property: private static transient volatile PurchasingAccountsPayableModuleService purapModuleService;
- Add new methods getPurchasingAccountsPayableModuleService and findPaymentRequestsWithInvoiceNumber
- Added method call for findPaymentRequestsWithInvoiceNumber to the findDVsWtihMatchingInvoice()
- Changed the name of the method findDVsWithMatchingInvoice to findDocsWithMatchingInvoice per Julie's request as we are checking multiple documents - DV and PREQ.
- Changed the name of the method checkDisbursementVoucherInvoiceNumberDuplicate to checkInvoiceNumberDuplicate.
- Combined the checkInvoiceNumberDuplicate and findDocsWithMatchingInvoice methods into one method. In KFS6, having these separate was causing issues with the DV to PREQ validation when you are entering a DV with a certain invoice number and vendor number.  It was displaying the PREQ document numbers next to the DV document numbers.  With the way it was coded on UAF-1668, the method would only allow one ArrayList of document numbers to be returned, but needed to have two lists, one with DV document numbers and one with PREQ document numbers.  In KFS3, the code in those two methods was actually one method called checkInvoiceNumberDuplicate.
- Updated the toCommaDelimitedString method signature to reflect multiple document types, so regardless of the doc type, the method will populate N/A if the document ID list is null or empty. Previously, it was only pulling in the DV document number list, so after the other changes I made, PREQ document numbers were showing up as {1}.

PaymentRequestAction.java
- Updated the performDuplicatePaymentRequestAndEncumberFiscalYearCheck method with the correct message that is displayed per the specs
- Removed line 62 that was added in previous step, the error message it was displaying after clicking "no" on the continue question was displaying the continue question. (The screen shot of this error is on UAF-1952 - UAF-1952 Error.png)  If this line is left in, a new message would need to be added and placed here as the current message includes the continue question. (KFS3 did not have this error message displaying on the page, so I removed the line in KFS6 to match KFS3.)  Verified with Juanita that this is not present in KFS3.

fp-resources.properties
- updated the message.dv.duplicate.invoice error message to read "Warning: A disbursement voucher and/or payment request for the specified invoice number and payee already exists.  Do you want to continue?[br][br]Disbursement Voucher(s): {0}[br]Payment Request(s):{1}" per the specs.

purap-resources.properties
- Updated the message.preq.duplicate.dv.invoice error message to display the correct (including the question and the document number) on the validation on PREQ when there is a DV with the same invoice number and vendor number. (Per specs)
