### PR TITLE
UAF-2828 PREQ Initiation screen Incident Report

### DIFF
--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/web/struts/PaymentRequestAction.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/web/struts/PaymentRequestAction.java
@@ -58,7 +58,7 @@ public class PaymentRequestAction extends org.kuali.kfs.module.purap.document.we
         Object buttonClicked = request.getParameter(KFSConstants.QUESTION_CLICKED_BUTTON);
         if (PurapConstants.PREQ_DUPLICATE_DV_QUESTION.equals(question)) {
             if (ConfirmationQuestion.NO.equals(buttonClicked)) {
-                paymentRequestDocument.getFinancialSystemDocumentHeader().setWorkflowDocumentStatusCode(PurapConstants.PaymentRequestStatuses.APPDOC_INITIATE);
+            	paymentRequestDocument.updateAndSaveAppDocStatus(PurapConstants.PaymentRequestStatuses.APPDOC_INITIATE);
                 return mapping.findForward(KFSConstants.MAPPING_BASIC);
             } else {
                 return null;


### PR DESCRIPTION
Changed edu/arizona version PaymentRequestAction.java performDuplicatePaymentRequestAndEncumberFiscalYearCheck().  The wrong status was being set when a DV was found with the same invoice number and payee.  Previously, it was setting the workflowDocumentStatus and causing a STE where it was trying to set a 9 character status code into the database field that only allowed 1 character.  Changed it to update and save the app doc status instead (As it does in the original baseline method for duplicate invoice).
