### PR TITLE
UAF-2554 - Adding/correcting message formats, changing scrubbers to not throw runtime exception in GTE validation.

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/gl/service/impl/ScrubberValidatorImpl.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/gl/service/impl/ScrubberValidatorImpl.java
@@ -24,6 +24,7 @@ import org.kuali.kfs.gl.batch.service.AccountingCycleCachingService;
 import org.kuali.kfs.gl.businessobject.OriginEntryFull;
 import org.kuali.kfs.gl.businessobject.OriginEntryInformation;
 import org.kuali.kfs.sys.Message;
+import org.kuali.kfs.sys.MessageBuilder;
 import org.kuali.kfs.sys.businessobject.UniversityDate;
 import org.kuali.kfs.sys.service.NonTransactional;
 import org.kuali.rice.krad.util.ObjectUtils;
@@ -203,7 +204,7 @@ public class ScrubberValidatorImpl extends org.kuali.kfs.gl.service.impl.Scrubbe
             errors.add(err);
         }
 
-        err = validateGTEAccount((OriginEntryFull) originEntry);
+        err = validateGTEAccount((OriginEntryFull) scrubbedEntry);
         if (err != null) {
             errors.add(err);
         }
@@ -219,15 +220,14 @@ public class ScrubberValidatorImpl extends org.kuali.kfs.gl.service.impl.Scrubbe
         account.refreshReferenceObject("subFundGroup");
 
         if(ObjectUtils.isNull(account)){
-            throw new IllegalArgumentException("This account specified "+originEntry.getChartOfAccountsCode()+"-"+originEntry.getAccountNumber()+" does not exist. For sequence "+originEntry.getTransactionLedgerEntrySequenceNumber());
+            return MessageBuilder.buildMessageWithPlaceHolder(edu.arizona.kfs.sys.KFSKeyConstants.ERROR_GLOBAL_TRANSACTION_EDIT_SCRUBBER_INVALID_VALUES, Message.TYPE_FATAL, new Object[] {"Account", originEntry.getChartOfAccountsCode() + "-" + originEntry.getAccountNumber()});
         }
         if(ObjectUtils.isNull(originEntry.getFinancialObject())){
-            throw new IllegalArgumentException("This account specified "+originEntry.getFinancialObjectCode()+"-"+originEntry.getAccountNumber()+" does not exist. For sequence "+originEntry.getTransactionLedgerEntrySequenceNumber());
+            return MessageBuilder.buildMessageWithPlaceHolder(edu.arizona.kfs.sys.KFSKeyConstants.ERROR_GLOBAL_TRANSACTION_EDIT_SCRUBBER_INVALID_VALUES, Message.TYPE_FATAL, new Object[] {"Object Code", originEntry.getChartOfAccountsCode() + "-" + originEntry.getFinancialObjectCode()});
         }
         if(ObjectUtils.isNull(account.getSubFundGroup())){
-            throw new IllegalArgumentException("This account specified "+originEntry.getChartOfAccountsCode()+"-"+originEntry.getAccountNumber()+" does not exist. For sequence "+originEntry.getTransactionLedgerEntrySequenceNumber());
+            return MessageBuilder.buildMessageWithPlaceHolder(edu.arizona.kfs.sys.KFSKeyConstants.ERROR_GLOBAL_TRANSACTION_EDIT_SCRUBBER_INVALID_VALUES, Message.TYPE_FATAL, new Object[] {"Sub Fund", account.getSubFundGroupCode()});
         }
-
 
         Message result = globalTransactionEditService.isAccountingLineAllowable(originEntry.getFinancialSystemOriginationCode(),
                 account.getSubFundGroup().getFundGroupCode(),

--- a/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSKeyConstants.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSKeyConstants.java
@@ -7,9 +7,10 @@ public class KFSKeyConstants extends org.kuali.kfs.sys.KFSKeyConstants {
 
     // GL
     public static final String ERROR_GLOBAL_TRANSACTION_EDIT_RULE_FAILURE = "error.gl.GlobalTransactionEdit";
-    public static final String ERROR_GLOBAL_TRANSACTION_EDIT_RULE_FAILURE_W_ACCT_LINE = "error.gl.GlobalTransactionEdit.accountingline";
+    public static final String ERROR_GLOBAL_TRANSACTION_EDIT_RULE_FAILURE_W_ACCT_LINE = "error.gl.GlobalTransactionEdit.accountingLine";
     public static final String ERROR_GLOBAL_TRANSACTION_EDIT_ACCOUNT_NUMBER_CHANGED = "error.gl.GlobalTransactionEdit.accountChanged";
     public static final String ERROR_GLOBAL_TRANSACTION_EDIT_SCRUBBER_INVALID_VALUES_ON_LINE = "error.gl.GlobalTransactionEdit.invalidFieldValueOnLine";
+    public static final String ERROR_GLOBAL_TRANSACTION_EDIT_SCRUBBER_INVALID_VALUES = "error.gl.GlobalTransactionEdit.invalidFieldValue";
 
     // GEC
     public static final String ERROR_GEC_REF_NUMBER_INVALID = "error.gec.ref.number";

--- a/kfs-core/src/main/resources/edu/arizona/kfs/gl/gl-resources.properties
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/gl/gl-resources.properties
@@ -1,1 +1,5 @@
-error.gl.GlobalTransactionEdit=Accounting line transaction is not allowed because it violates the following Global Transaction Edit validation rule: Reference Origin Code={0}, Fund Group={1}, Sub-Fund Group={2}, Document Type={3}, Object Type={4}, Object Sub-Type={5}.
+error.gl.GlobalTransactionEdit=Transaction is not allowed because: {0}\nTransaction Validation Rule: Reference Origin Code={1}, Fund Group={2}, Sub-Fund Group={3}, Document Type={4}, Object Type={5}, Object Sub-Type={6}.
+error.gl.GlobalTransactionEdit.accountingLine=Accounting line: Acct {0} - ObjCd {1} - OrgDocNbr {2}. Transaction is not allowed because: {3}\nTransaction Edit Validation Rule: Reference Origin Code={4}, Fund Group={5}, Sub-Fund Group={6}, Document Type={7}, Object Type={8}, Object Sub-Type={9}.
+error.gl.GlobalTransactionEdit.accountChanged=Accounting line transaction account number has been changed to Default because it violates the following Global Transaction Edit validation rule: Reference Origin Code={0}, Fund Group={1}, Sub-Fund Group={2}, Document Type={3}, Object Type={4}, Object Sub-Type={5}.
+error.gl.GlobalTransactionEdit.invalidFieldValue=GTE Validation not run: {0} is invalid: {1}.
+error.gl.GlobalTransactionEdit.invalidFieldValueOnLine=GTE Validation not run on line {0}: {1} is invalid: {2}.


### PR DESCRIPTION
Making various changes to correct validation message formatting, and to not halt scrubber if GTE validation fails:
**gl-resources.properties**: Added three missing message formats, and modified one pre-existing
**KFSKeyConstants.java**: Corrected a typo in one key, and added one entirely missing constant that the scrubbers have been changed to use
**gl/service/impl/ScrubberValidatorImpl.java**: Changed to provide validation message instead of throw runtime exception in GTE validation
**ld/batch/service/impl/ScrubberValidatorImpl.java**: Changed to provide validation message instead of throw runtime exception in GTE validation
