### PR TITLE
UAF-59 UAF-2753 Missing Invoice Number (Nonresident Alien Tax tab)

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/validation/impl/DisbursementVoucherDocumentPreRules.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/validation/impl/DisbursementVoucherDocumentPreRules.java
@@ -6,21 +6,17 @@ import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.fp.businessobject.DisbursementVoucherPayeeDetail;
-import org.kuali.kfs.fp.document.DisbursementVoucherConstants;
 import org.kuali.kfs.fp.document.DisbursementVoucherDocument;
 import org.kuali.kfs.integration.purap.PurchasingAccountsPayableModuleService;
 import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.rice.core.api.config.property.ConfigurationService;
-import org.kuali.rice.kew.api.WorkflowDocument;
 import org.kuali.rice.krad.document.Document;
-import org.kuali.rice.krad.util.GlobalVariables;
 
 import edu.arizona.kfs.fp.businessobject.DisbursementVoucherSourceAccountingLine;
 import edu.arizona.kfs.fp.businessobject.DisbursementVoucherSourceAccountingLineExtension;
 import edu.arizona.kfs.fp.service.DisbursementVoucherInvoiceService;
 import edu.arizona.kfs.sys.KFSConstants;
 import edu.arizona.kfs.sys.KFSKeyConstants;
-import edu.arizona.kfs.sys.KFSPropertyConstants;
 
 public class DisbursementVoucherDocumentPreRules extends org.kuali.kfs.fp.document.validation.impl.DisbursementVoucherDocumentPreRules {
 
@@ -46,27 +42,9 @@ public class DisbursementVoucherDocumentPreRules extends org.kuali.kfs.fp.docume
     public boolean doPrompts(Document document) {
         boolean result = super.doPrompts(document);
 
-        result &= checkDisbursementVoucherInvoiceNumberRequired((DisbursementVoucherDocument) document);
         result &= checkInvoiceNumberDuplicate((DisbursementVoucherDocument) document);
 
         return result;
-    }
-
-    @SuppressWarnings({ "deprecation", "unchecked" })
-    private boolean checkDisbursementVoucherInvoiceNumberRequired(DisbursementVoucherDocument document) {
-        boolean results = true;
-        DisbursementVoucherDocument disbursementVoucherDocument = (DisbursementVoucherDocument) document;
-        List<DisbursementVoucherSourceAccountingLine> accountingLines = disbursementVoucherDocument.getSourceAccountingLines();
-        for (DisbursementVoucherSourceAccountingLine accountingLine : accountingLines) {
-            DisbursementVoucherSourceAccountingLineExtension accountingLineExtension = accountingLine.getExtension();
-            if (StringUtils.isBlank(accountingLineExtension.getInvoiceNumber())) {
-                GlobalVariables.getMessageMap().putError(KFSPropertyConstants.SOURCE_ACCOUNTING_LINES, KFSKeyConstants.ERROR_REQUIRED, KFSConstants.INVOICE_NUMBER);
-                super.abortRulesCheck();
-                results = false;
-            }
-        }
-
-        return results;
     }
 
     @SuppressWarnings("deprecation")

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/validation/impl/DisbursementVoucherInvoiceNumberEnteredValidation.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/validation/impl/DisbursementVoucherInvoiceNumberEnteredValidation.java
@@ -1,11 +1,18 @@
 package edu.arizona.kfs.fp.document.validation.impl;
 
+import java.util.List;
+
 import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.fp.businessobject.DisbursementVoucherNonResidentAlienTax;
 import org.kuali.kfs.fp.document.DisbursementVoucherDocument;
+import org.kuali.kfs.fp.document.service.DisbursementVoucherTaxService;
 import org.kuali.kfs.sys.KFSKeyConstants;
+import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.kfs.sys.document.authorization.AccountingLineAuthorizer;
 import org.kuali.kfs.sys.document.validation.event.AttributedDocumentEvent;
+import org.kuali.kfs.sys.document.validation.event.UpdateAccountingLineEvent;
 import org.kuali.kfs.sys.document.validation.impl.AccountingLineAccessibleValidation;
+import org.kuali.rice.kew.api.WorkflowDocument;
 import org.kuali.rice.kim.api.identity.Person;
 import org.kuali.rice.krad.util.GlobalVariables;
 
@@ -18,6 +25,16 @@ public class DisbursementVoucherInvoiceNumberEnteredValidation extends Accountin
     @Override
     public boolean validate(AttributedDocumentEvent event) {
         DisbursementVoucherDocument accountingDocument = (DisbursementVoucherDocument) getAccountingDocumentForValidation();
+        DisbursementVoucherNonResidentAlienTax nonResidentAlienTax = accountingDocument.getDvNonResidentAlienTax();
+        
+        // tax accounting lines don't need to be validated
+        if (nonResidentAlienTax != null) {
+        	List<String> taxLineNumbers = SpringContext.getBean(DisbursementVoucherTaxService.class).getNRATaxLineNumbers(nonResidentAlienTax.getFinancialDocumentAccountingLineText());
+        	
+        	if (taxLineNumbers.contains(this.getAccountingLineForValidation().getSequenceNumber())) {
+        		return true;
+        	}
+        }
 
         Person financialSystemUser = GlobalVariables.getUserSession().getPerson();
         final AccountingLineAuthorizer accountingLineAuthorizer = lookupAccountingLineAuthorizer();
@@ -26,12 +43,29 @@ public class DisbursementVoucherInvoiceNumberEnteredValidation extends Accountin
 
         if (isAccessible) {
             DisbursementVoucherSourceAccountingLineExtension accountingLineExtension = (DisbursementVoucherSourceAccountingLineExtension) accountingLineForValidation.getExtension();
-            if (StringUtils.isBlank(accountingLineExtension.getInvoiceNumber())) {
+            if (isInvoiceNumberRequired(accountingDocument, event) && StringUtils.isBlank(accountingLineExtension.getInvoiceNumber())) {
                 GlobalVariables.getMessageMap().putError(KFSPropertyConstants.EXTENSION_INVOICE_NUMBER, KFSKeyConstants.ERROR_REQUIRED, KFSConstants.INVOICE_NUMBER);
                 return false;
             }
         }
         return true;
+    }
+    
+    protected boolean isInvoiceNumberRequired(DisbursementVoucherDocument document, AttributedDocumentEvent event) {
+    	WorkflowDocument workflowDocument = document.getDocumentHeader().getWorkflowDocument();
+    	
+    	if (workflowDocument.isInitiated() || workflowDocument.isSaved()) {
+    		return true;
+    	}
+    	
+    	if (event instanceof UpdateAccountingLineEvent && workflowDocument.isEnroute() && workflowDocument.isApprovalRequested()) {
+    		// the FO is not allowed to blank out the invoice number, but he isn't required to fill one in
+    		UpdateAccountingLineEvent uale = (UpdateAccountingLineEvent) event;
+    		String origInvoiceNumber = ((DisbursementVoucherSourceAccountingLineExtension) uale.getAccountingLine().getExtension()).getInvoiceNumber();
+    		return StringUtils.isNotBlank(origInvoiceNumber);
+    	}
+    	
+    	return false;
     }
 
 }


### PR DESCRIPTION
In DisbursementVoucherInvoiceNumberEnteredValidation.java - Added code to check to see if the invoice number is required and/or editable or not. Added the check to see if tax accounting lines need to be validated based on the NonResident Alien Tax.  Removed the checkDisbursementVoucherInvoiceNumberRequired method in DisbursementVoucherDocumentPreRules.java as it is not needed and was causing the NRA tax line to require the invoice number when it shouldn't be. Removed unused imports.  

Additional notes: The method checkDisbursementVoucherInvoiceNumberRequired() causing issues with the requirement that when information is added to the Nonresident Alien Tax tab and line(s) are generated, the invoice number field will be open, but can be left blank, and the DV can be successfully submitted.  These two items that were removed were added under UAF-1668.  After reviewing the original pull request (https://github.com/ua-eas/kfs/pull/55) to see why they were added, the comments stated that, at the time, it would allow a blank invoice number through, even though the DD definition has required=true for the invoice number.

After making changes, I tested trying to add a line to a DV, but it wouldn't allow me to add the line without an invoice number.  Once I added an invoice number, it added the line.  Once the line was added, I removed the invoice number from the line and tried to submit the DV.  It would not allow me to submit the DV without an invoice number.  Entered an invoice number and the DV submitted without error. Routed document to Final without errors.

Created a second document, same as above, but after submitting, I logged in as an AP Specialist, opened the document. Entered information into the Nonresident Alien Tax tab, generated the lines.  The invoice number on both lines (NRA generated and the original) were open to be edited.  Approved the DV without an invoice number for the NRA tax line, but still required it for the original line.
