### PR TITLE
UAF-2470 - Adding IU PO Auto-Close port as integrated in KualiCo master branch.

### DIFF
--- a/kfs-purap/src/main/java/org/kuali/kfs/module/purap/batch/AutoClosePurchaseOrdersStep.java
+++ b/kfs-purap/src/main/java/org/kuali/kfs/module/purap/batch/AutoClosePurchaseOrdersStep.java
@@ -20,7 +20,7 @@ package org.kuali.kfs.module.purap.batch;
 
 import java.util.Date;
 
-import org.kuali.kfs.module.purap.document.service.PurchaseOrderService;
+import org.kuali.kfs.module.purap.batch.service.AutoClosePurchaseOrderService;
 import org.kuali.kfs.sys.batch.AbstractStep;
 import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.rice.core.api.datetime.DateTimeService;
@@ -30,7 +30,7 @@ import org.kuali.rice.core.api.datetime.DateTimeService;
  */
 public class AutoClosePurchaseOrdersStep extends AbstractStep {
     private static org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(AutoClosePurchaseOrdersStep.class);
-    private PurchaseOrderService purchaseOrderService;
+    private AutoClosePurchaseOrderService autoClosePurchaseOrderService;
 
     public AutoClosePurchaseOrdersStep() {
         super();
@@ -42,7 +42,7 @@ public class AutoClosePurchaseOrdersStep extends AbstractStep {
      * @see org.kuali.kfs.sys.batch.Step#execute(String, Date)
      */
     public boolean execute(String jobName, Date jobRunDate) throws InterruptedException {
-        return purchaseOrderService.autoCloseFullyDisencumberedOrders();
+        return getAutoClosePurchaseOrderService().autoCloseFullyDisencumberedOrders();
     }
 
     /**
@@ -65,8 +65,12 @@ public class AutoClosePurchaseOrdersStep extends AbstractStep {
         }
     }
 
-    public void setPurchaseOrderService(PurchaseOrderService purchaseOrderService) {
-        this.purchaseOrderService = purchaseOrderService;
+    public AutoClosePurchaseOrderService getAutoClosePurchaseOrderService() {
+        return autoClosePurchaseOrderService;
+    }
+
+    public void setAutoClosePurchaseOrderService(AutoClosePurchaseOrderService autoClosePurchaseOrderService) {
+        this.autoClosePurchaseOrderService = autoClosePurchaseOrderService;
     }
 
 }

--- a/kfs-purap/src/main/java/org/kuali/kfs/module/purap/batch/service/AutoClosePurchaseOrderService.java
+++ b/kfs-purap/src/main/java/org/kuali/kfs/module/purap/batch/service/AutoClosePurchaseOrderService.java
@@ -1,0 +1,16 @@
+package org.kuali.kfs.module.purap.batch.service;
+
+import org.kuali.kfs.module.purap.businessobject.AutoClosePurchaseOrderView;
+
+public interface AutoClosePurchaseOrderService {
+    /**
+     * This gets a list of Purchase Orders in Open status and checks to see if their
+     * line item encumbrances are all fully disencumbered and if so then the Purchase
+     * Order is closed and notes added to indicate the change occurred in batch
+     *
+     * @return boolean true if the job is completed successfully and false otherwise.
+     */
+    public boolean autoCloseFullyDisencumberedOrders();
+
+    public void autoClosePurchaseOrder(AutoClosePurchaseOrderView poAutoClose);
+}

--- a/kfs-purap/src/main/java/org/kuali/kfs/module/purap/batch/service/impl/AutoClosePurchaseOrderServiceImpl.java
+++ b/kfs-purap/src/main/java/org/kuali/kfs/module/purap/batch/service/impl/AutoClosePurchaseOrderServiceImpl.java
@@ -1,0 +1,64 @@
+package org.kuali.kfs.module.purap.batch.service.impl;
+
+import java.util.List;
+
+import org.kuali.kfs.module.purap.PurapConstants;
+import org.kuali.kfs.module.purap.batch.service.AutoClosePurchaseOrderService;
+import org.kuali.kfs.module.purap.businessobject.AutoClosePurchaseOrderView;
+import org.kuali.kfs.module.purap.document.PurchaseOrderDocument;
+import org.kuali.kfs.module.purap.document.service.PurchaseOrderService;
+import org.kuali.kfs.sys.service.NonTransactional;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.springframework.transaction.annotation.Transactional;
+
+@NonTransactional
+public class AutoClosePurchaseOrderServiceImpl implements AutoClosePurchaseOrderService {
+    private static org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(AutoClosePurchaseOrderServiceImpl.class);
+    private static final String AUTO_CLOSE_NOTE = "This PO was automatically closed in batch.";
+    protected PurchaseOrderService purchaseOrderService;
+
+
+    /**
+     * @see AutoClosePurchaseOrderService#autoCloseFullyDisencumberedOrders()
+     */
+    @Override
+    @NonTransactional
+    public boolean autoCloseFullyDisencumberedOrders() {
+
+        LOG.debug("autoCloseFullyDisencumberedOrders() started");
+
+        LOG.info("autoCloseFullyDisencumberedOrders(): Querying PO view for all auto-close eligible records...");
+        List<AutoClosePurchaseOrderView> autoCloseList = getPurchaseOrderService().getAllOpenPurchaseOrdersForAutoClose();
+        LOG.info("autoCloseFullyDisencumberedOrders(): Query returned with " + autoCloseList.size() + " records.");
+
+        for (AutoClosePurchaseOrderView poAutoClose : autoCloseList) {
+            autoClosePurchaseOrder(poAutoClose);
+        }
+
+        LOG.debug("autoCloseFullyDisencumberedOrders() ended");
+
+        return true;
+    }
+
+    @Transactional
+    public void autoClosePurchaseOrder(AutoClosePurchaseOrderView poAutoClose) {
+        if ((poAutoClose.getTotalAmount() != null) && ((KualiDecimal.ZERO.compareTo(poAutoClose.getTotalAmount())) != 0)) {
+            LOG.info("autoCloseFullyDisencumberedOrders() PO ID " + poAutoClose.getPurapDocumentIdentifier() + " with total " + poAutoClose.getTotalAmount().doubleValue() + " will be closed");
+
+            String newStatus = PurapConstants.PurchaseOrderStatuses.APPDOC_PENDING_CLOSE;
+            String documentType = PurapConstants.PurchaseOrderDocTypes.PURCHASE_ORDER_CLOSE_DOCUMENT;
+            PurchaseOrderDocument document = getPurchaseOrderService().getPurchaseOrderByDocumentNumber(poAutoClose.getDocumentNumber());
+
+            getPurchaseOrderService().createNoteForAutoCloseOrders(document, AUTO_CLOSE_NOTE);
+            getPurchaseOrderService().createAndRoutePotentialChangeDocument(poAutoClose.getDocumentNumber(), documentType, AUTO_CLOSE_NOTE, null, newStatus);
+        }
+    }
+
+    public PurchaseOrderService getPurchaseOrderService() {
+        return purchaseOrderService;
+    }
+
+    public void setPurchaseOrderService(PurchaseOrderService purchaseOrderService) {
+        this.purchaseOrderService = purchaseOrderService;
+    }
+}

--- a/kfs-purap/src/main/java/org/kuali/kfs/module/purap/businessobject/AutoClosePurchaseOrderView.java
+++ b/kfs-purap/src/main/java/org/kuali/kfs/module/purap/businessobject/AutoClosePurchaseOrderView.java
@@ -18,6 +18,7 @@
  */
 package org.kuali.kfs.module.purap.businessobject;
 
+import org.kuali.kfs.sys.businessobject.FinancialSystemDocumentHeader;
 import org.kuali.rice.core.api.util.type.KualiDecimal;
 
 /**
@@ -27,6 +28,7 @@ public class AutoClosePurchaseOrderView extends PurchaseOrderView {
 
     private KualiDecimal totalEncumbrance;
     private KualiDecimal totalAmount;
+    private FinancialSystemDocumentHeader documentHeader;
     
     public KualiDecimal getTotalEncumbrance() {
         return totalEncumbrance;
@@ -43,5 +45,13 @@ public class AutoClosePurchaseOrderView extends PurchaseOrderView {
     public void setTotalAmount(KualiDecimal totalAmount) {
         this.totalAmount = totalAmount;
     }
-    
+
+    public FinancialSystemDocumentHeader getDocumentHeader() {
+        return documentHeader;
+    }
+
+    public void setDocumentHeader(FinancialSystemDocumentHeader documentHeader) {
+        this.documentHeader = documentHeader;
+    }
+
 }

--- a/kfs-purap/src/main/java/org/kuali/kfs/module/purap/document/dataaccess/impl/PurchaseOrderDaoOjb.java
+++ b/kfs-purap/src/main/java/org/kuali/kfs/module/purap/document/dataaccess/impl/PurchaseOrderDaoOjb.java
@@ -26,6 +26,7 @@ import org.apache.ojb.broker.query.Criteria;
 import org.apache.ojb.broker.query.QueryByCriteria;
 import org.apache.ojb.broker.query.ReportQueryByCriteria;
 import org.joda.time.DateTime;
+import org.kuali.kfs.module.purap.PurapConstants;
 import org.kuali.kfs.module.purap.PurapPropertyConstants;
 import org.kuali.kfs.module.purap.businessobject.AutoClosePurchaseOrderView;
 import org.kuali.kfs.module.purap.businessobject.PurchaseOrderItem;
@@ -190,7 +191,7 @@ public class PurchaseOrderDaoOjb extends PlatformAwareDaoBaseOjb implements Purc
      */
     @Override
     public List<AutoClosePurchaseOrderView> getAllOpenPurchaseOrders(List<String> excludedVendorChoiceCodes) {
-        LOG.debug("getAllOpenPurchaseOrders() started");
+        LOG.debug("getAllOpenPurchaseOrdersForAutoClose() started");
         Criteria criteria = new Criteria();
         criteria.addIsNull(PurapPropertyConstants.RECURRING_PAYMENT_TYPE_CODE);
         criteria.addEqualTo(PurapPropertyConstants.TOTAL_ENCUMBRANCE, new KualiDecimal(0));
@@ -198,12 +199,13 @@ public class PurchaseOrderDaoOjb extends PlatformAwareDaoBaseOjb implements Purc
         for (String excludeCode : excludedVendorChoiceCodes) {
             criteria.addNotEqualTo(PurapPropertyConstants.VENDOR_CHOICE_CODE, excludeCode);
         }
+        criteria.addEqualTo(KFSPropertyConstants.DOCUMENT_HEADER+"."+KFSPropertyConstants.APPLICATION_DOCUMENT_STATUS, PurapConstants.PurchaseOrderStatuses.APPDOC_OPEN);
         QueryByCriteria qbc = new QueryByCriteria(AutoClosePurchaseOrderView.class, criteria);
         if (LOG.isDebugEnabled()) {
-            LOG.debug("getAllOpenPurchaseOrders() Query criteria is " + criteria.toString());
+            LOG.debug("getAllOpenPurchaseOrdersForAutoClose() Query criteria is " + criteria.toString());
         }
         List<AutoClosePurchaseOrderView> l = (List<AutoClosePurchaseOrderView>) getPersistenceBrokerTemplate().getCollectionByQuery(qbc);
-        LOG.debug("getAllOpenPurchaseOrders() ended.");
+        LOG.debug("getAllOpenPurchaseOrdersForAutoClose() ended.");
 
         return l;
     }

--- a/kfs-purap/src/main/java/org/kuali/kfs/module/purap/document/service/PurchaseOrderService.java
+++ b/kfs-purap/src/main/java/org/kuali/kfs/module/purap/document/service/PurchaseOrderService.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.kuali.kfs.integration.purap.CapitalAssetSystem;
+import org.kuali.kfs.module.purap.businessobject.AutoClosePurchaseOrderView;
 import org.kuali.kfs.module.purap.businessobject.PurchaseOrderItem;
 import org.kuali.kfs.module.purap.businessobject.PurchaseOrderQuoteStatus;
 import org.kuali.kfs.module.purap.businessobject.PurchaseOrderVendorQuote;
@@ -362,13 +363,24 @@ public interface PurchaseOrderService extends PurchasingDocumentSpecificService 
     public void processACMReq(ContractManagerAssignmentDocument acmDoc);
 
     /**
-     * This gets a list of Purchase Orders in Open status and checks to see if their
-     * line item encumbrances are all fully disencumbered and if so then the Purchase
-     * Order is closed and notes added to indicate the change occurred in batch
+     * Creates and add a note to the purchase order document using the annotation String in the input parameter. This method is used
+     * by the autoCloseRecurringOrders() and autoCloseFullyDisencumberedOrders to add a note to the purchase order to indicate that
+     * the purchase order was closed by the batch job.
      *
-     * @return boolean true if the job is completed successfully and false otherwise.
+     * @param purchaseOrderDocument The purchase order document that is being closed by the batch job.
+     * @param annotation The string to appear on the note to be attached to the purchase order.
      */
-    public boolean autoCloseFullyDisencumberedOrders();
+    public void createNoteForAutoCloseOrders(PurchaseOrderDocument purchaseOrderDocument, String annotation);
+
+    /**
+     * This method gets all the PurchaseOrderView objects that relate to POs
+     * with no recurring payment type, status of 'OPEN', and total encumbrance
+     * of 0 that do not have any of the excluded vendor choice codes.
+     *
+     * @param excludedVendorChoiceCodes - list of strings of excluded vendor choice codes
+     * @return List of PurchaseOrderAutoClose objects
+     */
+    public List<AutoClosePurchaseOrderView> getAllOpenPurchaseOrdersForAutoClose();
 
 
     /**

--- a/kfs-purap/src/main/resources/org/kuali/kfs/module/purap/ojb-purap.xml
+++ b/kfs-purap/src/main/resources/org/kuali/kfs/module/purap/ojb-purap.xml
@@ -3503,6 +3503,9 @@
     <field-descriptor name="recurringPaymentEndDate" column="PO_END_DT" jdbc-type="TIMESTAMP"/>
     <field-descriptor name="totalEncumbrance" column="TOTAL_ENCUMBRANCE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
     <field-descriptor name="totalAmount" column="TOTAL_AMOUNT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
+    <reference-descriptor name="documentHeader" class-ref="org.kuali.kfs.sys.businessobject.FinancialSystemDocumentHeader" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" >
+        <foreignkey field-ref="documentNumber" />
+    </reference-descriptor>
 </class-descriptor>
 
 <class-descriptor class="org.kuali.kfs.module.purap.businessobject.PurchaseOrderQuoteLanguage" table="PUR_PO_QT_LANG_T">

--- a/kfs-purap/src/main/resources/org/kuali/kfs/module/purap/spring-purap.xml
+++ b/kfs-purap/src/main/resources/org/kuali/kfs/module/purap/spring-purap.xml
@@ -480,9 +480,10 @@
         <property name="parameterService" ref="parameterService" />
         <property name="dateTimeService" ref="dateTimeService"/>
     </bean>
-    
-    <bean id="autoClosePurchaseOrdersStep" class="org.kuali.kfs.module.purap.batch.AutoClosePurchaseOrdersStep" parent="step">
-        <property name="purchaseOrderService" ref="purchaseOrderService" />
+
+    <bean id="autoClosePurchaseOrdersStep" parent="autoClosePurchaseOrdersStep-parentBean"/>
+    <bean id="autoClosePurchaseOrdersStep-parentBean" abstract="true" class="org.kuali.kfs.module.purap.batch.AutoClosePurchaseOrdersStep" parent="step">
+        <property name="autoClosePurchaseOrderService" ref="autoClosePurchaseOrderService" />
     </bean>
     
     <bean id="autoCloseRecurringOrdersStep" class="org.kuali.kfs.module.purap.batch.AutoCloseRecurringOrdersStep" parent="step">
@@ -750,6 +751,11 @@
 		
 	<bean id="purchaseOrderParameters" parent="PurchaseOrderParameters-parentBean" scope="prototype"/>	
 	<bean id="PurchaseOrderParameters-parentBean" class="org.kuali.kfs.module.purap.pdf.PurchaseOrderTransmitParameters" scope="prototype" abstract="true" />
+
+    <bean id="autoClosePurchaseOrderService" parent="autoClosePurchaseOrderService-parentBean"/>
+    <bean id="autoClosePurchaseOrderService-parentBean" abstract="true" class="org.kuali.kfs.module.purap.batch.service.impl.AutoClosePurchaseOrderServiceImpl">
+        <property name="purchaseOrderService" ref="purchaseOrderService"/>
+    </bean>
 
     <!-- validations -->
 	<import resource="document/validation/configuration/PurapValidatorDefinitions.xml" />


### PR DESCRIPTION
I worked off of the KualiCo master branch, and did my best to perform a straight backport. This proved to be fairly easy, as the quality of code was high, and the architecting decisions solid. To get past the missing PO view column that was removed in a past version, a workflow header column was mapped to the a new field in the PO view object directly via OJB. Also a new service was split out specifically for PO Close, with the service being non-transactional, but the solitary PO-close _method_ becoming transactional. The remainder of changes were to support these two goals, where configuration, interfaces, and concrete classes needed to reflect the new names and signatures.
