### PR TITLE
UAF-36 / UAF-2862 / UAF-2869 GEC Step 1 Bug: Select All

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/gl/web/struts/GecEntryLookupAction.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/gl/web/struts/GecEntryLookupAction.java
@@ -162,7 +162,19 @@ public class GecEntryLookupAction extends KualiMultipleValueLookupAction {
 
         multipleValueLookupForm.jumpToFirstPage(resultTable.size(), maxRowsPerPage);
 
+        Map<String, String> compositeObjectIdMap = generateCompositeObjectIdMap(resultTable);
+        multipleValueLookupForm.setCompositeObjectIdMap(compositeObjectIdMap);
+
         return entries;
+    }
+
+    private Map<String, String> generateCompositeObjectIdMap(List<ResultRow> resultTable) {
+        Map<String, String> compositeObjectIdMap = new HashMap<String, String>();
+        for (ResultRow row : resultTable) {
+            String objId = row.getObjectId();
+            compositeObjectIdMap.put(objId, objId);
+        }
+        return compositeObjectIdMap;
     }
 
     @Override


### PR DESCRIPTION
Discovered that this is being caused by a bad compositeObjectIdMap on the multipleValueLookupForm. Simply create a new one and set it, and voila!
