### PR TITLE
UAF-36 / UAF-2354 / UAF-2355 MOD-FP0035-01 GEC Step 2 (Accounting Lines, GLPE, Rename To & From)

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/authorization/GeneralErrorCorrectionCorrectingAccountingLinesAuthorizer.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/authorization/GeneralErrorCorrectionCorrectingAccountingLinesAuthorizer.java
@@ -1,0 +1,83 @@
+package edu.arizona.kfs.fp.document.authorization;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.fp.document.authorization.CapitalAccountingLinesAuthorizerBase;
+import org.kuali.kfs.sys.KFSKeyConstants;
+import org.kuali.kfs.sys.businessobject.AccountingLine;
+import org.kuali.kfs.sys.document.AccountingDocument;
+import org.kuali.kfs.sys.document.web.AccountingLineRenderingContext;
+import org.kuali.kfs.sys.document.web.AccountingLineViewAction;
+import org.kuali.rice.kew.api.WorkflowDocument;
+import org.kuali.rice.kim.api.identity.Person;
+
+import edu.arizona.kfs.sys.KFSConstants;
+
+public class GeneralErrorCorrectionCorrectingAccountingLinesAuthorizer extends CapitalAccountingLinesAuthorizerBase {
+
+    @Override
+    public boolean renderNewLine(AccountingDocument accountingDocument, String accountingGroupProperty) {
+        return false;
+    }
+
+    @Override
+    public boolean isGroupEditable(AccountingDocument accountingDocument, List<? extends AccountingLineRenderingContext> accountingLineRenderingContexts, Person currentUser) {
+        WorkflowDocument workflowDocument = accountingDocument.getDocumentHeader().getWorkflowDocument();
+        if (workflowDocument.isInitiated() || workflowDocument.isSaved() || workflowDocument.isCompletionRequested()) {
+            return StringUtils.equalsIgnoreCase(workflowDocument.getInitiatorPrincipalId(), currentUser.getPrincipalId());
+        }
+        return false;
+    }
+
+    @Override
+    public List<AccountingLineViewAction> getActions(AccountingDocument accountingDocument, AccountingLineRenderingContext accountingLineRenderingContext, String accountingLinePropertyName, Integer accountingLineIndex, Person currentUser, String groupTitle) {
+        List<AccountingLineViewAction> actions = new ArrayList<AccountingLineViewAction>();
+        Map<String, AccountingLineViewAction> actionMap = this.getActionMap(accountingLineRenderingContext, accountingLinePropertyName, accountingLineIndex, groupTitle);
+        actions.addAll(actionMap.values());
+        return actions;
+    }
+
+    @Override
+    public boolean hasEditPermissionOnAccountingLine(AccountingDocument accountingDocument, AccountingLine accountingLine, String accountingLineCollectionProperty, Person currentUser, boolean pageIsEditable) {
+        return false;
+    }
+
+    @Override
+    public boolean hasEditPermissionOnField(AccountingDocument accountingDocument, AccountingLine accountingLine, String accountingLineCollectionProperty, String fieldName, boolean editableLine, boolean editablePage, Person currentUser) {
+        boolean retval = super.hasEditPermissionOnField(accountingDocument, accountingLine, accountingLineCollectionProperty, fieldName, editableLine, editablePage, currentUser);
+        return retval;
+    }
+
+    @Override
+    protected Map<String, AccountingLineViewAction> getActionMap(AccountingLineRenderingContext accountingLineRenderingContext, String accountingLinePropertyName, Integer accountingLineIndex, String groupTitle) {
+        Map<String, AccountingLineViewAction> retval = new HashMap<String, AccountingLineViewAction>();
+        if (accountingLineIndex != null) {
+            AccountingLineViewAction balanceInquiryAction = this.getBalanceInquiryAction(accountingLineRenderingContext.getAccountingLine(), accountingLinePropertyName, accountingLineIndex, groupTitle);
+            AccountingLineViewAction deleteAction = getDeleteAction(accountingLineRenderingContext.getAccountingLine(), accountingLinePropertyName, accountingLineIndex, groupTitle);
+            AccountingLineViewAction addAction = this.getAddLineAction(accountingLineRenderingContext.getAccountingLine(), accountingLinePropertyName, accountingLineIndex, groupTitle);
+            retval.put(KFSConstants.PERFORMANCE_BALANCE_INQUIRY_FOR_METHOD, balanceInquiryAction);
+            retval.put(KFSConstants.DELETE_LINE_METHOD, deleteAction);
+            retval.put(KFSConstants.ADD_LINE_METHOD, addAction);
+        }
+        return retval;
+    }
+
+    private AccountingLineViewAction getAddLineAction(AccountingLine accountingLine, String accountingLinePropertyName, Integer accountingLineIndex, String groupTitle) {
+        String actionMethod = this.getAddLineMethod(accountingLine, accountingLinePropertyName, accountingLineIndex);
+        String actionLabel = this.getActionLabel(KFSKeyConstants.AccountingLineViewRendering.ACCOUNTING_LINE_ADD_ACTION_LABEL, groupTitle);
+        String actionImageName = getRiceImagePath() + "tinybutton-add1.gif";
+        AccountingLineViewAction retval = new AccountingLineViewAction(actionMethod, actionLabel, actionImageName);
+        return retval;
+    }
+
+    private String getAddLineMethod(AccountingLine accountingLine, String accountingLineProperty, Integer accountingLineIndex) {
+        String infix = getActionInfixForNewAccountingLine(accountingLine, accountingLineProperty);
+        String retval = KFSConstants.INSERT_METHOD + infix + "Line.line" + accountingLineIndex + ".anchoraccounting" + infix + "Anchor";
+        return retval;
+    }
+
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/authorization/GeneralErrorCorrectionReversingAccountingLinesAuthorizer.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/authorization/GeneralErrorCorrectionReversingAccountingLinesAuthorizer.java
@@ -1,0 +1,111 @@
+package edu.arizona.kfs.fp.document.authorization;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.fp.document.authorization.CapitalAccountingLinesAuthorizerBase;
+import org.kuali.kfs.sys.businessobject.AccountingLine;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.kfs.sys.document.AccountingDocument;
+import org.kuali.kfs.sys.document.web.AccountingLineRenderingContext;
+import org.kuali.kfs.sys.document.web.AccountingLineViewAction;
+import org.kuali.rice.core.api.config.property.ConfigurationService;
+import org.kuali.rice.kew.api.WorkflowDocument;
+import org.kuali.rice.kim.api.identity.Person;
+import org.kuali.rice.krad.util.KRADConstants;
+
+import edu.arizona.kfs.sys.KFSConstants;
+import edu.arizona.kfs.sys.KFSKeyConstants;
+
+public class GeneralErrorCorrectionReversingAccountingLinesAuthorizer extends CapitalAccountingLinesAuthorizerBase {
+
+    @Override
+    public boolean renderNewLine(AccountingDocument accountingDocument, String accountingGroupProperty) {
+        return false;
+    }
+
+    @Override
+    public boolean isGroupEditable(AccountingDocument accountingDocument, List<? extends AccountingLineRenderingContext> accountingLineRenderingContexts, Person currentUser) {
+        WorkflowDocument workflowDocument = accountingDocument.getDocumentHeader().getWorkflowDocument();
+        if (workflowDocument.isInitiated() || workflowDocument.isSaved() || workflowDocument.isCompletionRequested()) {
+            return StringUtils.equalsIgnoreCase(workflowDocument.getInitiatorPrincipalId(), currentUser.getPrincipalId());
+        }
+        return false;
+    }
+
+    @Override
+    public boolean hasEditPermissionOnAccountingLine(AccountingDocument accountingDocument, AccountingLine accountingLine, String accountingLineCollectionProperty, Person currentUser, boolean pageIsEditable) {
+        return false;
+    }
+
+    @Override
+    public boolean hasEditPermissionOnField(AccountingDocument accountingDocument, AccountingLine accountingLine, String accountingLineCollectionProperty, String fieldName, boolean editableLine, boolean editablePage, Person currentUser) {
+        return false;
+    }
+
+    @Override
+    public List<AccountingLineViewAction> getActions(AccountingDocument accountingDocument, AccountingLineRenderingContext accountingLineRenderingContext, String accountingLinePropertyName, Integer accountingLineIndex, Person currentUser, String groupTitle) {
+        List<AccountingLineViewAction> actions = new ArrayList<AccountingLineViewAction>();
+        Map<String, AccountingLineViewAction> actionMap = this.getActionMap(accountingLineRenderingContext, accountingLinePropertyName, accountingLineIndex, groupTitle);
+        actions.addAll(actionMap.values());
+        return actions;
+    }
+
+    @Override
+    protected Map<String, AccountingLineViewAction> getActionMap(AccountingLineRenderingContext accountingLineRenderingContext, String accountingLinePropertyName, Integer accountingLineIndex, String groupTitle) {
+        Map<String, AccountingLineViewAction> retval = new HashMap<String, AccountingLineViewAction>();
+        if (accountingLineIndex != null) {
+            AccountingLineViewAction balanceInquiryAction = this.getBalanceInquiryAction(accountingLineRenderingContext.getAccountingLine(), accountingLinePropertyName, accountingLineIndex, groupTitle);
+            AccountingLineViewAction deleteAction = getDeleteAction(accountingLineRenderingContext.getAccountingLine(), accountingLinePropertyName, accountingLineIndex, groupTitle);
+            AccountingLineViewAction copyAction = getCopyAction(accountingLineRenderingContext.getAccountingLine(), accountingLinePropertyName, accountingLineIndex, groupTitle);
+            retval.put(KFSConstants.PERFORMANCE_BALANCE_INQUIRY_FOR_METHOD, balanceInquiryAction);
+            retval.put(KFSConstants.DELETE_LINE_METHOD, deleteAction);
+            retval.put(KFSConstants.COPY_METHOD, copyAction);
+        }
+        return retval;
+    }
+
+    /**
+     * construct the copy action for the given accounting line, typically, a new accounting line
+     *
+     * @param accountingLine
+     *            the given accounting line
+     * @param accountingLinePropertyName
+     *            the property name of the given account line, typically, the form name
+     * @param accountingLineIndex
+     *            the index of the given accounting line in its accounting line group
+     * @param groupTitle
+     *            the title of the accounting line group
+     * @return the copy action for the given accounting line
+     */
+    protected AccountingLineViewAction getCopyAction(AccountingLine accountingLine, String accountingLinePropertyName, Integer accountingLineIndex, String groupTitle) {
+        String actionMethod = this.getCopyLineMethod(accountingLine, accountingLinePropertyName, accountingLineIndex);
+        String actionLabel = this.getActionLabel(KFSKeyConstants.AccountingLineViewRendering.ACCOUNTING_LINE_COPY_ACTION_LABEL, groupTitle, accountingLineIndex + 1);
+        ConfigurationService kualiConfigurationService = SpringContext.getBean(ConfigurationService.class);
+        String imagesPath = kualiConfigurationService.getPropertyValueAsString(KRADConstants.APPLICATION_EXTERNALIZABLE_IMAGES_URL_KEY);
+        String actionImageName = imagesPath + "tinybutton-copy2.gif";
+        AccountingLineViewAction retval = new AccountingLineViewAction(actionMethod, actionLabel, actionImageName);
+        return retval;
+    }
+
+    /**
+     * Builds the action method name of the method that deletes accounting lines for this group
+     *
+     * @param accountingLine
+     *            the accounting line an action is being checked for
+     * @param accountingLinePropertyName
+     *            the property name of the accounting line
+     * @param accountingLineIndex
+     *            the index of the given accounting line within the the group being rendered
+     * @return the action method name of the method that deletes accounting lines for this group
+     */
+    protected String getCopyLineMethod(AccountingLine accountingLine, String accountingLineProperty, Integer accountingLineIndex) {
+        String infix = getActionInfixForExtantAccountingLine(accountingLine, accountingLineProperty);
+        String retval = "copyAccountingLine.line" + accountingLineIndex + ".anchoraccounting" + infix + "Anchor";
+        return retval;
+    }
+
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/web/struts/GeneralErrorCorrectionForm.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/web/struts/GeneralErrorCorrectionForm.java
@@ -11,7 +11,6 @@ public class GeneralErrorCorrectionForm extends org.kuali.kfs.fp.document.web.st
 
     private Integer universityFiscalYear;
     private String glDocId;
-    protected String lookupResultsSequenceNumber;
     private final String universityFiscalPeriodCodeLookupOverride = "*";
 
     public Integer getUniversityFiscalYear() {
@@ -28,14 +27,6 @@ public class GeneralErrorCorrectionForm extends org.kuali.kfs.fp.document.web.st
 
     public void setGlDocId(String glDocId) {
         this.glDocId = glDocId;
-    }
-
-    public String getLookupResultsSequenceNumber() {
-        return lookupResultsSequenceNumber;
-    }
-
-    public void setLookupResultsSequenceNumber(String lookupResultsSequenceNumber) {
-        this.lookupResultsSequenceNumber = lookupResultsSequenceNumber;
     }
 
     public String getUniversityFiscalPeriodCodeLookupOverride() {

--- a/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSConstants.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSConstants.java
@@ -9,6 +9,9 @@ public class KFSConstants extends org.kuali.kfs.sys.KFSConstants {
     public static final String DOC_FORM_KEY_VALUE_88888888 = "88888888";
     public static final String NULL_STRING = "null";
     public static final String PATH_SEPERATOR = "/";
+    public static final String BLANK_SUBACCOUNT = "-----";
+    public static final String BLANK_SUBOBJECT = "---";
+    public static final String BLANK_PROJECT_CODE = "----------";
 
     public static class SysKimApiConstants {
         public static final String ACCOUNT_SUPERVISOR_KIM_ROLE_NAME = "Account Supervisor";
@@ -59,9 +62,9 @@ public class KFSConstants extends org.kuali.kfs.sys.KFSConstants {
         public final static String DEFAULT_PRIMARY_DEPT_CHART_METHOD = "3";
 
     }
-    
+
     public static class Authorization {
-    	public static String PAYMENT_METHOD_EDIT_MODE = "paymentMethodEditMode";
+        public static String PAYMENT_METHOD_EDIT_MODE = "paymentMethodEditMode";
     }
 
 }

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/GeneralErrorCorrectionDocument.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/GeneralErrorCorrectionDocument.xml
@@ -6,7 +6,9 @@
  xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd         http://rice.kuali.org/dd         http://rice.kuali.org/dd/dd.xsd">
 
     <bean id="GeneralErrorCorrectionDocument" parent="GeneralErrorCorrectionDocument-parentBean">
-        <property name="documentPresentationControllerClass" value="edu.arizona.kfs.fp.document.authorization.GeneralErrorCorrectionDocumentPresentationController"/>
+        <property name="allowsErrorCorrection" value="false" />
+        <property name="documentPresentationControllerClass" value="edu.arizona.kfs.fp.document.authorization.GeneralErrorCorrectionDocumentPresentationController" />
+        <property name="allowsCopy" value="false" />
     </bean>
   
   <!-- workflow attributes for routing -->

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/GeneralErrorCorrectionDocumentSourceAccountingLine.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/GeneralErrorCorrectionDocumentSourceAccountingLine.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xmlns:p="http://www.springframework.org/schema/p"
+ xmlns:dd="http://rice.kuali.org/dd"
+ xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd         http://rice.kuali.org/dd         http://rice.kuali.org/dd/dd.xsd">
+
+    <bean id="GeneralErrorCorrectionDocument-sourceAccountingLineGroup" parent="GeneralErrorCorrectionDocument-sourceAccountingLineGroup-parentBean">
+        <property name="accountingLineView" ref="GeneralErrorCorrectionDocument-sourceAccountingLineView" />
+        <property name="groupLabel" value="Reversing" />
+        <property name="accountingLineAuthorizerClass" value="edu.arizona.kfs.fp.document.authorization.GeneralErrorCorrectionReversingAccountingLinesAuthorizer" />
+        <property name="accountingLineGroupActions" ref="GeneralErrorCorrectionDocument-sourceGroupActions" />
+        <property name="importingAllowed" value="false" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-sourceGroupActions" class="org.springframework.beans.factory.config.ListFactoryBean">
+        <property name="sourceList">
+            <list>
+                <bean parent="AccountingLineView-action" p:actionMethod="copyAllAccountingLines" p:actionLabel="copy all" p:imageName="tinybutton-copyall.gif" />
+                <bean parent="AccountingLineView-action" p:actionMethod="deleteAllSourceAccountingLines" p:actionLabel="delete all" p:imageName="tinybutton-deleteall.gif" />
+            </list>
+        </property>
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-sourceAccountingLineView" parent="AccountingLineView">
+       <property name="elements">
+         <list>
+             <ref bean="GeneralErrorCorrectionDocument-sourceAccountingLine-sequenceNumber" />
+             <ref bean="GeneralErrorCorrectionDocument-sourceAccountingLine-informationLines" />
+             <ref bean="GeneralErrorCorrectionDocument-sourceAccountingField-amount" />
+             <ref bean="GeneralErrorCorrectionDocument-sourceAccountingLine-actions" />
+         </list>
+     </property>
+   </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-sourceAccountingLine-sequenceNumber" parent="AccountingLineView-sequenceNumber" />
+
+    <bean id="GeneralErrorCorrectionDocument-sourceAccountingLine-informationLines" parent="AccountingLineView-lines" >
+        <property name="lines">
+            <list>
+                <ref bean="GeneralErrorCorrectionDocument-sourceAccountingInformation-accountingInformation" />
+                <ref bean="GeneralErrorCorrectionDocument-sourceAccountingInformation-lineDescriptionInformation" />
+                <ref bean="GeneralErrorCorrectionDocument-sourceAccountingInformation-salesTaxInformation" />
+            </list>
+        </property>
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-sourceAccountingLine-actions" parent="AccountingLineView-actions" />
+
+    <bean id="GeneralErrorCorrectionDocument-sourceAccountingInformation-accountingInformation" parent="AccountingLineView-line">
+        <property name="elementName" value="accountingInformation" />
+        <property name="fields">
+            <list>
+                <ref bean="GeneralErrorCorrectionDocument-sourceAccountingField-chartOfAccountsCode" />
+                <ref bean="GeneralErrorCorrectionDocument-sourceAccountingField-accountNumber" />
+                <ref bean="GeneralErrorCorrectionDocument-sourceAccountingField-subAccountNumber" />
+                <ref bean="GeneralErrorCorrectionDocument-sourceAccountingField-financialObjectCode" />
+                <ref bean="GeneralErrorCorrectionDocument-sourceAccountingField-financialSubObjectCode" />
+                <ref bean="GeneralErrorCorrectionDocument-sourceAccountingField-projectCode" />
+                <ref bean="GeneralErrorCorrectionDocument-sourceAccountingField-organizationReferenceId" />
+            </list>
+        </property>
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-sourceAccountingInformation-lineDescriptionInformation" parent="AccountingLineView-line">
+        <property name="elementName" value="lineDescription" />
+        <property name="fields">
+            <list>
+                <ref bean="GeneralErrorCorrectionDocument-sourceAccountingField-referenceOriginCode" />
+                <ref bean="GeneralErrorCorrectionDocument-sourceAccountingField-referenceNumber" />
+                <ref bean="GeneralErrorCorrectionDocument-sourceAccountingField-financialDocumentLineDescription" />
+            </list>
+        </property>
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-sourceAccountingInformation-salesTaxInformation" parent="salesTaxInformation" />
+
+    <bean id="GeneralErrorCorrectionDocument-sourceAccountingField-chartOfAccountsCode" parent="AccountingLineView-field">
+        <property name="name" value="chartOfAccountsCode" />
+        <property name="required" value="true" />
+        <property name="webUILeaveFieldFunction" value="loadChartInfo" />
+        <property name="dynamicLabelProperty" value="chart.finChartOfAccountDescription" />
+        <property name="useShortLabel" value="true" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-sourceAccountingField-accountNumber" parent="AccountingLineView-field">
+        <property name="name" value="accountNumber" />
+        <property name="required" value="true" />
+        <property name="webUILeaveFieldFunction" value="loadAccountInfo" />
+        <property name="dynamicLabelProperty" value="account.accountName" />
+        <property name="useShortLabel" value="true" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-sourceAccountingField-subAccountNumber" parent="AccountingLineView-field">
+        <property name="name" value="subAccountNumber" />
+        <property name="webUILeaveFieldFunction" value="loadSubAccountInfo" />
+        <property name="dynamicLabelProperty" value="subAccount.subAccountName" />
+        <property name="useShortLabel" value="true" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-sourceAccountingField-financialObjectCode" parent="AccountingLineView-field">
+        <property name="name" value="financialObjectCode" />
+        <property name="required" value="true" />
+        <property name="dynamicNameLabelGeneratorBeanName" value="objectCodeDynamicNameLabelGenerator" />
+        <property name="useShortLabel" value="true" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-sourceAccountingField-financialSubObjectCode" parent="AccountingLineView-field">
+        <property name="name" value="financialSubObjectCode" />
+        <property name="dynamicNameLabelGeneratorBeanName" value="subObjectCodeDynamicNameLabelGenerator" />
+        <property name="useShortLabel" value="true" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-sourceAccountingField-projectCode" parent="AccountingLineView-field">
+        <property name="name" value="projectCode" />
+        <property name="webUILeaveFieldFunction" value="loadProjectInfo" />
+        <property name="dynamicLabelProperty" value="project.name" />
+        <property name="useShortLabel" value="true" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-sourceAccountingField-organizationReferenceId" parent="AccountingLineView-field">
+        <property name="name" value="organizationReferenceId" />
+        <property name="useShortLabel" value="true" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-sourceAccountingField-referenceOriginCode" parent="AccountingLineView-field">
+        <property name="name" value="referenceOriginCode" />
+        <property name="required" value="true" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-sourceAccountingField-referenceNumber" parent="AccountingLineView-field">
+        <property name="name" value="referenceNumber" />
+        <property name="required" value="true" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-sourceAccountingField-financialDocumentLineDescription" parent="AccountingLineView-field">
+        <property name="name" value="financialDocumentLineDescription" />
+        <property name="overrideColSpan" value="5" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-sourceAccountingField-amount" parent="AccountingLineView-field">
+        <property name="name" value="amount" />
+        <property name="required" value="true" />
+    </bean>
+
+</beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/GeneralErrorCorrectionDocumentTargetAccountingLine.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/GeneralErrorCorrectionDocumentTargetAccountingLine.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xmlns:p="http://www.springframework.org/schema/p"
+ xmlns:dd="http://rice.kuali.org/dd"
+ xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd         http://rice.kuali.org/dd         http://rice.kuali.org/dd/dd.xsd">
+
+    <bean id="GeneralErrorCorrectionDocument-targetAccountingLineGroup" parent="GeneralErrorCorrectionDocument-targetAccountingLineGroup-parentBean">
+        <property name="accountingLineView" ref="GeneralErrorCorrectionDocument-targetAccountingLineView" />
+        <property name="groupLabel" value="Correcting" />
+        <property name="accountingLineAuthorizerClass" value="edu.arizona.kfs.fp.document.authorization.GeneralErrorCorrectionCorrectingAccountingLinesAuthorizer" />
+        <property name="accountingLineGroupActions" ref="GeneralErrorCorrectionDocument-targetGroupActions" />
+        <property name="importingAllowed" value="true" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-targetGroupActions" class="org.springframework.beans.factory.config.ListFactoryBean">
+        <property name="sourceList">
+            <list>
+                <bean parent="AccountingLineView-action" p:actionMethod="deleteAllTargetAccountingLines" p:actionLabel="delete all" p:imageName="tinybutton-deleteall.gif" />
+            </list>
+        </property>
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-targetAccountingLineView" parent="AccountingLineView">
+       <property name="elements">
+         <list>
+             <ref bean="GeneralErrorCorrectionDocument-targetAccountingLine-sequenceNumber" />
+             <ref bean="GeneralErrorCorrectionDocument-targetAccountingLine-informationLines" />
+             <ref bean="GeneralErrorCorrectionDocument-targetAccountingField-amount" />
+             <ref bean="GeneralErrorCorrectionDocument-targetAccountingLine-actions" />
+         </list>
+     </property>
+   </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-targetAccountingLine-sequenceNumber" parent="AccountingLineView-sequenceNumber" />
+
+    <bean id="GeneralErrorCorrectionDocument-targetAccountingLine-informationLines" parent="AccountingLineView-lines" >
+        <property name="lines">
+            <list>
+                <ref bean="GeneralErrorCorrectionDocument-targetAccountingInformation-accountingInformation" />
+                <ref bean="GeneralErrorCorrectionDocument-targetAccountingInformation-lineDescriptionInformation" />
+                <ref bean="GeneralErrorCorrectionDocument-targetAccountingInformation-salesTaxInformation" />
+            </list>
+        </property>
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-targetAccountingLine-actions" parent="AccountingLineView-actions" />
+
+    <bean id="GeneralErrorCorrectionDocument-targetAccountingInformation-accountingInformation" parent="AccountingLineView-line">
+        <property name="elementName" value="accountingInformation" />
+        <property name="fields">
+            <list>
+                <ref bean="GeneralErrorCorrectionDocument-targetAccountingField-chartOfAccountsCode" />
+                <ref bean="GeneralErrorCorrectionDocument-targetAccountingField-accountNumber" />
+                <ref bean="GeneralErrorCorrectionDocument-targetAccountingField-subAccountNumber" />
+                <ref bean="GeneralErrorCorrectionDocument-targetAccountingField-financialObjectCode" />
+                <ref bean="GeneralErrorCorrectionDocument-targetAccountingField-financialSubObjectCode" />
+                <ref bean="GeneralErrorCorrectionDocument-targetAccountingField-projectCode" />
+                <ref bean="GeneralErrorCorrectionDocument-targetAccountingField-organizationReferenceId" />
+            </list>
+        </property>
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-targetAccountingInformation-lineDescriptionInformation" parent="AccountingLineView-line">
+        <property name="elementName" value="lineDescription" />
+        <property name="fields">
+            <list>
+                <ref bean="GeneralErrorCorrectionDocument-targetAccountingField-referenceOriginCode" />
+                <ref bean="GeneralErrorCorrectionDocument-targetAccountingField-referenceNumber" />
+                <ref bean="GeneralErrorCorrectionDocument-targetAccountingField-financialDocumentLineDescription" />
+            </list>
+        </property>
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-targetAccountingInformation-salesTaxInformation" parent="salesTaxInformation" />
+
+    <bean id="GeneralErrorCorrectionDocument-targetAccountingField-chartOfAccountsCode" parent="AccountingLineView-field">
+        <property name="name" value="chartOfAccountsCode" />
+        <property name="required" value="true" />
+        <property name="webUILeaveFieldFunction" value="loadChartInfo" />
+        <property name="dynamicLabelProperty" value="chart.finChartOfAccountDescription" />
+        <property name="useShortLabel" value="true" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-targetAccountingField-accountNumber" parent="AccountingLineView-field">
+        <property name="name" value="accountNumber" />
+        <property name="required" value="true" />
+        <property name="webUILeaveFieldFunction" value="loadAccountInfo" />
+        <property name="dynamicLabelProperty" value="account.accountName" />
+        <property name="useShortLabel" value="true" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-targetAccountingField-subAccountNumber" parent="AccountingLineView-field">
+        <property name="name" value="subAccountNumber" />
+        <property name="webUILeaveFieldFunction" value="loadSubAccountInfo" />
+        <property name="dynamicLabelProperty" value="subAccount.subAccountName" />
+        <property name="useShortLabel" value="true" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-targetAccountingField-financialObjectCode" parent="AccountingLineView-field">
+        <property name="name" value="financialObjectCode" />
+        <property name="required" value="true" />
+        <property name="dynamicNameLabelGeneratorBeanName" value="objectCodeDynamicNameLabelGenerator" />
+        <property name="useShortLabel" value="true" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-targetAccountingField-financialSubObjectCode" parent="AccountingLineView-field">
+        <property name="name" value="financialSubObjectCode" />
+        <property name="dynamicNameLabelGeneratorBeanName" value="subObjectCodeDynamicNameLabelGenerator" />
+        <property name="useShortLabel" value="true" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-targetAccountingField-projectCode" parent="AccountingLineView-field">
+        <property name="name" value="projectCode" />
+        <property name="webUILeaveFieldFunction" value="loadProjectInfo" />
+        <property name="dynamicLabelProperty" value="project.name" />
+        <property name="useShortLabel" value="true" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-targetAccountingField-organizationReferenceId" parent="AccountingLineView-field">
+        <property name="name" value="organizationReferenceId" />
+        <property name="useShortLabel" value="true" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-targetAccountingField-referenceOriginCode" parent="AccountingLineView-field">
+        <property name="name" value="referenceOriginCode" />
+        <property name="required" value="true" />
+        <property name="unconditionallyReadOnly" value="true" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-targetAccountingField-referenceNumber" parent="AccountingLineView-field">
+        <property name="name" value="referenceNumber" />
+        <property name="required" value="true" />
+        <property name="unconditionallyReadOnly" value="true" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-targetAccountingField-financialDocumentLineDescription" parent="AccountingLineView-field">
+        <property name="name" value="financialDocumentLineDescription" />
+        <property name="overrideColSpan" value="5" />
+    </bean>
+
+    <bean id="GeneralErrorCorrectionDocument-targetAccountingField-amount" parent="AccountingLineView-field">
+        <property name="name" value="amount" />
+        <property name="required" value="true" />
+    </bean>
+
+</beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/validation/configuration/GeneralErrorCorrectionValidation.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/validation/configuration/GeneralErrorCorrectionValidation.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:aop="http://www.springframework.org/schema/aop"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                           http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+                           http://www.springframework.org/schema/tx
+                           http://www.springframework.org/schema/tx/spring-tx-2.0.xsd
+                           http://www.springframework.org/schema/aop
+                           http://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+
+    <bean id="GeneralErrorCorrection-addAccountingLineValidation" parent="GeneralErrorCorrection-addAccountingLineValidation-parentBean" scope="prototype">
+        <property name="validations">
+            <list>
+                <bean parent="GeneralErrorCorrection-objectTypeValidation" scope="prototype">
+                    <property name="parameterProperties">
+                        <list>
+                            <bean parent="accountingLineFieldConversion" />
+                        </list>
+                    </property>
+                </bean>
+                <bean parent="GeneralErrorCorrection-requiredReferenceFieldValidation" scope="prototype">
+                    <property name="parameterProperties">
+                        <list>
+                            <bean parent="accountingLineFieldConversion" />
+                        </list>
+                    </property>
+                </bean>
+            </list>
+        </property>
+    </bean>
+
+</beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/spring-fp.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/spring-fp.xml
@@ -31,6 +31,7 @@
     </bean>
 
     <import resource="document/validation/configuration/DisbursementVoucherValidation.xml" />
+    <import resource="document/validation/configuration/GeneralErrorCorrectionValidation.xml" />
 
     <bean id="disbursementVoucherInvoiceService" class="edu.arizona.kfs.fp.service.impl.DisbursementVoucherInvoiceServiceImpl" />
 


### PR DESCRIPTION
Includes:
 Created Accounting Line Authorizer for both the Reversing Lines and the Correcting Lines.
 Adjusted the how the retrieved Entry was copied to the Reversing Accounting Line.
 Created the Reversing group buttons "Copy All" and "Delete All" with specified functionality.
 Created the Reversing Accounting Line buttons "Delete", "Balance Inquiry", and "Copy" with specified functionality.
 Created the Correcting group buttons "Delete All" and "Import Lines" with specified functionality.
 Created the Correcting Accounting Line buttons "Delete", "Add", and "Balance Inquiry" with specified functionality.
 Changed the display of the Accounting Lines per specifications.
 Adjusted validation to not use the "AccountingDocument-AddCapitalAccountingLines-DefaultValidation" bean. (this was preventing the ability to save accounting lines to the document due to the Reversing lines being read only, and because of that was no longer required.)

Acceptance Criteria:
 When user opens GEC/YEGE and views the accounting lines tab, I should see Reversing Entry and Correcting Entry instead of  From or To.
 When user selects transaction and it appears in the Reversing Entry section, I should have option to use import lines in the Correcting Entry section.
 When user selects transaction and it appears in the Reversing Entry section, I should see a copy button, delete button and balance inquiry button.
 When user selects transaction and copies transaction to the Correcting Entry section, I should have editable fields (Chart, Account Number, Sub-Account, Object, Sub-Object, Project, Amount, or Line Description).
 When user selects transaction and copies transaction to the Correcting Entry section, I should see the Reference Origin Code and Reference Number as uneditable fields.
 As a user I can split the amount in the Correcting Entry section into multiple accounting lines by using the add button.
 When user completes accounting lines and selects submit, error message should be prompted when the total amount returned on the Reversing Entry line has been exceed.
 When user selects the accounting line and clicks return selected, the Reversing Entry line will be populated and will not be editable.
 When user completes document and submits for approval, system must authenticate the full transaction has been corrected.
