### PR TITLE
UAF-2385 - State/City Tax Additional Attribute Added To Vendor Doc

### DIFF
--- a/kfs-core/src/main/resources/edu/arizona/kfs/vnd/businessobject/datadictionary/VendorDetail.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/vnd/businessobject/datadictionary/VendorDetail.xml
@@ -10,11 +10,17 @@
                 <ref bean="VendorDetail-exportControlsFlag" />
                 <ref bean="VendorDetail-conflictOfInterest" />
                 <ref bean="VendorDetail-defaultB2BPaymentMethodCode" />
+                <ref bean="VendorDetail-azSalesTaxLicense" />
+                <ref bean="VendorDetail-tucSalesTaxLicense" />
             </list>
         </property>
     </bean>
 
     <!-- Attribute Definitions -->
+
+    <dd:boAttributeRef id="VendorDetail-azSalesTaxLicense" parent="VendorDetailExtension-azSalesTaxLicense-parentBean" attributeName="extension.azSalesTaxLicense" />
+
+    <dd:boAttributeRef id="VendorDetail-tucSalesTaxLicense" parent="VendorDetailExtension-tucSalesTaxLicense-parentBean" attributeName="extension.tucSalesTaxLicense" />
 
     <dd:boAttributeRef id="VendorDetail-exportControlsFlag" parent="VendorDetailExtension-exportControlsFlag" attributeName="extension.exportControlsFlag" />
     
@@ -72,6 +78,8 @@
         <property name="numberOfColumns" value="1" />
         <property name="inquiryFields">
             <list>
+                <bean parent="FieldDefinition" p:attributeName="extension.azSalesTaxLicense" />
+                <bean parent="FieldDefinition" p:attributeName="extension.tucSalesTaxLicense" />
                 <bean parent="FieldDefinition" p:attributeName="extension.exportControlsFlag" />
             </list>
         </property>
@@ -173,5 +181,5 @@
 				<bean parent="FieldDefinition" p:attributeName="extension.defaultB2BPaymentMethodCode" />
 			</list>
 		</property>
-	</bean>	
+	</bean>
 </beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/vnd/businessobject/datadictionary/VendorDetailExtension.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/vnd/businessobject/datadictionary/VendorDetailExtension.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?><beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:p="http://www.springframework.org/schema/p"
-    xmlns:dd="http://rice.kuali.org/dd"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-                        http://rice.kuali.org/dd http://rice.kuali.org/dd/dd.xsd">
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+    http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
     <bean id="VendorDetailExtension" parent="VendorDetailExtension-parentBean" />
     <bean id="VendorDetailExtension-parentBean" abstract="true" parent="BusinessObjectEntry">
@@ -16,6 +15,8 @@
                 <ref bean="VendorDetailExtension-exportControlsFlag" />
                 <ref bean="VendorDetailExtension-conflictOfInterest" />
                 <ref bean="VendorDetailExtension-defaultB2BPaymentMethodCode" />
+                <ref bean="VendorDetailExtension-azSalesTaxLicense" />
+                <ref bean="VendorDetailExtension-tucSalesTaxLicense" />
             </list>
         </property>
     </bean>
@@ -39,7 +40,7 @@
 			<bean parent="SelectControlDefinition" p:valuesFinderClass="edu.arizona.kfs.vnd.businessobject.options.ConflictOfInterestTypeValuesFinder" p:includeKeyInLabel="false" />
 		</property>
 	</bean>
-	
+
 	<bean id="VendorDetailExtension-defaultB2BPaymentMethodCode" parent="VendorDetailExtension-defaultB2BPaymentMethodCode-parentBean" />
 	<bean id="VendorDetailExtension-defaultB2BPaymentMethodCode-parentBean" abstract="true" parent="PaymentMethod-paymentMethodCode">
 		<property name="name" value="defaultB2BPaymentMethodCode" />
@@ -49,5 +50,29 @@
 		  <bean parent="SelectControlDefinition" p:valuesFinderClass="edu.arizona.kfs.fp.businessobject.options.PaymentMethodsForVendorValuesFinder" />
 		</property>
 	</bean>
+
+    <bean id="VendorDetailExtension-azSalesTaxLicense" parent="VendorDetailExtension-azSalesTaxLicense-parentBean"/>
+    <bean id="VendorDetailExtension-azSalesTaxLicense-parentBean" abstract="true" parent="AttributeDefinition">
+        <property name="name" value="azSalesTaxLicense"/>
+        <property name="forceUppercase" value="false"/>
+        <property name="label" value="Arizona Sales Tax License Number"/>
+        <property name="shortLabel" value="AZ Tax#"/>
+        <property name="maxLength" value="11"/>
+        <property name="control">
+            <bean parent="TextControlDefinition" p:size="22"/>
+        </property>
+    </bean>
+
+    <bean id="VendorDetailExtension-tucSalesTaxLicense" parent="VendorDetailExtension-tucSalesTaxLicense-parentBean"/>
+    <bean id="VendorDetailExtension-tucSalesTaxLicense-parentBean" abstract="true" parent="AttributeDefinition">
+        <property name="name" value="tucSalesTaxLicense"/>
+        <property name="forceUppercase" value="false"/>
+        <property name="label" value="City of Tucson Sales Tax License Number"/>
+        <property name="shortLabel" value="Tuc City Tax#"/>
+        <property name="maxLength" value="7"/>
+        <property name="control">
+            <bean parent="TextControlDefinition" p:size="22"/>
+        </property>
+    </bean>
 
 </beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/vnd/document/datadictionary/VendorMaintenanceDocument.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/vnd/document/datadictionary/VendorMaintenanceDocument.xml
@@ -35,6 +35,9 @@
         <property name="title" value="Additional Attributes" />
         <property name="maintainableItems">
             <list>
+                <bean parent="MaintainableSubSectionHeaderDefinition" p:name="Vendor Sales Tax" />
+                <bean parent="MaintainableFieldDefinition" p:name="extension.azSalesTaxLicense" />
+                <bean parent="MaintainableFieldDefinition" p:name="extension.tucSalesTaxLicense" />
                 <bean parent="MaintainableFieldDefinition" p:name="extension.exportControlsFlag" />
             </list>
         </property>

--- a/kfs-core/src/test/java/edu/arizona/kfs/vnd/document/service/AZVendorServiceTest.java
+++ b/kfs-core/src/test/java/edu/arizona/kfs/vnd/document/service/AZVendorServiceTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2009 The Kuali Foundation.
+ * 
+ * Licensed under the Educational Community License, Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.opensource.org/licenses/ecl1.php
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.arizona.kfs.vnd.document.service;
+
+import edu.arizona.kfs.vnd.businessobject.VendorDetailExtension;
+import edu.arizona.kfs.vnd.document.service.impl.VendorServiceImpl;
+import org.kuali.kfs.sys.ConfigureContext;
+import org.kuali.kfs.sys.context.KualiTestBase;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.kfs.vnd.businessobject.VendorDetail;
+import org.kuali.kfs.vnd.businessobject.VendorHeader;
+import org.kuali.kfs.vnd.fixture.VendorRoutingChangesFixture;
+
+@ConfigureContext
+public class AZVendorServiceTest extends KualiTestBase {
+    public VendorDetail oldVDtl;
+    public VendorHeader oldVHdr;
+    public VendorDetail newVDtl;
+    public VendorHeader newVHdr;
+    private VendorRoutingChangesFixture fixture;
+    private VendorDetailExtension oldVDtlExtension;
+    private VendorDetailExtension newVDtlExtension;
+
+    protected void setUp() throws Exception {
+        super.setUp();
+        oldVDtl = new VendorDetail();
+        oldVHdr = new VendorHeader();
+        newVDtl = new VendorDetail();
+        newVHdr = new VendorHeader();
+        fixture = VendorRoutingChangesFixture.COMPLETE_NO_CHANGES;
+        fixture.populate(oldVDtl, oldVHdr, newVDtl, newVHdr);
+        oldVDtlExtension = new VendorDetailExtension();
+        newVDtlExtension = new VendorDetailExtension();
+    }
+
+    protected void tearDown() throws Exception {
+        oldVDtl = null;
+        oldVHdr = null;
+        newVDtl = null;
+        newVHdr = null;
+        oldVDtlExtension = null;
+        newVDtlExtension = null;
+        super.tearDown();
+    }
+
+    public void testNoRouteSignificantChangeOccurredForExtensions_No_Changes() {
+        oldVDtlExtension.setConflictOfInterest(null);
+        oldVDtlExtension.setAzSalesTaxLicense(null);
+        oldVDtlExtension.setTucSalesTaxLicense(null);
+        newVDtlExtension.setConflictOfInterest(null);
+        newVDtlExtension.setAzSalesTaxLicense(null);
+        newVDtlExtension.setTucSalesTaxLicense(null);
+
+        assertTrue(SpringContext.getBean(VendorServiceImpl.class).noRouteSignificantChangeOccurredForExtensions(oldVDtlExtension, newVDtlExtension));
+    }
+
+    public void testNoRouteSignificantChangeOccurredForExtensions_ConflictOfInterest_Change() {
+        oldVDtlExtension.setConflictOfInterest(null);
+        oldVDtlExtension.setAzSalesTaxLicense(null);
+        oldVDtlExtension.setTucSalesTaxLicense(null);
+        newVDtlExtension.setConflictOfInterest("None");
+        newVDtlExtension.setAzSalesTaxLicense(null);
+        newVDtlExtension.setTucSalesTaxLicense(null);
+
+        assertFalse(SpringContext.getBean(VendorServiceImpl.class).noRouteSignificantChangeOccurredForExtensions(oldVDtlExtension, newVDtlExtension));
+    }
+
+    public void testNoRouteSignificantChangeOccurredForExtensions_AzSalesTax_Change() {
+        oldVDtlExtension.setConflictOfInterest(null);
+        oldVDtlExtension.setAzSalesTaxLicense(null);
+        oldVDtlExtension.setTucSalesTaxLicense(null);
+        newVDtlExtension.setConflictOfInterest(null);
+        newVDtlExtension.setAzSalesTaxLicense("12345");
+        newVDtlExtension.setTucSalesTaxLicense(null);
+
+        assertFalse(SpringContext.getBean(VendorServiceImpl.class).noRouteSignificantChangeOccurredForExtensions(oldVDtlExtension, newVDtlExtension));
+    }
+
+    public void testNoRouteSignificantChangeOccurredForExtensions_TucSalesTax_Change() {
+        oldVDtlExtension.setConflictOfInterest(null);
+        oldVDtlExtension.setAzSalesTaxLicense(null);
+        oldVDtlExtension.setTucSalesTaxLicense(null);
+        newVDtlExtension.setConflictOfInterest(null);
+        newVDtlExtension.setAzSalesTaxLicense(null);
+        newVDtlExtension.setTucSalesTaxLicense("67890");
+
+        assertFalse(SpringContext.getBean(VendorServiceImpl.class).noRouteSignificantChangeOccurredForExtensions(oldVDtlExtension, newVDtlExtension));
+    }
+}


### PR DESCRIPTION
Added Spring wiring to activate and display State/City tax field on the Vendor maintenance document. It turns out that all of the actual code had been ported already by UAF-1834, and activating the new tax fields was an exercise in finding which Spring config needed to be pulled in and translated. Additionally, I pulled in the test class that was written to flex these fields.
