### PR TITLE
UAF-2682 Bug - Account (ACCT) Document Routes to Exception

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/coa/businessobject/AccountExtension.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/coa/businessobject/AccountExtension.java
@@ -31,10 +31,10 @@ public class AccountExtension extends PersistableBusinessObjectExtensionBase {
     private String institutionalFringeAccountExt;
 
     // Helper Objects
-    private transient volatile BudgetShellCode budgetShell;
-    private transient volatile CrossOrganizationCode crossOrganization;
-    private transient volatile FACostSubCategory faCostSubCategory;    // FA Subcategory Object
-    private transient volatile TaxRegion taxRegionObj;
+    private BudgetShellCode budgetShell;
+    private CrossOrganizationCode crossOrganization;
+    private FACostSubCategory faCostSubCategory;    // FA Subcategory Object
+    private TaxRegion taxRegionObj;
 
     public String getChartOfAccountsCode() {
         return chartOfAccountsCode;
@@ -105,15 +105,11 @@ public class AccountExtension extends PersistableBusinessObjectExtensionBase {
     }
 
     public FACostSubCategory getFaCostSubCategory() {
-    	if (faCostSubCategory == null || !StringUtils.equals(faCostSubCategory.getFaCostSubCatCode(), faCostSubCatCode)) {
-    		faCostSubCategory = getBusinessObjectService().findBySinglePrimaryKey(FACostSubCategory.class, faCostSubCatCode);
-        }
     	return faCostSubCategory;
     }
     
     public void setFaCostSubCategory(FACostSubCategory faCostSubCategory) {
     	this.faCostSubCategory = faCostSubCategory;
-    	setFaCostSubCatCode(faCostSubCategory.getFaCostSubCatCode());
     }
 
     public String getInstitutionalFringeCoaCodeExt() {
@@ -133,27 +129,19 @@ public class AccountExtension extends PersistableBusinessObjectExtensionBase {
     }
 
     public BudgetShellCode getBudgetShell() {
-        if (budgetShell == null || !StringUtils.equals(budgetShell.getBudgetShellCode(), budgetShellCode)) {
-            budgetShell = getBusinessObjectService().findBySinglePrimaryKey(BudgetShellCode.class, budgetShellCode);
-        }
         return budgetShell;
     }
 
     public void setBudgetShell(BudgetShellCode budgetShell) {
         this.budgetShell = budgetShell;
-        setBudgetShellCode(budgetShell.getBudgetShellCode());
     }
 
     public CrossOrganizationCode getCrossOrganization() {
-        if (crossOrganization == null || !StringUtils.equals(crossOrganization.getCrossOrganizationCode(), crossOrganizationCode)) {
-            crossOrganization = getBusinessObjectService().findBySinglePrimaryKey(CrossOrganizationCode.class, crossOrganizationCode);
-        }
         return crossOrganization;
     }
 
     public void setCrossOrganization(CrossOrganizationCode crossOrganization) {
         this.crossOrganization = crossOrganization;
-        setCrossOrganizationCode(crossOrganization.getCrossOrganizationCode());
     }
 
     protected BusinessObjectService getBusinessObjectService() {


### PR DESCRIPTION
Changed the variables from private transient volatile to private. Also, updated the setters/getters for CrossOrganization, BudgetShell, FACost to normal getters/setters as previously they were relying on values being in the database.   Found these were returning null values and were causing the document to route to exception. Since these fields are not required, there may not be values in the database for those fields.  Did not change TaxRegion getter/setter as this field is required.
