### PR TITLE
UAF-2554 - Correcting authorizors so that GEC validation behaves as before GTE code was merged.

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/authorization/GeneralErrorCorrectionCorrectingAccountingLinesAuthorizer.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/authorization/GeneralErrorCorrectionCorrectingAccountingLinesAuthorizer.java
@@ -1,10 +1,6 @@
 package edu.arizona.kfs.fp.document.authorization;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import edu.arizona.kfs.sys.KFSConstants;
 import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.fp.document.authorization.CapitalAccountingLinesAuthorizerBase;
 import org.kuali.kfs.sys.KFSKeyConstants;
@@ -15,7 +11,10 @@ import org.kuali.kfs.sys.document.web.AccountingLineViewAction;
 import org.kuali.rice.kew.api.WorkflowDocument;
 import org.kuali.rice.kim.api.identity.Person;
 
-import edu.arizona.kfs.sys.KFSConstants;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class GeneralErrorCorrectionCorrectingAccountingLinesAuthorizer extends CapitalAccountingLinesAuthorizerBase {
 
@@ -39,6 +38,11 @@ public class GeneralErrorCorrectionCorrectingAccountingLinesAuthorizer extends C
         Map<String, AccountingLineViewAction> actionMap = this.getActionMap(accountingLineRenderingContext, accountingLinePropertyName, accountingLineIndex, groupTitle);
         actions.addAll(actionMap.values());
         return actions;
+    }
+
+    @Override
+    public boolean hasEditPermissionOnAccountingLine(AccountingDocument accountingDocument, AccountingLine accountingLine, String accountingLineCollectionProperty, Person currentUser, boolean pageIsEditable) {
+        return false;
     }
 
     @Override

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/authorization/GeneralErrorCorrectionReversingAccountingLinesAuthorizer.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/authorization/GeneralErrorCorrectionReversingAccountingLinesAuthorizer.java
@@ -1,10 +1,7 @@
 package edu.arizona.kfs.fp.document.authorization;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import edu.arizona.kfs.sys.KFSConstants;
+import edu.arizona.kfs.sys.KFSKeyConstants;
 import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.fp.document.authorization.CapitalAccountingLinesAuthorizerBase;
 import org.kuali.kfs.sys.businessobject.AccountingLine;
@@ -17,8 +14,10 @@ import org.kuali.rice.kew.api.WorkflowDocument;
 import org.kuali.rice.kim.api.identity.Person;
 import org.kuali.rice.krad.util.KRADConstants;
 
-import edu.arizona.kfs.sys.KFSConstants;
-import edu.arizona.kfs.sys.KFSKeyConstants;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class GeneralErrorCorrectionReversingAccountingLinesAuthorizer extends CapitalAccountingLinesAuthorizerBase {
 
@@ -33,6 +32,16 @@ public class GeneralErrorCorrectionReversingAccountingLinesAuthorizer extends Ca
         if (workflowDocument.isInitiated() || workflowDocument.isSaved() || workflowDocument.isCompletionRequested()) {
             return StringUtils.equalsIgnoreCase(workflowDocument.getInitiatorPrincipalId(), currentUser.getPrincipalId());
         }
+        return false;
+    }
+
+    @Override
+    public boolean hasEditPermissionOnAccountingLine(AccountingDocument accountingDocument, AccountingLine accountingLine, String accountingLineCollectionProperty, Person currentUser, boolean pageIsEditable) {
+        return false;
+    }
+
+    @Override
+    public boolean hasEditPermissionOnField(AccountingDocument accountingDocument, AccountingLine accountingLine, String accountingLineCollectionProperty, String fieldName, boolean editableLine, boolean editablePage, Person currentUser) {
         return false;
     }
 

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/validation/configuration/GeneralErrorCorrectionValidation.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/validation/configuration/GeneralErrorCorrectionValidation.xml
@@ -51,6 +51,7 @@
   <bean id="GeneralErrorCorrection-updateAccountingLineValidation" parent="GeneralErrorCorrection-updateAccountingLineValidation-parentBean" scope="prototype" >
 		<property name="validations">
 			<list>
+				<bean parent="AccountingDocument-UpdateAccountingLine-DefaultValidation" scope="prototype"/>
 				<bean parent="GeneralErrorCorrection-referenceNumberValidation" scope="prototype">
 					<property name="parameterProperties">
 						<list>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/validation/configuration/GeneralErrorCorrectionValidation.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/validation/configuration/GeneralErrorCorrectionValidation.xml
@@ -16,7 +16,6 @@
     <bean id="GeneralErrorCorrection-addAccountingLineValidation" parent="GeneralErrorCorrection-addAccountingLineValidation-parentBean" scope="prototype">
         <property name="validations">
             <list>
-				<bean parent="AccountingDocument-AddCapitalAccountingLines-DefaultValidation" />
                 <bean parent="GeneralErrorCorrection-objectTypeValidation" scope="prototype">
                     <property name="parameterProperties">
                         <list>
@@ -52,7 +51,6 @@
   <bean id="GeneralErrorCorrection-updateAccountingLineValidation" parent="GeneralErrorCorrection-updateAccountingLineValidation-parentBean" scope="prototype" >
 		<property name="validations">
 			<list>
-				<bean parent="AccountingDocument-UpdateCapitalAccountingLines-DefaultValidation" scope="prototype"/>
 				<bean parent="GeneralErrorCorrection-referenceNumberValidation" scope="prototype">
 					<property name="parameterProperties">
 						<list>


### PR DESCRIPTION
CapitalAccountingLinesAccesibleValidation is redundant and incompatible with the new-to-KFS6 GeneralErrorCorrectionReversingAccountingLinesAuthorizer and GeneralErrorCorrectionCorrectingAccountingLinesAuthorizer classes. These have a delegator-delegatee relationship that will fail validation in that configuration, and the latter two are wired directly into place anyway. This sets things to behave as it did before release 16 when GEC validation was functioning correctly, and manages to retain the new GTE validation portion of code/config to boot.
