### PR TITLE
UAF-2767 : Bug - Account Doc Fiscal Officer field Doesn't Allow Hyphen or Underscore Chars

### DIFF
--- a/kfs-core/src/main/resources/edu/arizona/kfs/coa/businessobject/datadictionary/Account.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/coa/businessobject/datadictionary/Account.xml
@@ -49,6 +49,16 @@
 	<bean id="Account-taxRegionCode" parent="Account-taxRegionCode-parentBean" />
  	<dd:boAttributeRef id="Account-taxRegionCode-parentBean" abstract="true" parent="AccountExtension-taxRegionCode-parentBean" attributeName="extension.taxRegionCode" />
 
+	<bean id="Account-accountFiscalOfficerUser.principalName"
+		parent="Account-accountFiscalOfficerUser.principalName-parentBean" >
+        <property name="validationPattern">
+            <bean parent="AlphaNumericValidationPattern"
+                p:allowDash="true"
+                p:allowUnderscore="true"
+                p:allowWhitespace="false"/>
+        </property>
+	</bean>
+
     <!-- Business Object Inquiry Definition -->
 
     <bean id="Account-inquiryDefinition" parent="Account-inquiryDefinition-parentBean">


### PR DESCRIPTION
UAF-2767 : Bug - Account Doc - Fiscal Officer field Doesn't Allow Hyphen or Underscore Chars - Code Feature. Added 'validationPattern' property override for 'accountFiscalOfficerUser' to '/kfs-core/src/main/resources/edu/arizona/kfs/coa/businessobject/datadictionary/Account.xml'
