### PR TITLE
UAF-2544 - Correcting spring config to always use AZ version GEC authorizors, and removing erroneously overridden methods

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/authorization/GeneralErrorCorrectionCorrectingAccountingLinesAuthorizer.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/authorization/GeneralErrorCorrectionCorrectingAccountingLinesAuthorizer.java
@@ -42,11 +42,6 @@ public class GeneralErrorCorrectionCorrectingAccountingLinesAuthorizer extends C
     }
 
     @Override
-    public boolean hasEditPermissionOnAccountingLine(AccountingDocument accountingDocument, AccountingLine accountingLine, String accountingLineCollectionProperty, Person currentUser, boolean pageIsEditable) {
-        return false;
-    }
-
-    @Override
     public boolean hasEditPermissionOnField(AccountingDocument accountingDocument, AccountingLine accountingLine, String accountingLineCollectionProperty, String fieldName, boolean editableLine, boolean editablePage, Person currentUser) {
         boolean retval = super.hasEditPermissionOnField(accountingDocument, accountingLine, accountingLineCollectionProperty, fieldName, editableLine, editablePage, currentUser);
         return retval;

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/authorization/GeneralErrorCorrectionReversingAccountingLinesAuthorizer.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/authorization/GeneralErrorCorrectionReversingAccountingLinesAuthorizer.java
@@ -37,16 +37,6 @@ public class GeneralErrorCorrectionReversingAccountingLinesAuthorizer extends Ca
     }
 
     @Override
-    public boolean hasEditPermissionOnAccountingLine(AccountingDocument accountingDocument, AccountingLine accountingLine, String accountingLineCollectionProperty, Person currentUser, boolean pageIsEditable) {
-        return false;
-    }
-
-    @Override
-    public boolean hasEditPermissionOnField(AccountingDocument accountingDocument, AccountingLine accountingLine, String accountingLineCollectionProperty, String fieldName, boolean editableLine, boolean editablePage, Person currentUser) {
-        return false;
-    }
-
-    @Override
     public List<AccountingLineViewAction> getActions(AccountingDocument accountingDocument, AccountingLineRenderingContext accountingLineRenderingContext, String accountingLinePropertyName, Integer accountingLineIndex, Person currentUser, String groupTitle) {
         List<AccountingLineViewAction> actions = new ArrayList<AccountingLineViewAction>();
         Map<String, AccountingLineViewAction> actionMap = this.getActionMap(accountingLineRenderingContext, accountingLinePropertyName, accountingLineIndex, groupTitle);

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/GeneralErrorCorrectionDocument.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/GeneralErrorCorrectionDocument.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:p="http://www.springframework.org/schema/p"
-       xmlns:dd="http://rice.kuali.org/dd"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd         http://rice.kuali.org/dd         http://rice.kuali.org/dd/dd.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+       http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
     <bean id="GeneralErrorCorrectionDocument" parent="GeneralErrorCorrectionDocument-parentBean">
 		<property name="documentClass" value="edu.arizona.kfs.fp.document.GeneralErrorCorrectionDocument"/>
@@ -11,6 +10,12 @@
         <property name="allowsErrorCorrection" value="false" />
         <property name="documentPresentationControllerClass" value="edu.arizona.kfs.fp.document.authorization.GeneralErrorCorrectionDocumentPresentationController" />
         <property name="allowsCopy" value="false" />
+        <property name="accountingLineGroups">
+            <map>
+                <entry key="source" value-ref="AzGeneralErrorCorrectionDocument-sourceAccountingLineGroup" />
+                <entry key="target" value-ref="AzGeneralErrorCorrectionDocument-targetAccountingLineGroup"/>
+            </map>
+        </property>
     </bean>
 
     <!-- workflow attributes for routing -->

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/GeneralErrorCorrectionDocumentSourceAccountingLine.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/GeneralErrorCorrectionDocumentSourceAccountingLine.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
- xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- xmlns:p="http://www.springframework.org/schema/p"
- xmlns:dd="http://rice.kuali.org/dd"
- xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd         http://rice.kuali.org/dd         http://rice.kuali.org/dd/dd.xsd">
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+       http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
-    <bean id="GeneralErrorCorrectionDocument-sourceAccountingLineGroup" parent="GeneralErrorCorrectionDocument-sourceAccountingLineGroup-parentBean">
+    <bean id="AzGeneralErrorCorrectionDocument-sourceAccountingLineGroup" parent="GeneralErrorCorrectionDocument-sourceAccountingLineGroup-parentBean">
         <property name="accountingLineView" ref="GeneralErrorCorrectionDocument-sourceAccountingLineView" />
         <property name="groupLabel" value="Reversing" />
         <property name="accountingLineAuthorizerClass" value="edu.arizona.kfs.fp.document.authorization.GeneralErrorCorrectionReversingAccountingLinesAuthorizer" />

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/GeneralErrorCorrectionDocumentTargetAccountingLine.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/GeneralErrorCorrectionDocumentTargetAccountingLine.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
- xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- xmlns:p="http://www.springframework.org/schema/p"
- xmlns:dd="http://rice.kuali.org/dd"
- xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd         http://rice.kuali.org/dd         http://rice.kuali.org/dd/dd.xsd">
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+       http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
-    <bean id="GeneralErrorCorrectionDocument-targetAccountingLineGroup" parent="GeneralErrorCorrectionDocument-targetAccountingLineGroup-parentBean">
+    <bean id="AzGeneralErrorCorrectionDocument-targetAccountingLineGroup" parent="GeneralErrorCorrectionDocument-targetAccountingLineGroup-parentBean">
         <property name="accountingLineView" ref="GeneralErrorCorrectionDocument-targetAccountingLineView" />
         <property name="groupLabel" value="Correcting" />
         <property name="accountingLineAuthorizerClass" value="edu.arizona.kfs.fp.document.authorization.GeneralErrorCorrectionCorrectingAccountingLinesAuthorizer" />


### PR DESCRIPTION
Changed to remove ambiguity between AZ and Kuali versions, thus ensuring AZ authorizors always wins out:  
GeneralErrorCorrectionDocument.xml
GeneralErrorCorrectionDocumentSourceAccountingLine.xml
GeneralErrorCorrectionDocumentTargetAccountingLine.xml

Removed erroneous overridden methods; it was clear these weren't being hit before, and that the validation would have always failed, since the methods were previously returning false unconditionally:
GeneralErrorCorrectionCorrectingAccountingLinesAuthorizer.java
GeneralErrorCorrectionReversingAccountingLinesAuthorizer.java
