### PR TITLE
UAF-2499 Procurement Card Level 3 Data

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/impl/ProcurementCardLoadTransactionsServiceImpl.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/impl/ProcurementCardLoadTransactionsServiceImpl.java
@@ -1,0 +1,29 @@
+package edu.arizona.kfs.fp.batch.service.impl;
+
+import java.util.HashMap;
+
+import edu.arizona.kfs.fp.businessobject.ProcurementCardTranAddItem;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardTranNonFuel;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardTransaction;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardTranShipSvc;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardTranTempSvc;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardTranTransportLeg;
+
+
+public class ProcurementCardLoadTransactionsServiceImpl extends org.kuali.kfs.fp.batch.service.impl.ProcurementCardLoadTransactionsServiceImpl {
+    private static org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(ProcurementCardLoadTransactionsServiceImpl.class);
+   
+    /**
+     * Calls businessObjectService to remove all the procurement card transaction rows from the transaction load table.
+     */
+    @Override
+    public void cleanTransactionsTable() {    	
+    	super.businessObjectService.deleteMatching(ProcurementCardTranAddItem.class, new HashMap());
+    	super.businessObjectService.deleteMatching(ProcurementCardTranNonFuel.class, new HashMap());        
+        super.businessObjectService.deleteMatching(ProcurementCardTranShipSvc.class, new HashMap());
+        super.businessObjectService.deleteMatching(ProcurementCardTranTempSvc.class, new HashMap());
+        super.businessObjectService.deleteMatching(ProcurementCardTranTransportLeg.class, new HashMap());
+        super.businessObjectService.deleteMatching(ProcurementCardTransaction.class, new HashMap());
+    }
+   
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3Add.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3Add.java
@@ -1,0 +1,137 @@
+package edu.arizona.kfs.fp.businessobject;
+
+import java.sql.Date;
+import java.util.LinkedHashMap;
+
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
+
+public class ProcurementCardLevel3Add extends PersistableBusinessObjectBase {
+
+	private String documentNumber;
+	private Integer financialDocumentTransactionLineNumber;
+	private String invoiceNumber;
+	private Date orderDate;
+	private String purchaseTime;
+	private String shipPostal;
+	private String destinationPostal;
+	private String destinationCountryCode;
+	private KualiDecimal taxAmount;
+	private KualiDecimal taxRate;
+	private KualiDecimal discountAmount;
+	private KualiDecimal freightAmount;
+	private KualiDecimal dutyAmount;
+	
+	
+	public String getDocumentNumber() {
+		return documentNumber;
+	}
+	
+	public void setDocumentNumber(String documentNumber) {
+		this.documentNumber = documentNumber;
+	}
+	
+	public Integer getFinancialDocumentTransactionLineNumber() {
+		return financialDocumentTransactionLineNumber;
+	}
+	
+	public void setFinancialDocumentTransactionLineNumber(Integer financialDocumentTransactionLineNumber) {
+		this.financialDocumentTransactionLineNumber = financialDocumentTransactionLineNumber;
+	}
+	
+	public String getInvoiceNumber() {
+		return invoiceNumber;
+	}
+	
+	public void setInvoiceNumber(String invoiceNumber) {
+		this.invoiceNumber = invoiceNumber;
+	}
+	
+	public Date getOrderDate() {
+		return orderDate;
+	}
+	
+	public void setOrderDate(Date orderDate) {
+		this.orderDate = orderDate;
+	}
+	
+	public String getPurchaseTime() {
+		return purchaseTime;
+	}
+	
+	public void setPurchaseTime(String purchaseTime) {
+		this.purchaseTime = purchaseTime;
+	}
+	
+	public String getShipPostal() {
+		return shipPostal;
+	}
+	
+	public void setShipPostal(String shipPostal) {
+		this.shipPostal = shipPostal;
+	}
+	
+	public String getDestinationPostal() {
+		return destinationPostal;
+	}
+	
+	public void setDestinationPostal(String destinationPostal) {
+		this.destinationPostal = destinationPostal;
+	}
+	
+	public String getDestinationCountryCode() {
+		return destinationCountryCode;
+	}
+	
+	public void setDestinationCountryCode(String destinationCountryCode) {
+		this.destinationCountryCode = destinationCountryCode;
+	}
+	
+	public KualiDecimal getTaxAmount() {
+		return taxAmount;
+	}
+	
+	public void setTaxAmount(KualiDecimal taxAmount) {
+		this.taxAmount = taxAmount;
+	}
+	
+	public KualiDecimal getTaxRate() {
+		return taxRate;
+	}
+	
+	public void setTaxRate(KualiDecimal taxRate) {
+		this.taxRate = taxRate;
+	}
+	
+	public KualiDecimal getDiscountAmount() {
+		return discountAmount;
+	}
+	
+	public void setDiscountAmount(KualiDecimal discountAmount) {
+		this.discountAmount = discountAmount;
+	}
+	
+	public KualiDecimal getFreightAmount() {
+		return freightAmount;
+	}
+	
+	public void setFreightAmount(KualiDecimal freightAmount) {
+		this.freightAmount = freightAmount;
+	}
+	
+	public KualiDecimal getDutyAmount() {
+		return dutyAmount;
+	}
+	
+	public void setDutyAmount(KualiDecimal dutyAmount) {
+		this.dutyAmount = dutyAmount;
+	}
+	
+	protected LinkedHashMap<String, String> toStringMapper() {
+		LinkedHashMap<String, String> m = new LinkedHashMap<String, String>();
+		m.put("documentNumber", documentNumber);
+		m.put("financialDocumentTransactionLineNumber", getFinancialDocumentTransactionLineNumber().toString());
+		return m;
+	}
+	
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3AddItem.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3AddItem.java
@@ -1,0 +1,144 @@
+package edu.arizona.kfs.fp.businessobject;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
+
+public class ProcurementCardLevel3AddItem extends PersistableBusinessObjectBase {
+
+	private String documentNumber;
+	private Integer financialDocumentTransactionLineNumber;
+	private Integer sequenceNumber;
+	private String itemCommodityCode;
+	private String itemProductCode;
+	private String itemDescription;
+	private BigDecimal itemQuantity;
+	private String itemUnitCode;
+	private KualiDecimal itemAmount;
+	private String itemDebitCreditCode;
+	private KualiDecimal itemTaxRate;
+	private KualiDecimal itemTaxAmount;
+	private KualiDecimal itemDiscountAmount;
+	private KualiDecimal itemExtendedAmount;
+	
+	public String getDocumentNumber() {
+		return documentNumber;
+	}
+	
+	public void setDocumentNumber(String documentNumber) {
+		this.documentNumber = documentNumber;
+	}
+	
+	public Integer getFinancialDocumentTransactionLineNumber() {
+		return financialDocumentTransactionLineNumber;
+	}
+	
+	public void setFinancialDocumentTransactionLineNumber(Integer financialDocumentTransactionLineNumber) {
+		this.financialDocumentTransactionLineNumber = financialDocumentTransactionLineNumber;
+	}
+	
+	public Integer getSequenceNumber() {
+		return sequenceNumber;
+	}
+	
+	public void setSequenceNumber(Integer sequenceNumber) {
+		this.sequenceNumber = sequenceNumber;
+	}
+	
+	public String getItemCommodityCode() {
+		return itemCommodityCode;
+	}
+	
+	public void setItemCommodityCode(String itemCommodityCode) {
+		this.itemCommodityCode = itemCommodityCode;
+	}
+	
+	public String getItemProductCode() {
+		return itemProductCode;
+	}
+	
+	public void setItemProductCode(String itemProductCode) {
+		this.itemProductCode = itemProductCode;
+	}
+	
+	public String getItemDescription() {
+		return itemDescription;
+	}
+	
+	public void setItemDescription(String itemDescription) {
+		this.itemDescription = itemDescription;
+	}
+	
+	public BigDecimal getItemQuantity() {
+		return itemQuantity;
+	}
+	
+	public void setItemQuantity(BigDecimal itemQuantity) {
+		this.itemQuantity = itemQuantity;
+	}
+	
+	public String getItemUnitCode() {
+		return itemUnitCode;
+	}
+	
+	public void setItemUnitCode(String itemUnitCode) {
+		this.itemUnitCode = itemUnitCode;
+	}
+	
+	public KualiDecimal getItemAmount() {
+		return itemAmount;
+	}
+	
+	public void setItemAmount(KualiDecimal itemAmount) {
+		this.itemAmount = itemAmount;
+	}
+	
+	public String getItemDebitCreditCode() {
+		return itemDebitCreditCode;
+	}
+	
+	public void setItemDebitCreditCode(String itemDebitCreditCode) {
+		this.itemDebitCreditCode = itemDebitCreditCode;
+	}
+	
+	public KualiDecimal getItemTaxRate() {
+		return itemTaxRate;
+	}
+	
+	public void setItemTaxRate(KualiDecimal itemTaxRate) {
+		this.itemTaxRate = itemTaxRate;
+	}
+	
+	public KualiDecimal getItemTaxAmount() {
+		return itemTaxAmount;
+	}
+	
+	public void setItemTaxAmount(KualiDecimal itemTaxAmount) {
+		this.itemTaxAmount = itemTaxAmount;
+	}
+	
+	public KualiDecimal getItemDiscountAmount() {
+		return itemDiscountAmount;
+	}
+	
+	public void setItemDiscountAmount(KualiDecimal itemDiscountAmount) {
+		this.itemDiscountAmount = itemDiscountAmount;
+	}
+	
+	public KualiDecimal getItemExtendedAmount() {
+		return itemExtendedAmount;
+	}
+	
+	public void setItemExtendedAmount(KualiDecimal itemExtendedAmount) {
+		this.itemExtendedAmount = itemExtendedAmount;
+	}
+	
+	protected LinkedHashMap<String, String> toStringMapper() {
+		LinkedHashMap<String, String> m = new LinkedHashMap<String, String>();
+		m.put("documentNumber", documentNumber);
+		m.put("financialDocumentTransactionLineNumber", getFinancialDocumentTransactionLineNumber().toString());
+		return m;
+	}
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3AddUser.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3AddUser.java
@@ -1,0 +1,54 @@
+package edu.arizona.kfs.fp.businessobject;
+
+import java.sql.Date;
+import java.util.LinkedHashMap;
+
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
+
+public class ProcurementCardLevel3AddUser extends PersistableBusinessObjectBase {
+
+	private String documentNumber;
+	private Integer financialDocumentTransactionLineNumber;
+	private Date userEffectiveDate;
+	private KualiDecimal userAmount;
+	
+	public String getDocumentNumber() {
+		return documentNumber;
+	}
+	
+	public void setDocumentNumber(String documentNumber) {
+		this.documentNumber = documentNumber;
+	}
+	
+	public Integer getFinancialDocumentTransactionLineNumber() {
+		return financialDocumentTransactionLineNumber;
+	}
+	
+	public void setFinancialDocumentTransactionLineNumber(Integer financialDocumentTransactionLineNumber) {
+		this.financialDocumentTransactionLineNumber = financialDocumentTransactionLineNumber;
+	}
+	
+	public Date getUserEffectiveDate() {
+		return userEffectiveDate;
+	}
+	
+	public void setUserEffectiveDate(Date userEffectiveDate) {
+		this.userEffectiveDate = userEffectiveDate;
+	}
+	
+	public KualiDecimal getUserAmount() {
+		return userAmount;
+	}
+	
+	public void setUserAmount(KualiDecimal userAmount) {
+		this.userAmount = userAmount;
+	}
+	
+	protected LinkedHashMap<String, String> toStringMapper() {
+		LinkedHashMap<String, String> m = new LinkedHashMap<String, String>();
+		m.put("documentNumber", documentNumber);
+		m.put("financialDocumentTransactionLineNumber", getFinancialDocumentTransactionLineNumber().toString());
+		return m;
+	}
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3Fuel.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3Fuel.java
@@ -1,0 +1,180 @@
+package edu.arizona.kfs.fp.businessobject;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
+
+public class ProcurementCardLevel3Fuel extends PersistableBusinessObjectBase {
+
+	private String documentNumber;
+	private Integer financialDocumentTransactionLineNumber;
+	private String oilBrandName;
+	private String odometerReading;
+	private String fleetId;
+	private String messageId;
+	private String usage;
+	private String fuelServiceType;
+	private String fuelProductCd;
+	private String productTypeCd;
+	private BigDecimal fuelQuantity;
+	private Integer fuelUnitOfMeasure;
+	private KualiDecimal fuelUnitPrice;
+	private KualiDecimal fuelSaleAmount;
+	private KualiDecimal fuelDiscountAmount;
+	private KualiDecimal taxAmount1;
+	private KualiDecimal taxAmount2;
+	private KualiDecimal totalAmount;
+	
+	public String getDocumentNumber() {
+		return documentNumber;
+	}
+	
+	public void setDocumentNumber(String documentNumber) {
+		this.documentNumber = documentNumber;
+	}
+	
+	public Integer getFinancialDocumentTransactionLineNumber() {
+		return financialDocumentTransactionLineNumber;
+	}
+	
+	public void setFinancialDocumentTransactionLineNumber(Integer financialDocumentTransactionLineNumber) {
+		this.financialDocumentTransactionLineNumber = financialDocumentTransactionLineNumber;
+	}
+	
+	public String getOilBrandName() {
+		return oilBrandName;
+	}
+	
+	public void setOilBrandName(String oilBrandName) {
+		this.oilBrandName = oilBrandName;
+	}
+	
+	public String getOdometerReading() {
+		return odometerReading;
+	}
+	
+	public void setOdometerReading(String odometerReading) {
+		this.odometerReading = odometerReading;
+	}
+	
+	public String getFleetId() {
+		return fleetId;
+	}
+	
+	public void setFleetId(String fleetId) {
+		this.fleetId = fleetId;
+	}
+	
+	public String getMessageId() {
+		return messageId;
+	}
+	
+	public void setMessageId(String messageId) {
+		this.messageId = messageId;
+	}
+	
+	public String getUsage() {
+		return usage;
+	}
+	
+	public void setUsage(String usage) {
+		this.usage = usage;
+	}
+	
+	public String getFuelServiceType() {
+		return fuelServiceType;
+	}
+	
+	public void setFuelServiceType(String fuelServiceType) {
+		this.fuelServiceType = fuelServiceType;
+	}
+	
+	public String getFuelProductCd() {
+		return fuelProductCd;
+	}
+	
+	public void setFuelProductCd(String fuelProductCd) {
+		this.fuelProductCd = fuelProductCd;
+	}
+	
+	public String getProductTypeCd() {
+		return productTypeCd;
+	}
+	
+	public void setProductTypeCd(String productTypeCd) {
+		this.productTypeCd = productTypeCd;
+	}
+	
+	public BigDecimal getFuelQuantity() {
+		return fuelQuantity;
+	}
+	
+	public void setFuelQuantity(BigDecimal fuelQuantity) {
+		this.fuelQuantity = fuelQuantity;
+	}
+	
+	public Integer getFuelUnitOfMeasure() {
+		return fuelUnitOfMeasure;
+	}
+	
+	public void setFuelUnitOfMeasure(Integer fuelUnitOfMeasure) {
+		this.fuelUnitOfMeasure = fuelUnitOfMeasure;
+	}
+	
+	public KualiDecimal getFuelUnitPrice() {
+		return fuelUnitPrice;
+	}
+	
+	public void setFuelUnitPrice(KualiDecimal fuelUnitPrice) {
+		this.fuelUnitPrice = fuelUnitPrice;
+	}
+	
+	public KualiDecimal getFuelSaleAmount() {
+		return fuelSaleAmount;
+	}
+	
+	public void setFuelSaleAmount(KualiDecimal fuelSaleAmount) {
+		this.fuelSaleAmount = fuelSaleAmount;
+	}
+	
+	public KualiDecimal getFuelDiscountAmount() {
+		return fuelDiscountAmount;
+	}
+	
+	public void setFuelDiscountAmount(KualiDecimal fuelDiscountAmount) {
+		this.fuelDiscountAmount = fuelDiscountAmount;
+	}
+	
+	public KualiDecimal getTaxAmount1() {
+		return taxAmount1;
+	}
+	
+	public void setTaxAmount1(KualiDecimal taxAmount1) {
+		this.taxAmount1 = taxAmount1;
+	}
+	
+	public KualiDecimal getTaxAmount2() {
+		return taxAmount2;
+	}
+	
+	public void setTaxAmount2(KualiDecimal taxAmount2) {
+		this.taxAmount2 = taxAmount2;
+	}
+	
+	public KualiDecimal getTotalAmount() {
+		return totalAmount;
+	}
+	
+	public void setTotalAmount(KualiDecimal totalAmount) {
+		this.totalAmount = totalAmount;
+	}
+	
+	protected LinkedHashMap<String, String> toStringMapper() {
+		LinkedHashMap<String, String> m = new LinkedHashMap<String, String>();
+		m.put("documentNumber", documentNumber);
+		m.put("financialDocumentTransactionLineNumber", getFinancialDocumentTransactionLineNumber().toString());
+		return m;
+	}
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3Generic.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3Generic.java
@@ -1,0 +1,53 @@
+package edu.arizona.kfs.fp.businessobject;
+
+import java.sql.Date;
+import java.util.LinkedHashMap;
+
+import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
+
+public class ProcurementCardLevel3Generic extends PersistableBusinessObjectBase {
+
+	private String documentNumber;
+	private Integer financialDocumentTransactionLineNumber;
+	private Date genericEffectiveDate;
+	private String genericData;
+	
+	public String getDocumentNumber() {
+		return documentNumber;
+	}
+	
+	public void setDocumentNumber(String documentNumber) {
+		this.documentNumber = documentNumber;
+	}
+	
+	public Integer getFinancialDocumentTransactionLineNumber() {
+		return financialDocumentTransactionLineNumber;
+	}
+	
+	public void setFinancialDocumentTransactionLineNumber(Integer financialDocumentTransactionLineNumber) {
+		this.financialDocumentTransactionLineNumber = financialDocumentTransactionLineNumber;
+	}
+	
+	public Date getGenericEffectiveDate() {
+		return genericEffectiveDate;
+	}
+	
+	public void setGenericEffectiveDate(Date genericEffectiveDate) {
+		this.genericEffectiveDate = genericEffectiveDate;
+	}
+	
+	public String getGenericData() {
+		return genericData;
+	}
+	
+	public void setGenericData(String genericData) {
+		this.genericData = genericData;
+	}
+	
+	protected LinkedHashMap<String, String> toStringMapper() {
+		LinkedHashMap<String, String> m = new LinkedHashMap<String, String>();
+		m.put("documentNumber", documentNumber);
+		m.put("financialDocumentTransactionLineNumber", getFinancialDocumentTransactionLineNumber().toString());
+		return m;
+	}
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3Lodging.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3Lodging.java
@@ -1,0 +1,225 @@
+package edu.arizona.kfs.fp.businessobject;
+
+import java.sql.Date;
+import java.util.LinkedHashMap;
+
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
+
+public class ProcurementCardLevel3Lodging extends PersistableBusinessObjectBase {
+
+	private String documentNumber;
+	private Integer financialDocumentTransactionLineNumber;
+	private Date arriveDate;
+	private Date departureDate;
+	private String folioNum;
+	private String propertyPhoneNum;
+	private String customerServiceNum;
+	private KualiDecimal prePaidAmt;
+	private KualiDecimal roomRate;
+	private KualiDecimal roomTax;
+	private String programCode;
+	private KualiDecimal callCharges;
+	private KualiDecimal foodSvcCharges;
+	private KualiDecimal miniBarCharges;
+	private KualiDecimal giftShopCharges;
+	private KualiDecimal laundryCharges;
+	private KualiDecimal healthClubCharges;
+	private KualiDecimal movieCharges;
+	private KualiDecimal busCtrCharges;
+	private KualiDecimal parkingCharges;
+	private String otherCode;
+	private KualiDecimal otherCharges;
+	private KualiDecimal adjustmentAmount;
+	
+	public String getDocumentNumber() {
+		return documentNumber;
+	}
+	
+	public void setDocumentNumber(String documentNumber) {
+		this.documentNumber = documentNumber;
+	}
+	
+	public Integer getFinancialDocumentTransactionLineNumber() {
+		return financialDocumentTransactionLineNumber;
+	}
+	
+	public void setFinancialDocumentTransactionLineNumber(Integer financialDocumentTransactionLineNumber) {
+		this.financialDocumentTransactionLineNumber = financialDocumentTransactionLineNumber;
+	}
+	
+	public Date getArriveDate() {
+		return arriveDate;
+	}
+	
+	public void setArriveDate(Date arriveDate) {
+		this.arriveDate = arriveDate;
+	}
+	
+	public Date getDepartureDate() {
+		return departureDate;
+	}
+	
+	public void setDepartureDate(Date departureDate) {
+		this.departureDate = departureDate;
+	}
+	
+	public String getFolioNum() {
+		return folioNum;
+	}
+	
+	public void setFolioNum(String folioNum) {
+		this.folioNum = folioNum;
+	}
+	
+	public String getPropertyPhoneNum() {
+		return propertyPhoneNum;
+	}
+	
+	public void setPropertyPhoneNum(String propertyPhoneNum) {
+		this.propertyPhoneNum = propertyPhoneNum;
+	}
+	
+	public String getCustomerServiceNum() {
+		return customerServiceNum;
+	}
+	
+	public void setCustomerServiceNum(String customerServiceNum) {
+		this.customerServiceNum = customerServiceNum;
+	}
+	
+	public KualiDecimal getPrePaidAmt() {
+		return prePaidAmt;
+	}
+	
+	public void setPrePaidAmt(KualiDecimal prePaidAmt) {
+		this.prePaidAmt = prePaidAmt;
+	}
+	
+	public KualiDecimal getRoomRate() {
+		return roomRate;
+	}
+	
+	public void setRoomRate(KualiDecimal roomRate) {
+		this.roomRate = roomRate;
+	}
+	
+	public KualiDecimal getRoomTax() {
+		return roomTax;
+	}
+	
+	public void setRoomTax(KualiDecimal roomTax) {
+		this.roomTax = roomTax;
+	}
+	
+	public String getProgramCode() {
+		return programCode;
+	}
+	
+	public void setProgramCode(String programCode) {
+		this.programCode = programCode;
+	}
+	
+	public KualiDecimal getCallCharges() {
+		return callCharges;
+	}
+	
+	public void setCallCharges(KualiDecimal callCharges) {
+		this.callCharges = callCharges;
+	}
+	
+	public KualiDecimal getFoodSvcCharges() {
+		return foodSvcCharges;
+	}
+	
+	public void setFoodSvcCharges(KualiDecimal foodSvcCharges) {
+		this.foodSvcCharges = foodSvcCharges;
+	}
+	
+	public KualiDecimal getMiniBarCharges() {
+		return miniBarCharges;
+	}
+	
+	public void setMiniBarCharges(KualiDecimal miniBarCharges) {
+		this.miniBarCharges = miniBarCharges;
+	}
+	
+	public KualiDecimal getGiftShopCharges() {
+		return giftShopCharges;
+	}
+	
+	public void setGiftShopCharges(KualiDecimal giftShopCharges) {
+		this.giftShopCharges = giftShopCharges;
+	}
+	
+	public KualiDecimal getLaundryCharges() {
+		return laundryCharges;
+	}
+	
+	public void setLaundryCharges(KualiDecimal laundryCharges) {
+		this.laundryCharges = laundryCharges;
+	}
+	
+	public KualiDecimal getHealthClubCharges() {
+		return healthClubCharges;
+	}
+	
+	public void setHealthClubCharges(KualiDecimal healthClubCharges) {
+		this.healthClubCharges = healthClubCharges;
+	}
+	
+	public KualiDecimal getMovieCharges() {
+		return movieCharges;
+	}
+	
+	public void setMovieCharges(KualiDecimal movieCharges) {
+		this.movieCharges = movieCharges;
+	}
+	
+	public KualiDecimal getBusCtrCharges() {
+		return busCtrCharges;
+	}
+	
+	public void setBusCtrCharges(KualiDecimal busCtrCharges) {
+		this.busCtrCharges = busCtrCharges;
+	}
+	
+	public KualiDecimal getParkingCharges() {
+		return parkingCharges;
+	}
+	
+	public void setParkingCharges(KualiDecimal parkingCharges) {
+		this.parkingCharges = parkingCharges;
+	}
+	
+	public String getOtherCode() {
+		return otherCode;
+	}
+	
+	public void setOtherCode(String otherCode) {
+		this.otherCode = otherCode;
+	}
+	
+	public KualiDecimal getOtherCharges() {
+		return otherCharges;
+	}
+	
+	public void setOtherCharges(KualiDecimal otherCharges) {
+		this.otherCharges = otherCharges;
+	}
+	
+	public KualiDecimal getAdjustmentAmount() {
+		return adjustmentAmount;
+	}
+	
+	public void setAdjustmentAmount(KualiDecimal adjustmentAmount) {
+		this.adjustmentAmount = adjustmentAmount;
+	}
+	
+	protected LinkedHashMap<String, String> toStringMapper() {
+		LinkedHashMap<String, String> m = new LinkedHashMap<String, String>();
+		m.put("documentNumber", documentNumber);
+		m.put("financialDocumentTransactionLineNumber", getFinancialDocumentTransactionLineNumber().toString());
+		return m;
+	}
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3NonFuel.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3NonFuel.java
@@ -1,0 +1,125 @@
+package edu.arizona.kfs.fp.businessobject;
+
+import java.util.LinkedHashMap;
+
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
+
+public class ProcurementCardLevel3NonFuel extends PersistableBusinessObjectBase {
+
+	private String documentNumber;
+	private Integer financialDocumentTransactionLineNumber;
+	private Integer sequenceNumber;
+	private String nonFuelProductCode;
+	private String itemDesc;
+	private String itemQuant;
+	private String itemUnitOfMeasure;
+	private String taxRateApplied;
+	private KualiDecimal itemTaxAmt;
+	private String alternateTaxId;
+	private KualiDecimal itemDiscountAmt;
+	private KualiDecimal itemTotal;
+	
+	public String getDocumentNumber() {
+		return documentNumber;
+	}
+	
+	public void setDocumentNumber(String documentNumber) {
+		this.documentNumber = documentNumber;
+	}
+	
+	public Integer getFinancialDocumentTransactionLineNumber() {
+		return financialDocumentTransactionLineNumber;
+	}
+	
+	public void setFinancialDocumentTransactionLineNumber(Integer financialDocumentTransactionLineNumber) {
+		this.financialDocumentTransactionLineNumber = financialDocumentTransactionLineNumber;
+	}
+	
+	public Integer getSequenceNumber() {
+		return sequenceNumber;
+	}
+	
+	public void setSequenceNumber(Integer sequenceNumber) {
+		this.sequenceNumber = sequenceNumber;
+	}
+	
+	public String getNonFuelProductCode() {
+		return nonFuelProductCode;
+	}
+	
+	public void setNonFuelProductCode(String nonFuelProductCode) {
+		this.nonFuelProductCode = nonFuelProductCode;
+	}
+	
+	public String getItemDesc() {
+		return itemDesc;
+	}
+	
+	public void setItemDesc(String itemDesc) {
+		this.itemDesc = itemDesc;
+	}
+	
+	public String getItemQuant() {
+		return itemQuant;
+	}
+	
+	public void setItemQuant(String itemQuant) {
+		this.itemQuant = itemQuant;
+	}
+	
+	public String getItemUnitOfMeasure() {
+		return itemUnitOfMeasure;
+	}
+	
+	public void setItemUnitOfMeasure(String itemUnitOfMeasure) {
+		this.itemUnitOfMeasure = itemUnitOfMeasure;
+	}
+	
+	public String getTaxRateApplied() {
+		return taxRateApplied;
+	}
+	
+	public void setTaxRateApplied(String taxRateApplied) {
+		this.taxRateApplied = taxRateApplied;
+	}
+	
+	public KualiDecimal getItemTaxAmt() {
+		return itemTaxAmt;
+	}
+	
+	public void setItemTaxAmt(KualiDecimal itemTaxAmt) {
+		this.itemTaxAmt = itemTaxAmt;
+	}
+	
+	public String getAlternateTaxId() {
+		return alternateTaxId;
+	}
+	
+	public void setAlternateTaxId(String alternateTaxId) {
+		this.alternateTaxId = alternateTaxId;
+	}
+	
+	public KualiDecimal getItemDiscountAmt() {
+		return itemDiscountAmt;
+	}
+	
+	public void setItemDiscountAmt(KualiDecimal itemDiscountAmt) {
+		this.itemDiscountAmt = itemDiscountAmt;
+	}
+	
+	public KualiDecimal getItemTotal() {
+		return itemTotal;
+	}
+	
+	public void setItemTotal(KualiDecimal itemTotal) {
+		this.itemTotal = itemTotal;
+	}
+	
+	protected LinkedHashMap<String, String> toStringMapper() {
+		LinkedHashMap<String, String> m = new LinkedHashMap<String, String>();
+		m.put("documentNumber", documentNumber);
+		m.put("financialDocumentTransactionLineNumber", getFinancialDocumentTransactionLineNumber().toString());
+		return m;
+	}
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3Rental.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3Rental.java
@@ -1,0 +1,279 @@
+package edu.arizona.kfs.fp.businessobject;
+
+import java.sql.Date;
+import java.util.LinkedHashMap;
+
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
+
+public class ProcurementCardLevel3Rental extends PersistableBusinessObjectBase {
+
+	private String documentNumber;
+	private Integer financialDocumentTransactionLineNumber;
+	private Date checkOutDate;
+	private String rentalAgreementNum;
+	private String renterName;
+	private String returnCity;
+	private String returnState;
+	private String returnCountry;
+	private Date returnDate;
+	private String returnLocation;
+	private String customerSvcNum;
+	private String rentalClass;
+	private KualiDecimal dailyRate;
+	private KualiDecimal weeklyRate;
+	private KualiDecimal ratePerMile;
+	private Integer maxFreeMiles;
+	private Integer totalMiles;
+	private KualiDecimal oneWayCharges;
+	private KualiDecimal insuranceCharges;
+	private KualiDecimal regularCharges;
+	private KualiDecimal towingCharges;
+	private KualiDecimal extraCharges;
+	private KualiDecimal lateReturnFee;
+	private String adjustCode;
+	private KualiDecimal adjustAmount;
+	private String progCode;
+	private KualiDecimal phoneCharges;
+	private KualiDecimal othrCharges;
+	private KualiDecimal totalTaxAmount;
+	
+	public String getDocumentNumber() {
+		return documentNumber;
+	}
+	
+	public void setDocumentNumber(String documentNumber) {
+		this.documentNumber = documentNumber;
+	}
+	
+	public Integer getFinancialDocumentTransactionLineNumber() {
+		return financialDocumentTransactionLineNumber;
+	}
+	
+	public void setFinancialDocumentTransactionLineNumber(Integer financialDocumentTransactionLineNumber) {
+		this.financialDocumentTransactionLineNumber = financialDocumentTransactionLineNumber;
+	}
+	
+	public Date getCheckOutDate() {
+		return checkOutDate;
+	}
+	
+	public void setCheckOutDate(Date checkOutDate) {
+		this.checkOutDate = checkOutDate;
+	}
+	
+	public String getRentalAgreementNum() {
+		return rentalAgreementNum;
+	}
+	
+	public void setRentalAgreementNum(String rentalAgreementNum) {
+		this.rentalAgreementNum = rentalAgreementNum;
+	}
+	
+	public String getRenterName() {
+		return renterName;
+	}
+	
+	public void setRenterName(String renterName) {
+		this.renterName = renterName;
+	}
+	
+	public String getReturnCity() {
+		return returnCity;
+	}
+	
+	public void setReturnCity(String returnCity) {
+		this.returnCity = returnCity;
+	}
+	
+	public String getReturnState() {
+		return returnState;
+	}
+	
+	public void setReturnState(String returnState) {
+		this.returnState = returnState;
+	}
+	
+	public String getReturnCountry() {
+		return returnCountry;
+	}
+	
+	public void setReturnCountry(String returnCountry) {
+		this.returnCountry = returnCountry;
+	}
+	
+	public Date getReturnDate() {
+		return returnDate;
+	}
+	
+	public void setReturnDate(Date returnDate) {
+		this.returnDate = returnDate;
+	}
+	
+	public String getReturnLocation() {
+		return returnLocation;
+	}
+	
+	public void setReturnLocation(String returnLocation) {
+		this.returnLocation = returnLocation;
+	}
+	
+	public String getCustomerSvcNum() {
+		return customerSvcNum;
+	}
+	
+	public void setCustomerSvcNum(String customerSvcNum) {
+		this.customerSvcNum = customerSvcNum;
+	}
+	
+	public String getRentalClass() {
+		return rentalClass;
+	}
+	
+	public void setRentalClass(String rentalClass) {
+		this.rentalClass = rentalClass;
+	}
+	
+	public KualiDecimal getDailyRate() {
+		return dailyRate;
+	}
+	
+	public void setDailyRate(KualiDecimal dailyRate) {
+		this.dailyRate = dailyRate;
+	}
+	
+	public KualiDecimal getWeeklyRate() {
+		return weeklyRate;
+	}
+	
+	public void setWeeklyRate(KualiDecimal weeklyRate) {
+		this.weeklyRate = weeklyRate;
+	}
+	
+	public KualiDecimal getRatePerMile() {
+		return ratePerMile;
+	}
+	
+	public void setRatePerMile(KualiDecimal ratePerMile) {
+		this.ratePerMile = ratePerMile;
+	}
+	
+	public Integer getMaxFreeMiles() {
+		return maxFreeMiles;
+	}
+	
+	public void setMaxFreeMiles(Integer maxFreeMiles) {
+		this.maxFreeMiles = maxFreeMiles;
+	}
+	
+	public Integer getTotalMiles() {
+		return totalMiles;
+	}
+	
+	public void setTotalMiles(Integer totalMiles) {
+		this.totalMiles = totalMiles;
+	}
+	
+	public KualiDecimal getOneWayCharges() {
+		return oneWayCharges;
+	}
+	
+	public void setOneWayCharges(KualiDecimal oneWayCharges) {
+		this.oneWayCharges = oneWayCharges;
+	}
+	
+	public KualiDecimal getInsuranceCharges() {
+		return insuranceCharges;
+	}
+	
+	public void setInsuranceCharges(KualiDecimal insuranceCharges) {
+		this.insuranceCharges = insuranceCharges;
+	}
+	
+	public KualiDecimal getRegularCharges() {
+		return regularCharges;
+	}
+	
+	public void setRegularCharges(KualiDecimal regularCharges) {
+		this.regularCharges = regularCharges;
+	}
+	
+	public KualiDecimal getTowingCharges() {
+		return towingCharges;
+	}
+	
+	public void setTowingCharges(KualiDecimal towingCharges) {
+		this.towingCharges = towingCharges;
+	}
+	
+	public KualiDecimal getExtraCharges() {
+		return extraCharges;
+	}
+	
+	public void setExtraCharges(KualiDecimal extraCharges) {
+		this.extraCharges = extraCharges;
+	}
+	
+	public KualiDecimal getLateReturnFee() {
+		return lateReturnFee;
+	}
+	
+	public void setLateReturnFee(KualiDecimal lateReturnFee) {
+		this.lateReturnFee = lateReturnFee;
+	}
+	
+	public String getAdjustCode() {
+		return adjustCode;
+	}
+	
+	public void setAdjustCode(String adjustCode) {
+		this.adjustCode = adjustCode;
+	}
+	
+	public KualiDecimal getAdjustAmount() {
+		return adjustAmount;
+	}
+	
+	public void setAdjustAmount(KualiDecimal adjustAmount) {
+		this.adjustAmount = adjustAmount;
+	}
+	
+	public String getProgCode() {
+		return progCode;
+	}
+	
+	public void setProgCode(String progCode) {
+		this.progCode = progCode;
+	}
+	
+	public KualiDecimal getPhoneCharges() {
+		return phoneCharges;
+	}
+	
+	public void setPhoneCharges(KualiDecimal phoneCharges) {
+		this.phoneCharges = phoneCharges;
+	}
+	
+	public KualiDecimal getOthrCharges() {
+		return othrCharges;
+	}
+	
+	public void setOthrCharges(KualiDecimal othrCharges) {
+		this.othrCharges = othrCharges;
+	}
+	
+	public KualiDecimal getTotalTaxAmount() {
+		return totalTaxAmount;
+	}
+	
+	public void setTotalTaxAmount(KualiDecimal totalTaxAmount) {
+		this.totalTaxAmount = totalTaxAmount;
+	}
+	
+	protected LinkedHashMap<String, String> toStringMapper() {
+		LinkedHashMap<String, String> m = new LinkedHashMap<String, String>();
+		m.put("documentNumber", documentNumber);
+		m.put("financialDocumentTransactionLineNumber", getFinancialDocumentTransactionLineNumber().toString());
+		return m;
+	}
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3ShipSvc.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3ShipSvc.java
@@ -1,0 +1,216 @@
+package edu.arizona.kfs.fp.businessobject;
+
+import java.sql.Date;
+import java.util.LinkedHashMap;
+
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
+
+public class ProcurementCardLevel3ShipSvc extends PersistableBusinessObjectBase {
+
+	private String documentNumber;
+	private Integer financialDocumentTransactionLineNumber;
+	private Integer sequenceNumber;
+	private String courierName;
+	private String trackingNumber;
+	private String serviceDescription;
+	private Date pickupDate;
+	private String originZip;
+	private String originCountryCd;
+	private String destinationZip;
+	private String destinationCountryCd;
+	private KualiDecimal netAmount;
+	private KualiDecimal taxAmt;
+	private KualiDecimal discAmt;
+	private Integer numberOfPackages;
+	private String weight;
+	private String unitsOfMeasure;
+	private String senderName;
+	private String senderAddress;
+	private String receiverName;
+	private String receiverAddress;
+	private String customerRefNumber;
+	
+	public String getDocumentNumber() {
+		return documentNumber;
+	}
+	
+	public void setDocumentNumber(String documentNumber) {
+		this.documentNumber = documentNumber;
+	}
+	
+	public Integer getFinancialDocumentTransactionLineNumber() {
+		return financialDocumentTransactionLineNumber;
+	}
+	
+	public void setFinancialDocumentTransactionLineNumber(Integer financialDocumentTransactionLineNumber) {
+		this.financialDocumentTransactionLineNumber = financialDocumentTransactionLineNumber;
+	}
+	
+	public Integer getSequenceNumber() {
+		return sequenceNumber;
+	}
+	
+	public void setSequenceNumber(Integer sequenceNumber) {
+		this.sequenceNumber = sequenceNumber;
+	}
+	
+	public String getCourierName() {
+		return courierName;
+	}
+	
+	public void setCourierName(String courierName) {
+		this.courierName = courierName;
+	}
+	
+	public String getTrackingNumber() {
+		return trackingNumber;
+	}
+	
+	public void setTrackingNumber(String trackingNumber) {
+		this.trackingNumber = trackingNumber;
+	}
+	
+	public String getServiceDescription() {
+		return serviceDescription;
+	}
+	
+	public void setServiceDescription(String serviceDescription) {
+		this.serviceDescription = serviceDescription;
+	}
+	
+	public Date getPickupDate() {
+		return pickupDate;
+	}
+	
+	public void setPickupDate(Date pickupDate) {
+		this.pickupDate = pickupDate;
+	}
+	
+	public String getOriginZip() {
+		return originZip;
+	}
+	
+	public void setOriginZip(String originZip) {
+		this.originZip = originZip;
+	}
+	
+	public String getOriginCountryCd() {
+		return originCountryCd;
+	}
+	
+	public void setOriginCountryCd(String originCountryCd) {
+		this.originCountryCd = originCountryCd;
+	}
+	
+	public String getDestinationZip() {
+		return destinationZip;
+	}
+	
+	public void setDestinationZip(String destinationZip) {
+		this.destinationZip = destinationZip;
+	}
+	
+	public String getDestinationCountryCd() {
+		return destinationCountryCd;
+	}
+	
+	public void setDestinationCountryCd(String destinationCountryCd) {
+		this.destinationCountryCd = destinationCountryCd;
+	}
+	
+	public KualiDecimal getNetAmount() {
+		return netAmount;
+	}
+	
+	public void setNetAmount(KualiDecimal netAmount) {
+		this.netAmount = netAmount;
+	}
+	
+	public KualiDecimal getTaxAmt() {
+		return taxAmt;
+	}
+	
+	public void setTaxAmt(KualiDecimal taxAmt) {
+		this.taxAmt = taxAmt;
+	}
+	
+	public KualiDecimal getDiscAmt() {
+		return discAmt;
+	}
+	
+	public void setDiscAmt(KualiDecimal discAmt) {
+		this.discAmt = discAmt;
+	}
+	
+	public Integer getNumberOfPackages() {
+		return numberOfPackages;
+	}
+	
+	public void setNumberOfPackages(Integer numberOfPackages) {
+		this.numberOfPackages = numberOfPackages;
+	}
+	
+	public String getWeight() {
+		return weight;
+	}
+	
+	public void setWeight(String weight) {
+		this.weight = weight;
+	}
+	
+	public String getUnitsOfMeasure() {
+		return unitsOfMeasure;
+	}
+	
+	public void setUnitsOfMeasure(String unitsOfMeasure) {
+		this.unitsOfMeasure = unitsOfMeasure;
+	}
+	
+	public String getSenderName() {
+		return senderName;
+	}
+	
+	public void setSenderName(String senderName) {
+		this.senderName = senderName;
+	}
+	
+	public String getSenderAddress() {
+		return senderAddress;
+	}
+	
+	public void setSenderAddress(String senderAddress) {
+		this.senderAddress = senderAddress;
+	}
+	
+	public String getReceiverName() {
+		return receiverName;
+	}
+	
+	public void setReceiverName(String receiverName) {
+		this.receiverName = receiverName;
+	}
+	
+	public String getReceiverAddress() {
+		return receiverAddress;
+	}
+	
+	public void setReceiverAddress(String receiverAddress) {
+		this.receiverAddress = receiverAddress;
+	}
+	
+	public String getCustomerRefNumber() {
+		return customerRefNumber;
+	}
+	
+	public void setCustomerRefNumber(String customerRefNumber) {
+		this.customerRefNumber = customerRefNumber;
+	}
+	
+	protected LinkedHashMap<String, String> toStringMapper() {
+		LinkedHashMap<String, String> m = new LinkedHashMap<String, String>();
+		m.put("documentNumber", documentNumber);
+		m.put("financialDocumentTransactionLineNumber", getFinancialDocumentTransactionLineNumber().toString());
+		return m;
+	}
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3TempSvc.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3TempSvc.java
@@ -1,0 +1,189 @@
+package edu.arizona.kfs.fp.businessobject;
+
+import java.sql.Date;
+import java.util.LinkedHashMap;
+
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
+
+public class ProcurementCardLevel3TempSvc extends PersistableBusinessObjectBase {
+
+	private String documentNumber;
+	private Integer financialDocumentTransactionLineNumber;
+	private Integer sequenceNumber;
+	private Date weekEndingDate;
+	private String serviceDesc;
+	private String employeeName;
+	private KualiDecimal regularRate;
+	private KualiDecimal regularHours;
+	private KualiDecimal overtimeRate;
+	private KualiDecimal overtimeHours;
+	private KualiDecimal miscExpenseAmt;
+	private KualiDecimal subTotalAmt;
+	private KualiDecimal salesTaxAmt;
+	private KualiDecimal discountAmt;
+	private Date startDate;
+	private String supervisor;
+	private String timeSheetNumber;
+	private String commodityCode;
+	private String jobCode;
+	
+	public String getDocumentNumber() {
+		return documentNumber;
+	}
+	
+	public void setDocumentNumber(String documentNumber) {
+		this.documentNumber = documentNumber;
+	}
+	
+	public Integer getFinancialDocumentTransactionLineNumber() {
+		return financialDocumentTransactionLineNumber;
+	}
+	
+	public void setFinancialDocumentTransactionLineNumber(Integer financialDocumentTransactionLineNumber) {
+		this.financialDocumentTransactionLineNumber = financialDocumentTransactionLineNumber;
+	}
+	
+	public Integer getSequenceNumber() {
+		return sequenceNumber;
+	}
+	
+	public void setSequenceNumber(Integer sequenceNumber) {
+		this.sequenceNumber = sequenceNumber;
+	}
+	
+	public Date getWeekEndingDate() {
+		return weekEndingDate;
+	}
+	
+	public void setWeekEndingDate(Date weekEndingDate) {
+		this.weekEndingDate = weekEndingDate;
+	}
+	
+	public String getServiceDesc() {
+		return serviceDesc;
+	}
+	
+	public void setServiceDesc(String serviceDesc) {
+		this.serviceDesc = serviceDesc;
+	}
+	
+	public String getEmployeeName() {
+		return employeeName;
+	}
+	
+	public void setEmployeeName(String employeeName) {
+		this.employeeName = employeeName;
+	}
+	
+	public KualiDecimal getRegularRate() {
+		return regularRate;
+	}
+	
+	public void setRegularRate(KualiDecimal regularRate) {
+		this.regularRate = regularRate;
+	}
+	
+	public KualiDecimal getRegularHours() {
+		return regularHours;
+	}
+	
+	public void setRegularHours(KualiDecimal regularHours) {
+		this.regularHours = regularHours;
+	}
+	
+	public KualiDecimal getOvertimeRate() {
+		return overtimeRate;
+	}
+	
+	public void setOvertimeRate(KualiDecimal overtimeRate) {
+		this.overtimeRate = overtimeRate;
+	}
+	
+	public KualiDecimal getOvertimeHours() {
+		return overtimeHours;
+	}
+	
+	public void setOvertimeHours(KualiDecimal overtimeHours) {
+		this.overtimeHours = overtimeHours;
+	}
+	
+	public KualiDecimal getMiscExpenseAmt() {
+		return miscExpenseAmt;
+	}
+	
+	public void setMiscExpenseAmt(KualiDecimal miscExpenseAmt) {
+		this.miscExpenseAmt = miscExpenseAmt;
+	}
+	
+	public KualiDecimal getSubTotalAmt() {
+		return subTotalAmt;
+	}
+	
+	public void setSubTotalAmt(KualiDecimal subTotalAmt) {
+		this.subTotalAmt = subTotalAmt;
+	}
+	
+	public KualiDecimal getSalesTaxAmt() {
+		return salesTaxAmt;
+	}
+	
+	public void setSalesTaxAmt(KualiDecimal salesTaxAmt) {
+		this.salesTaxAmt = salesTaxAmt;
+	}
+	
+	public KualiDecimal getDiscountAmt() {
+		return discountAmt;
+	}
+	
+	public void setDiscountAmt(KualiDecimal discountAmt) {
+		this.discountAmt = discountAmt;
+	}
+	
+	public Date getStartDate() {
+		return startDate;
+	}
+	
+	public void setStartDate(Date startDate) {
+		this.startDate = startDate;
+	}
+	
+	public String getSupervisor() {
+		return supervisor;
+	}
+	
+	public void setSupervisor(String supervisor) {
+		this.supervisor = supervisor;
+	}
+	
+	public String getTimeSheetNumber() {
+		return timeSheetNumber;
+	}
+	
+	public void setTimeSheetNumber(String timeSheetNumber) {
+		this.timeSheetNumber = timeSheetNumber;
+	}
+	
+	public String getCommodityCode() {
+		return commodityCode;
+	}
+	
+	public void setCommodityCode(String commodityCode) {
+		this.commodityCode = commodityCode;
+	}
+	
+	public String getJobCode() {
+		return jobCode;
+	}
+	
+	public void setJobCode(String jobCode) {
+		this.jobCode = jobCode;
+	}
+	
+	protected LinkedHashMap<String, String> toStringMapper() {
+		LinkedHashMap<String, String> m = new LinkedHashMap<String, String>();
+		m.put("documentNumber", documentNumber);
+		m.put("financialDocumentTransactionLineNumber", getFinancialDocumentTransactionLineNumber().toString());
+		return m;
+	}
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3Transport.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3Transport.java
@@ -1,0 +1,144 @@
+package edu.arizona.kfs.fp.businessobject;
+
+import java.sql.Date;
+import java.util.LinkedHashMap;
+
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
+
+public class ProcurementCardLevel3Transport extends PersistableBusinessObjectBase {
+
+	private String documentNumber;
+	private Integer financialDocumentTransactionLineNumber;
+	private String passengerName;
+	private Date departDate;
+	private String departureCity;
+	private String agencyCode;
+	private String agencyName;
+	private long ticketNumber;
+	private String customerCode;
+	private Date issueDate;
+	private String issuingCarrier;
+	private KualiDecimal totalFare;
+	private KualiDecimal totalFees;
+	private KualiDecimal totalTaxes;
+	
+	public String getDocumentNumber() {
+		return documentNumber;
+	}
+	
+	public void setDocumentNumber(String documentNumber) {
+		this.documentNumber = documentNumber;
+	}
+	
+	public Integer getFinancialDocumentTransactionLineNumber() {
+		return financialDocumentTransactionLineNumber;
+	}
+	
+	public void setFinancialDocumentTransactionLineNumber(Integer financialDocumentTransactionLineNumber) {
+		this.financialDocumentTransactionLineNumber = financialDocumentTransactionLineNumber;
+	}
+	
+	public String getPassengerName() {
+		return passengerName;
+	}
+	
+	public void setPassengerName(String passengerName) {
+		this.passengerName = passengerName;
+	}
+	
+	public Date getDepartDate() {
+		return departDate;
+	}
+	
+	public void setDepartDate(Date departDate) {
+		this.departDate = departDate;
+	}
+	
+	public String getDepartureCity() {
+		return departureCity;
+	}
+	
+	public void setDepartureCity(String departureCity) {
+		this.departureCity = departureCity;
+	}
+	
+	public String getAgencyCode() {
+		return agencyCode;
+	}
+	
+	public void setAgencyCode(String agencyCode) {
+		this.agencyCode = agencyCode;
+	}
+	
+	public String getAgencyName() {
+		return agencyName;
+	}
+	
+	public void setAgencyName(String agencyName) {
+		this.agencyName = agencyName;
+	}
+	
+	public long getTicketNumber() {
+		return ticketNumber;
+	}
+	
+	public void setTicketNumber(long ticketNumber) {
+		this.ticketNumber = ticketNumber;
+	}
+	
+	public String getCustomerCode() {
+		return customerCode;
+	}
+	
+	public void setCustomerCode(String customerCode) {
+		this.customerCode = customerCode;
+	}
+	
+	public Date getIssueDate() {
+		return issueDate;
+	}
+	
+	public void setIssueDate(Date issueDate) {
+		this.issueDate = issueDate;
+	}
+	
+	public String getIssuingCarrier() {
+		return issuingCarrier;
+	}
+	
+	public void setIssuingCarrier(String issuingCarrier) {
+		this.issuingCarrier = issuingCarrier;
+	}
+	
+	public KualiDecimal getTotalFare() {
+		return totalFare;
+	}
+	
+	public void setTotalFare(KualiDecimal totalFare) {
+		this.totalFare = totalFare;
+	}
+	
+	public KualiDecimal getTotalFees() {
+		return totalFees;
+	}
+	
+	public void setTotalFees(KualiDecimal totalFees) {
+		this.totalFees = totalFees;
+	}
+	
+	public KualiDecimal getTotalTaxes() {
+		return totalTaxes;
+	}
+	
+	public void setTotalTaxes(KualiDecimal totalTaxes) {
+		this.totalTaxes = totalTaxes;
+	}
+	
+	protected LinkedHashMap<String, String> toStringMapper() {
+		LinkedHashMap<String, String> m = new LinkedHashMap<String, String>();
+		m.put("documentNumber", documentNumber);
+		m.put("financialDocumentTransactionLineNumber", getFinancialDocumentTransactionLineNumber().toString());
+		return m;
+	}
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3TransportLeg.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardLevel3TransportLeg.java
@@ -1,0 +1,197 @@
+package edu.arizona.kfs.fp.businessobject;
+
+import java.util.LinkedHashMap;
+
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
+
+public class ProcurementCardLevel3TransportLeg extends PersistableBusinessObjectBase {
+
+	private String documentNumber;
+	private Integer financialDocumentTransactionLineNumber;
+	private Integer sequenceNumber;
+	private String carrierCode;
+	private String serviceClass;
+	private String departCity;
+	private String conjunctionTicket;
+	private String exchangeTicket;
+	private String destinationCity;
+	private String fareBasisCode;
+	private String flightNumber;
+	private String departTime;
+	private String departTimeSegment;
+	private String arriveTime;
+	private String arriveTimeSegment;
+	private KualiDecimal fare;
+	private KualiDecimal fees;
+	private KualiDecimal taxes;
+	private String endorsements;
+	private String controlCode;
+	
+	public String getDocumentNumber() {
+		return documentNumber;
+	}
+	
+	public void setDocumentNumber(String documentNumber) {
+		this.documentNumber = documentNumber;
+	}
+	
+	public Integer getFinancialDocumentTransactionLineNumber() {
+		return financialDocumentTransactionLineNumber;
+	}
+	
+	public void setFinancialDocumentTransactionLineNumber(Integer financialDocumentTransactionLineNumber) {
+		this.financialDocumentTransactionLineNumber = financialDocumentTransactionLineNumber;
+	}
+	
+	public Integer getSequenceNumber() {
+		return sequenceNumber;
+	}
+	
+	public void setSequenceNumber(Integer sequenceNumber) {
+		this.sequenceNumber = sequenceNumber;
+	}
+	
+	public String getCarrierCode() {
+		return carrierCode;
+	}
+	
+	public void setCarrierCode(String carrierCode) {
+		this.carrierCode = carrierCode;
+	}
+	
+	public String getServiceClass() {
+		return serviceClass;
+	}
+	
+	public void setServiceClass(String serviceClass) {
+		this.serviceClass = serviceClass;
+	}
+	
+	public String getDepartCity() {
+		return departCity;
+	}
+	
+	public void setDepartCity(String departCity) {
+		this.departCity = departCity;
+	}
+	
+	public String getConjunctionTicket() {
+		return conjunctionTicket;
+	}
+	
+	public void setConjunctionTicket(String conjunctionTicket) {
+		this.conjunctionTicket = conjunctionTicket;
+	}
+	
+	public String getExchangeTicket() {
+		return exchangeTicket;
+	}
+	
+	public void setExchangeTicket(String exchangeTicket) {
+		this.exchangeTicket = exchangeTicket;
+	}
+	
+	public String getDestinationCity() {
+		return destinationCity;
+	}
+	
+	public void setDestinationCity(String destinationCity) {
+		this.destinationCity = destinationCity;
+	}
+	
+	public String getFareBasisCode() {
+		return fareBasisCode;
+	}
+	
+	public void setFareBasisCode(String fareBasisCode) {
+		this.fareBasisCode = fareBasisCode;
+	}
+	
+	public String getFlightNumber() {
+		return flightNumber;
+	}
+	
+	public void setFlightNumber(String flightNumber) {
+		this.flightNumber = flightNumber;
+	}
+	
+	public String getDepartTime() {
+		return departTime;
+	}
+	
+	public void setDepartTime(String departTime) {
+		this.departTime = departTime;
+	}
+	
+	public String getDepartTimeSegment() {
+		return departTimeSegment;
+	}
+	
+	public void setDepartTimeSegment(String departTimeSegment) {
+		this.departTimeSegment = departTimeSegment;
+	}
+	
+	public String getArriveTime() {
+		return arriveTime;
+	}
+	
+	public void setArriveTime(String arriveTime) {
+		this.arriveTime = arriveTime;
+	}
+	
+	public String getArriveTimeSegment() {
+		return arriveTimeSegment;
+	}
+	
+	public void setArriveTimeSegment(String arriveTimeSegment) {
+		this.arriveTimeSegment = arriveTimeSegment;
+	}
+	
+	public KualiDecimal getFare() {
+		return fare;
+	}
+	
+	public void setFare(KualiDecimal fare) {
+		this.fare = fare;
+	}
+	
+	public KualiDecimal getFees() {
+		return fees;
+	}
+	
+	public void setFees(KualiDecimal fees) {
+		this.fees = fees;
+	}
+	
+	public KualiDecimal getTaxes() {
+		return taxes;
+	}
+	
+	public void setTaxes(KualiDecimal taxes) {
+		this.taxes = taxes;
+	}
+	
+	public String getEndorsements() {
+		return endorsements;
+	}
+	
+	public void setEndorsements(String endorsements) {
+		this.endorsements = endorsements;
+	}
+	
+	public String getControlCode() {
+		return controlCode;
+	}
+	
+	public void setControlCode(String controlCode) {
+		this.controlCode = controlCode;
+	}
+	
+	protected LinkedHashMap<String, String> toStringMapper() {
+		LinkedHashMap<String, String> m = new LinkedHashMap<String, String>();
+		m.put("documentNumber", documentNumber);
+		m.put("financialDocumentTransactionLineNumber", getFinancialDocumentTransactionLineNumber().toString());
+		return m;
+	}
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardTranAddItem.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardTranAddItem.java
@@ -1,0 +1,184 @@
+package edu.arizona.kfs.fp.businessobject;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
+
+public class ProcurementCardTranAddItem extends PersistableBusinessObjectBase {
+
+	private Integer transactionSequenceRowNumber;
+	private Integer sequenceRowNumber;
+	private String itemCommodityCode;
+	private String itemProductCode;
+	private String itemDescription;
+	private BigDecimal itemQuantity;
+	private String itemUnitCode;
+	private KualiDecimal itemAmount;
+	private String itemDebitCreditCode;
+	private KualiDecimal itemTaxRate;
+	private KualiDecimal itemTaxAmount;
+	private KualiDecimal itemDiscountAmount;
+	private KualiDecimal itemExtendedAmount;
+	
+	public Integer getTransactionSequenceRowNumber() {
+		return transactionSequenceRowNumber;
+	}
+	
+	public void setTransactionSequenceRowNumber(Integer transactionSequenceRowNumber) {
+		this.transactionSequenceRowNumber = transactionSequenceRowNumber;
+	}
+	
+	public Integer getSequenceRowNumber() {
+		return sequenceRowNumber;
+	}
+	
+	public void setSequenceRowNumber(Integer sequenceRowNumber) {
+		this.sequenceRowNumber = sequenceRowNumber;
+	}
+	
+	public String getItemCommodityCode() {
+		return itemCommodityCode;
+	}
+	
+	public void setItemCommodityCode(String itemCommodityCode) {
+		this.itemCommodityCode = itemCommodityCode;
+	}
+	
+	public String getItemProductCode() {
+		return itemProductCode;
+	}
+	
+	public void setItemProductCode(String itemProductCode) {
+		this.itemProductCode = itemProductCode;
+	}
+	
+	public String getItemDescription() {
+		return itemDescription;
+	}
+	
+	public void setItemDescription(String itemDescription) {
+		this.itemDescription = itemDescription;
+	}
+	
+	public BigDecimal getItemQuantity() {
+		return itemQuantity;
+	}
+	
+	public void setItemQuantity(BigDecimal itemQuantity) {
+		this.itemQuantity = itemQuantity;
+	}
+	
+	public void setItemQuantity(String itemQuantity) {
+		if(StringUtils.isNotBlank(itemQuantity)) {
+			this.itemQuantity = new BigDecimal(itemQuantity);
+		} else {
+			this.itemQuantity = BigDecimal.ZERO;
+		}
+	}
+	
+	public String getItemUnitCode() {
+		return itemUnitCode;
+	}
+	
+	public void setItemUnitCode(String itemUnitCode) {
+		this.itemUnitCode = itemUnitCode;
+	}
+	
+	public KualiDecimal getItemAmount() {
+		return itemAmount;
+	}
+	
+	public void setItemAmount(KualiDecimal itemAmount) {
+		this.itemAmount = itemAmount;
+	}
+	
+	public void setItemAmount(String itemAmount) {
+		if(StringUtils.isNotBlank(itemAmount)) {
+			this.itemAmount = new KualiDecimal(itemAmount);
+		} else {
+			this.itemAmount = KualiDecimal.ZERO;
+		}
+	}
+	
+	public String getItemDebitCreditCode() {
+		return itemDebitCreditCode;
+	}
+	
+	public void setItemDebitCreditCode(String itemDebitCreditCode) {
+		this.itemDebitCreditCode = itemDebitCreditCode;
+	}
+	
+	public KualiDecimal getItemTaxRate() {
+		return itemTaxRate;
+	}
+	
+	public void setItemTaxRate(KualiDecimal itemTaxRate) {
+		this.itemTaxRate = itemTaxRate;
+	}
+	
+	public void setItemTaxRate(String itemTaxRate) {
+		if(StringUtils.isNotBlank(itemTaxRate)) {
+			this.itemTaxRate = new KualiDecimal(itemTaxRate);
+		} else {
+			this.itemTaxRate = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getItemTaxAmount() {
+		return itemTaxAmount;
+	}
+	
+	public void setItemTaxAmount(KualiDecimal itemTaxAmount) {
+		this.itemTaxAmount = itemTaxAmount;
+	}
+	
+	public void setItemTaxAmount(String itemTaxAmount) {
+		if(StringUtils.isNotBlank(itemTaxAmount)) {
+			this.itemTaxAmount = new KualiDecimal(itemTaxAmount);
+		} else {
+			this.itemTaxAmount = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getItemDiscountAmount() {
+		return itemDiscountAmount;
+	}
+	
+	public void setItemDiscountAmount(KualiDecimal itemDiscountAmount) {
+		this.itemDiscountAmount = itemDiscountAmount;
+	}
+	
+	public void setItemDiscountAmount(String itemDiscountAmount) {
+		if(StringUtils.isNotBlank(itemDiscountAmount)) {
+			this.itemDiscountAmount = new KualiDecimal(itemDiscountAmount);
+		} else {
+			this.itemDiscountAmount = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getItemExtendedAmount() {
+		return itemExtendedAmount;
+	}
+	
+	public void setItemExtendedAmount(KualiDecimal itemExtendedAmount) {
+		this.itemExtendedAmount = itemExtendedAmount;
+	}
+	
+	public void setItemExtendedAmount(String itemExtendedAmount) {
+		if(StringUtils.isNotBlank(itemExtendedAmount)) {
+			this.itemExtendedAmount = new KualiDecimal(itemExtendedAmount);
+		} else {
+			this.itemExtendedAmount = KualiDecimal.ZERO;
+		}
+	}
+	
+	protected LinkedHashMap<String, Integer> toStringMapper() {
+		LinkedHashMap<String, Integer> m = new LinkedHashMap<String, Integer>();
+		m.put("transactionSquenceRowNumber", getTransactionSequenceRowNumber());
+		m.put("sequenceRowNumber", getSequenceRowNumber());
+		return m;
+	}
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardTranNonFuel.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardTranNonFuel.java
@@ -1,0 +1,141 @@
+package edu.arizona.kfs.fp.businessobject;
+
+import java.util.LinkedHashMap;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
+
+public class ProcurementCardTranNonFuel extends PersistableBusinessObjectBase {
+
+	private Integer transactionSequenceRowNumber;
+	private Integer sequenceRowNumber;
+	private String nonFuelProductCode;
+	private String itemDesc;
+	private String itemQuant;
+	private String itemUnitOfMeasure;
+	private String taxRateApplied;
+	private KualiDecimal itemTaxAmt;
+	private String alternateTaxId;
+	private KualiDecimal itemDiscountAmt;
+	private KualiDecimal itemTotal;
+	
+	public Integer getTransactionSequenceRowNumber() {
+		return transactionSequenceRowNumber;
+	}
+	
+	public void setTransactionSequenceRowNumber(Integer transactionSequenceRowNumber) {
+		this.transactionSequenceRowNumber = transactionSequenceRowNumber;
+	}
+	
+	public Integer getSequenceRowNumber() {
+		return sequenceRowNumber;
+	}
+	
+	public void setSequenceRowNumber(Integer sequenceRowNumber) {
+		this.sequenceRowNumber = sequenceRowNumber;
+	}
+	
+	public String getNonFuelProductCode() {
+		return nonFuelProductCode;
+	}
+	
+	public void setNonFuelProductCode(String nonFuelProductCode) {
+		this.nonFuelProductCode = nonFuelProductCode;
+	}
+	
+	public String getItemDesc() {
+		return itemDesc;
+	}
+	
+	public void setItemDesc(String itemDesc) {
+		this.itemDesc = itemDesc;
+	}
+	
+	public String getItemQuant() {
+		return itemQuant;
+	}
+	
+	public void setItemQuant(String itemQuant) {
+		this.itemQuant = itemQuant;
+	}
+	
+	public String getItemUnitOfMeasure() {
+		return itemUnitOfMeasure;
+	}
+	
+	public void setItemUnitOfMeasure(String itemUnitOfMeasure) {
+		this.itemUnitOfMeasure = itemUnitOfMeasure;
+	}
+	
+	public String getTaxRateApplied() {
+		return taxRateApplied;
+	}
+	
+	public void setTaxRateApplied(String taxRateApplied) {
+		this.taxRateApplied = taxRateApplied;
+	}
+	
+	public KualiDecimal getItemTaxAmt() {
+		return itemTaxAmt;
+	}
+	
+	public void setItemTaxAmt(KualiDecimal itemTaxAmt) {
+		this.itemTaxAmt = itemTaxAmt;
+	}
+	
+	public void setItemTaxAmt(String itemTaxAmt) {
+		if(StringUtils.isNotBlank(itemTaxAmt)) {
+			this.itemTaxAmt = new KualiDecimal(itemTaxAmt);
+		} else {
+			this.itemTaxAmt = KualiDecimal.ZERO;
+		}
+	}
+	
+	public String getAlternateTaxId() {
+		return alternateTaxId;
+	}
+	
+	public void setAlternateTaxId(String alternateTaxId) {
+		this.alternateTaxId = alternateTaxId;
+	}
+	
+	public KualiDecimal getItemDiscountAmt() {
+		return itemDiscountAmt;
+	}
+	
+	public void setItemDiscountAmt(KualiDecimal itemDiscountAmt) {
+		this.itemDiscountAmt = itemDiscountAmt;
+	}
+	
+	public void setItemDiscountAmt(String itemDiscountAmt) {
+		if(StringUtils.isNotBlank(itemDiscountAmt)) {
+			this.itemDiscountAmt = new KualiDecimal(itemDiscountAmt);
+		} else {
+			this.itemDiscountAmt = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getItemTotal() {
+		return itemTotal;
+	}
+	
+	public void setItemTotal(KualiDecimal itemTotal) {
+		this.itemTotal = itemTotal;
+	}
+	
+	public void setItemTotal(String itemTotal) {
+		if(StringUtils.isNotBlank(itemTotal)) {
+			this.itemTotal = new KualiDecimal(itemTotal);
+		} else {
+			this.itemTotal = KualiDecimal.ZERO;
+		}
+	}
+	
+	protected LinkedHashMap<String, Integer> toStringMapper() {
+		LinkedHashMap<String, Integer> m = new LinkedHashMap<String, Integer>();
+		m.put("transactionSequenceRowNumber", getTransactionSequenceRowNumber());
+		m.put("sequenceRowNumber", getSequenceRowNumber());
+		return m;
+	}
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardTranShipSvc.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardTranShipSvc.java
@@ -1,0 +1,247 @@
+package edu.arizona.kfs.fp.businessobject;
+
+import java.sql.Date;
+import java.util.LinkedHashMap;
+
+import org.apache.commons.beanutils.converters.SqlDateConverter;
+import org.apache.commons.lang.StringUtils;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
+
+public class ProcurementCardTranShipSvc extends PersistableBusinessObjectBase {
+
+	private Integer transactionSequenceRowNumber;
+	private Integer sequenceRowNumber;
+	private String courierName;
+	private String trackingNumber;
+	private String serviceDescription;
+	private Date pickupDate;
+	private String originZip;
+	private String originCountryCd;
+	private String destinationZip;
+	private String destinationCountryCd;
+	private KualiDecimal netAmount;
+	private KualiDecimal taxAmt;
+	private KualiDecimal discAmt;
+	private Integer numberOfPackages;
+	private String weight;
+	private String unitsOfMeasure;
+	private String senderName;
+	private String senderAddress;
+	private String receiverName;
+	private String receiverAddress;
+	private String customerRefNumber;
+	
+	public Integer getTransactionSequenceRowNumber() {
+		return transactionSequenceRowNumber;
+	}
+	
+	public void setTransactionSequenceRowNumber(Integer transactionSequenceRowNumber) {
+		this.transactionSequenceRowNumber = transactionSequenceRowNumber;
+	}
+	
+	public Integer getSequenceRowNumber() {
+		return sequenceRowNumber;
+	}
+	
+	public void setSequenceRowNumber(Integer sequenceRowNumber) {
+		this.sequenceRowNumber = sequenceRowNumber;
+	}
+	
+	public String getCourierName() {
+		return courierName;
+	}
+	
+	public void setCourierName(String courierName) {
+		this.courierName = courierName;
+	}
+	
+	public String getTrackingNumber() {
+		return trackingNumber;
+	}
+	
+	public void setTrackingNumber(String trackingNumber) {
+		this.trackingNumber = trackingNumber;
+	}
+	
+	public String getServiceDescription() {
+		return serviceDescription;
+	}
+	
+	public void setServiceDescription(String serviceDescription) {
+		this.serviceDescription = serviceDescription;
+	}
+	
+	public Date getPickupDate() {
+		return pickupDate;
+	}
+	
+	public void setPickupDate(Date pickupDate) {
+		this.pickupDate = pickupDate;
+	}
+	
+	public void setPickupDate(String pickupDate) {
+		if(StringUtils.isNotBlank(pickupDate)) {
+			this.pickupDate = (Date) (new SqlDateConverter()).convert(Date.class, pickupDate);
+		}
+	}
+	
+	public String getOriginZip() {
+		return originZip;
+	}
+	
+	public void setOriginZip(String originZip) {
+		this.originZip = originZip;
+	}
+	
+	public String getOriginCountryCd() {
+		return originCountryCd;
+	}
+	
+	public void setOriginCountryCd(String originCountryCd) {
+		this.originCountryCd = originCountryCd;
+	}
+	
+	public String getDestinationZip() {
+		return destinationZip;
+	}
+	
+	public void setDestinationZip(String destinationZip) {
+		this.destinationZip = destinationZip;
+	}
+	
+	public String getDestinationCountryCd() {
+		return destinationCountryCd;
+	}
+	
+	public void setDestinationCountryCd(String destinationCountryCd) {
+		this.destinationCountryCd = destinationCountryCd;
+	}
+	
+	public KualiDecimal getNetAmount() {
+		return netAmount;
+	}
+	
+	public void setNetAmount(KualiDecimal netAmount) {
+		this.netAmount = netAmount;
+	}
+	
+	public void setNetAmount(String netAmount) {
+		if(StringUtils.isNotBlank(netAmount)) {
+			this.netAmount = new KualiDecimal(netAmount);
+		} else {
+			this.netAmount = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getTaxAmt() {
+		return taxAmt;
+	}
+	
+	public void setTaxAmt(KualiDecimal taxAmt) {
+		this.taxAmt = taxAmt;
+	}
+	
+	public void setTaxAmt(String taxAmt) {
+		if(StringUtils.isNotBlank(taxAmt)) {
+			this.taxAmt = new KualiDecimal(taxAmt);
+		} else {
+			this.taxAmt = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getDiscAmt() {
+		return discAmt;
+	}
+	
+	public void setDiscAmt(KualiDecimal discAmt) {
+		this.discAmt = discAmt;
+	}
+	
+	public void setDiscAmt(String discAmt) {
+		if(StringUtils.isNotBlank(discAmt)) {
+			this.discAmt = new KualiDecimal(discAmt);
+		} else {
+			this.discAmt = KualiDecimal.ZERO;
+		}
+	}
+	
+	public Integer getNumberOfPackages() {
+		return numberOfPackages;
+	}
+	
+	public void setNumberOfPackages(Integer numberOfPackages) {
+		this.numberOfPackages = numberOfPackages;
+	}
+	
+	public void setNumberOfPackages(String numberOfPackages) {
+		if(StringUtils.isNotBlank(numberOfPackages)) {
+			this.numberOfPackages = new Integer(numberOfPackages);
+		} else {
+			this.numberOfPackages = 0;
+		}
+	}
+	
+	public String getWeight() {
+		return weight;
+	}
+	
+	public void setWeight(String weight) {
+		this.weight = weight;
+	}
+	
+	public String getUnitsOfMeasure() {
+		return unitsOfMeasure;
+	}
+	
+	public void setUnitsOfMeasure(String unitsOfMeasure) {
+		this.unitsOfMeasure = unitsOfMeasure;
+	}
+	
+	public String getSenderName() {
+		return senderName;
+	}
+	
+	public void setSenderName(String senderName) {
+		this.senderName = senderName;
+	}
+	
+	public String getSenderAddress() {
+		return senderAddress;
+	}
+	
+	public void setSenderAddress(String senderAddress) {
+		this.senderAddress = senderAddress;
+	}
+	
+	public String getReceiverName() {
+		return receiverName;
+	}
+	
+	public void setReceiverName(String receiverName) {
+		this.receiverName = receiverName;
+	}
+	
+	public String getReceiverAddress() {
+		return receiverAddress;
+	}
+	
+	public void setReceiverAddress(String receiverAddress) {
+		this.receiverAddress = receiverAddress;
+	}
+	
+	public String getCustomerRefNumber() {
+		return customerRefNumber;
+	}
+	
+	public void setCustomerRefNumber(String customerRefNumber) {
+		this.customerRefNumber = customerRefNumber;
+	}
+	
+	protected LinkedHashMap<String, Integer> toStringMapper() {
+		LinkedHashMap<String, Integer> m = new LinkedHashMap<String, Integer>();
+		m.put("transactionSequenceRowNumber", getTransactionSequenceRowNumber());
+		m.put("sequenceRowNumber", getSequenceRowNumber());
+		return m;
+	}
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardTranTempSvc.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardTranTempSvc.java
@@ -1,0 +1,258 @@
+package edu.arizona.kfs.fp.businessobject;
+
+import java.sql.Date;
+import java.util.LinkedHashMap;
+
+import org.apache.commons.beanutils.converters.SqlDateConverter;
+import org.apache.commons.lang.StringUtils;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
+
+public class ProcurementCardTranTempSvc extends PersistableBusinessObjectBase {
+
+	private Integer transactionSequenceRowNumber;
+	private Integer sequenceRowNumber;
+	private Date weekEndingDate;
+	private String serviceDesc;
+	private String employeeName;
+	private KualiDecimal regularRate;
+	private KualiDecimal regularHours;
+	private KualiDecimal overtimeRate;
+	private KualiDecimal overtimeHours;
+	private KualiDecimal miscExpenseAmt;
+	private KualiDecimal subTotalAmt;
+	private KualiDecimal salesTaxAmt;
+	private KualiDecimal discountAmt;
+	private Date startDate;
+	private String supervisor;
+	private String timeSheetNumber;
+	private String commodityCode;
+	private String jobCode;
+	
+	public Integer getTransactionSequenceRowNumber() {
+		return transactionSequenceRowNumber;
+	}
+	
+	public void setTransactionSequenceRowNumber(Integer transactionSequenceRowNumber) {
+		this.transactionSequenceRowNumber = transactionSequenceRowNumber;
+	}
+	
+	public Integer getSequenceRowNumber() {
+		return sequenceRowNumber;
+	}
+	
+	public void setSequenceRowNumber(Integer sequenceRowNumber) {
+		this.sequenceRowNumber = sequenceRowNumber;
+	}
+	
+	public Date getWeekEndingDate() {
+		return weekEndingDate;
+	}
+	
+	public void setWeekEndingDate(Date weekEndingDate) {
+		this.weekEndingDate = weekEndingDate;
+	}
+	
+	public void setWeekEndingDate(String weekEndingDate) {
+		if(StringUtils.isNotBlank(weekEndingDate)) {
+			this.weekEndingDate = (Date) (new SqlDateConverter()).convert(Date.class, weekEndingDate);
+		}
+	}
+	
+	public String getServiceDesc() {
+		return serviceDesc;
+	}
+	
+	public void setServiceDesc(String serviceDesc) {
+		this.serviceDesc = serviceDesc;
+	}
+	
+	public String getEmployeeName() {
+		return employeeName;
+	}
+	
+	public void setEmployeeName(String employeeName) {
+		this.employeeName = employeeName;
+	}
+	
+	public KualiDecimal getRegularRate() {
+		return regularRate;
+	}
+	
+	public void setRegularRate(KualiDecimal regularRate) {
+		this.regularRate = regularRate;
+	}
+	
+	public void setRegularRate(String regularRate) {
+		if(StringUtils.isNotBlank(regularRate)) {
+			this.regularRate = new KualiDecimal(regularRate);
+		} else {
+			this.regularRate = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getRegularHours() {
+		return regularHours;
+	}
+	
+	public void setRegularHours(KualiDecimal regularHours) {
+		this.regularHours = regularHours;
+	}
+	
+	public void setRegularHours(String regularHours) {
+		if(StringUtils.isNotBlank(regularHours)) {
+			this.regularHours = new KualiDecimal(regularHours);
+		} else {
+			this.regularHours = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getOvertimeRate() {
+		return overtimeRate;
+	}
+	
+	public void setOvertimeRate(KualiDecimal overtimeRate) {
+		this.overtimeRate = overtimeRate;
+	}
+	
+	public void setOvertimeRate(String overtimeRate) {
+		if(StringUtils.isNotBlank(overtimeRate)) {
+			this.overtimeRate = new KualiDecimal(overtimeRate);
+		} else {
+			this.overtimeRate = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getOvertimeHours() {
+		return overtimeHours;
+	}
+	
+	public void setOvertimeHours(KualiDecimal overtimeHours) {
+		this.overtimeHours = overtimeHours;
+	}
+	
+	public void setOvertimeHours(String overtimeHours) {
+		if(StringUtils.isNotBlank(overtimeHours)) {
+			this.overtimeHours = new KualiDecimal(overtimeHours);
+		} else {
+			this.overtimeHours = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getMiscExpenseAmt() {
+		return miscExpenseAmt;
+	}
+	
+	public void setMiscExpenseAmt(KualiDecimal miscExpenseAmt) {
+		this.miscExpenseAmt = miscExpenseAmt;
+	}
+	
+	public void setMiscExpenseAmt(String miscExpenseAmt) {
+		if(StringUtils.isNotBlank(miscExpenseAmt)) {
+			this.miscExpenseAmt = new KualiDecimal(miscExpenseAmt);
+		} else {
+			this.miscExpenseAmt = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getSubTotalAmt() {
+		return subTotalAmt;
+	}
+	
+	public void setSubTotalAmt(KualiDecimal subTotalAmt) {
+		this.subTotalAmt = subTotalAmt;
+	}
+	
+	public void setSubTotalAmt(String subTotalAmt) {
+		if(StringUtils.isNotBlank(subTotalAmt)) {
+			this.subTotalAmt = new KualiDecimal(subTotalAmt);
+		} else {
+			this.subTotalAmt = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getSalesTaxAmt() {
+		return salesTaxAmt;
+	}
+	
+	public void setSalesTaxAmt(KualiDecimal salesTaxAmt) {
+		this.salesTaxAmt = salesTaxAmt;
+	}
+	
+	public void setSalesTaxAmount(String salesTaxAmt) {
+		if(StringUtils.isNotBlank(salesTaxAmt)) {
+			this.salesTaxAmt = new KualiDecimal(salesTaxAmt);
+		} else {
+			this.salesTaxAmt = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getDiscountAmt() {
+		return discountAmt;
+	}
+	
+	public void setDiscountAmt(KualiDecimal discountAmt) {
+		this.discountAmt = discountAmt;
+	}
+	
+	public void setDiscountAmt(String discountAmt) {
+		if(StringUtils.isNotBlank(discountAmt)) {
+			this.discountAmt = new KualiDecimal(discountAmt);
+		} else {
+			this.discountAmt = KualiDecimal.ZERO;
+		}
+	}
+	
+	public Date getStartDate() {
+		return startDate;
+	}
+	
+	public void setStartDate(Date startDate) {
+		this.startDate = startDate;
+	}
+	
+	public void setStartDate(String startDate) {
+		if(StringUtils.isNotBlank(startDate)) {
+			this.startDate = (Date) (new SqlDateConverter()).convert(Date.class, startDate);
+		}
+	}
+	
+	public String getSupervisor() {
+		return supervisor;
+	}
+	
+	public void setSupervisor(String supervisor) {
+		this.supervisor = supervisor;
+	}
+	
+	public String getTimeSheetNumber() {
+		return timeSheetNumber;
+	}
+	
+	public void setTimeSheetNumber(String timeSheetNumber) {
+		this.timeSheetNumber = timeSheetNumber;
+	}
+	
+	public String getCommodityCode() {
+		return commodityCode;
+	}
+	
+	public void setCommodityCode(String commodityCode) {
+		this.commodityCode = commodityCode;
+	}
+	
+	public String getJobCode() {
+		return jobCode;
+	}
+	
+	public void setJobCode(String jobCode) {
+		this.jobCode = jobCode;
+	}
+	
+	protected LinkedHashMap<String, Integer> toStringMapper() {
+		LinkedHashMap<String, Integer> m = new LinkedHashMap<String, Integer>();
+		m.put("transactionSequenceRowNumber", getTransactionSequenceRowNumber());
+		m.put("sequenceRowNumber", getSequenceRowNumber());
+		return m;
+	}
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardTranTransportLeg.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardTranTransportLeg.java
@@ -1,0 +1,213 @@
+package edu.arizona.kfs.fp.businessobject;
+
+import java.util.LinkedHashMap;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
+
+public class ProcurementCardTranTransportLeg extends PersistableBusinessObjectBase {
+
+	private Integer transactionSequenceRowNumber;
+	private Integer sequenceRowNumber;
+	private String carrierCode;
+	private String serviceClass;
+	private String departCity;
+	private String conjunctionTicket;
+	private String exchangeTicket;
+	private String destinationCity;
+	private String fareBasisCode;
+	private String flightNumber;
+	private String departTime;
+	private String departTimeSegment;
+	private String arriveTime;
+	private String arriveTimeSegment;
+	private KualiDecimal fare;
+	private KualiDecimal fees;
+	private KualiDecimal taxes;
+	private String endorsements;
+	private String controlCode;
+	
+	public Integer getTransactionSequenceRowNumber() {
+		return transactionSequenceRowNumber;
+	}
+	
+	public void setTransactionSequenceRowNumber(Integer transactionSequenceRowNumber) {
+		this.transactionSequenceRowNumber = transactionSequenceRowNumber;
+	}
+	
+	public Integer getSequenceRowNumber() {
+		return sequenceRowNumber;
+	}
+	
+	public void setSequenceRowNumber(Integer sequenceRowNumber) {
+		this.sequenceRowNumber = sequenceRowNumber;
+	}
+	
+	public String getCarrierCode() {
+		return carrierCode;
+	}
+	
+	public void setCarrierCode(String carrierCode) {
+		this.carrierCode = carrierCode;
+	}
+	
+	public String getServiceClass() {
+		return serviceClass;
+	}
+	
+	public void setServiceClass(String serviceClass) {
+		this.serviceClass = serviceClass;
+	}
+	
+	public String getDepartCity() {
+		return departCity;
+	}
+	
+	public void setDepartCity(String departCity) {
+		this.departCity = departCity;
+	}
+	
+	public String getConjunctionTicket() {
+		return conjunctionTicket;
+	}
+	
+	public void setConjunctionTicket(String conjunctionTicket) {
+		this.conjunctionTicket = conjunctionTicket;
+	}
+	
+	public String getExchangeTicket() {
+		return exchangeTicket;
+	}
+	
+	public void setExchangeTicket(String exchangeTicket) {
+		this.exchangeTicket = exchangeTicket;
+	}
+	
+	public String getDestinationCity() {
+		return destinationCity;
+	}
+	
+	public void setDestinationCity(String destinationCity) {
+		this.destinationCity = destinationCity;
+	}
+	
+	public String getFareBasisCode() {
+		return fareBasisCode;
+	}
+	
+	public void setFareBasisCode(String fareBasisCode) {
+		this.fareBasisCode = fareBasisCode;
+	}
+	
+	public String getFlightNumber() {
+		return flightNumber;
+	}
+	
+	public void setFlightNumber(String flightNumber) {
+		this.flightNumber = flightNumber;
+	}
+	
+	public String getDepartTime() {
+		return departTime;
+	}
+	
+	public void setDepartTime(String departTime) {
+		this.departTime = departTime;
+	}
+	
+	public String getDepartTimeSegment() {
+		return departTimeSegment;
+	}
+	
+	public void setDepartTimeSegment(String departTimeSegment) {
+		this.departTimeSegment = departTimeSegment;
+	}
+	
+	public String getArriveTime() {
+		return arriveTime;
+	}
+	
+	public void setArriveTime(String arriveTime) {
+		this.arriveTime = arriveTime;
+	}
+	
+	public String getArriveTimeSegment() {
+		return arriveTimeSegment;
+	}
+	
+	public void setArriveTimeSegment(String arriveTimeSegment) {
+		this.arriveTimeSegment = arriveTimeSegment;
+	}
+	
+	public KualiDecimal getFare() {
+		return fare;
+	}
+	
+	public void setFare(KualiDecimal fare) {
+		this.fare = fare;
+	}
+	
+	public void setFare(String fare) {
+		if(StringUtils.isNotBlank(fare)) {
+			this.fare = new KualiDecimal(fare);
+		} else {
+			this.fare = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getFees() {
+		return fees;
+	}
+	
+	public void setFees(KualiDecimal fees) {
+		this.fees = fees;
+	}
+	
+	public void setFees(String fees) {
+		if(StringUtils.isNotBlank(fees)) {
+			this.fees = new KualiDecimal(fees);
+		} else {
+			this.fees = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getTaxes() {
+		return taxes;
+	}
+	
+	public void setTaxes(KualiDecimal taxes) {
+		this.taxes = taxes;
+	}
+	
+	public void setTaxes(String taxes) {
+		if(StringUtils.isNotBlank(taxes)) {
+			this.taxes = new KualiDecimal(taxes);
+		} else {
+			this.taxes = KualiDecimal.ZERO;
+		}
+	}
+	
+	public String getEndorsements() {
+		return endorsements;
+	}
+	
+	public void setEndorsements(String endorsements) {
+		this.endorsements = endorsements;
+	}
+	
+	public String getControlCode() {
+		return controlCode;
+	}
+	
+	public void setControlCode(String controlCode) {
+		this.controlCode = controlCode;
+	}
+	
+	protected LinkedHashMap<String, Integer> toStringMapper() {
+		LinkedHashMap<String, Integer> m = new LinkedHashMap<String, Integer>();
+		m.put("transactionSequenceRowNumber", getTransactionSequenceRowNumber());
+		m.put("sequenceRowNumber", getSequenceRowNumber());
+		return m;
+	}
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardTransaction.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardTransaction.java
@@ -1,0 +1,2014 @@
+package edu.arizona.kfs.fp.businessobject;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import org.apache.commons.beanutils.converters.SqlDateConverter;
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
+
+public class ProcurementCardTransaction extends PersistableBusinessObjectBase {
+
+	private Integer transactionSequenceRowNumber;
+	private String transactionCreditCardNumber;
+	private KualiDecimal financialDocumentTotalAmount;
+	private String transactionDebitCreditCode;
+	private String chartOfAccountsCode;
+	private String accountNumber;
+	private String subAccountNumber;
+	private String financialObjectCode;
+	private String financialSubObjectCode;
+	private String projectCode;
+	private Date transactionCycleStartDate;
+	private Date transactionCycleEndDate;
+	private String cardHolderName;
+	private Date transactionDate;
+	private String transactionReferenceNumber;
+	private String transactionMerchantCategoryCode;
+	private Date transactionPostingDate;
+	private String transactionOriginalCurrencyCode;
+	private String transactionBillingCurrencyCode;
+	private KualiDecimal transactionOriginalCurrencyAmount;
+	private BigDecimal transactionCurrencyExchangeRate;
+	private KualiDecimal transactionSettlementAmount;
+	private KualiDecimal transactionSalesTaxAmount;
+	private boolean transactionTaxExemptIndicator;
+	private boolean transactionPurchaseIdentifierIndicator;
+	private String transactionPurchaseIdentifierDescription;
+	private String transactionUnitContactName;
+	private String transactionTravelAuthorizationCode;
+	private String transactionPointOfSaleCode;
+	private String vendorName;
+	private String vendorLine1Address;
+	private String vendorLine2Address;
+	private String vendorCityName;
+	private String vendorStateCode;
+	private String vendorZipCode;
+	private String vendorOrderNumber;
+	private String visaVendorIdentifier;
+	private String cardHolderAlternateName;
+	private String cardHolderLine1Address;
+	private String cardHolderLine2Address;
+	private String cardHolderCityName;
+	private String cardHolderStateCode;
+	private String cardHolderZipCode;
+	private String cardHolderWorkPhoneNumber;
+	private KualiDecimal cardLimit;
+	private KualiDecimal cardCycleAmountLimit;
+	private KualiDecimal cardCycleVolumeLimit;
+	private String cardStatusCode;
+	private String cardNoteText;
+ // Procurement Card Level 3 Addendum Header Data
+	private String invoiceNumber;
+	private Date orderDate;
+	private String purchaseTime;
+	private String shipPostal;
+	private String destinationPostal;
+	private String destinationCountryCode;
+	private KualiDecimal taxAmount;
+	private KualiDecimal taxRate;
+	private KualiDecimal discountAmount;
+	private KualiDecimal freightAmount;
+	private KualiDecimal dutyAmount;
+ // Procurement Card Level 3 User Amounts data
+	private Date userEffectiveDate;
+	private KualiDecimal userAmount;
+ // Procurement Card Level 3 Fuel data
+	private String oilBrandName;
+	private String odometerReading;
+	private String fleetId;
+	private String messageId;
+	private String usage;
+	private String fuelServiceType;
+	private String fuelProductCd;
+	private String productTypeCd;
+	private BigDecimal fuelQuantity;
+	private Integer fuelUnitOfMeasure;
+	private KualiDecimal fuelUnitPrice;
+	private KualiDecimal fuelSaleAmount;
+	private KualiDecimal fuelDiscountAmount;
+	private KualiDecimal taxAmount1;
+	private KualiDecimal taxAmount2;
+	private KualiDecimal totalAmount;
+ // Procurement Card Level 3 Generic data
+	private Date genericEffectiveDate;
+	private String genericData;
+ // Procurement Card Level 3 Lodging data
+	private Date arriveDate;
+	private Date departureDate;
+	private String folioNum;
+	private String propertyPhoneNum;
+	private String customerServiceNum;
+	private KualiDecimal prePaidAmt;
+	private KualiDecimal roomRate;
+	private KualiDecimal roomTax;
+	private String programCode;
+	private KualiDecimal callCharges;
+	private KualiDecimal foodSvcCharges;
+	private KualiDecimal miniBarCharges;
+	private KualiDecimal giftShopCharges;
+	private KualiDecimal laundryCharges;
+	private KualiDecimal healthClubCharges;
+	private KualiDecimal movieCharges;
+	private KualiDecimal busCtrCharges;
+	private KualiDecimal parkingCharges;
+	private String otherCode;
+	private KualiDecimal otherCharges;
+	private KualiDecimal adjustmentAmount;
+ // Procurement Card Level 3 Car Rental data
+	private Date checkOutDate;
+	private String rentalAgreementNum;
+	private String renterName;
+	private String returnCity;
+	private String returnState;
+	private String returnCountry;
+	private Date returnDate;
+	private String returnLocation;
+	private String customerSvcNum;
+	private String rentalClass;
+	private KualiDecimal dailyRate;
+	private KualiDecimal weeklyRate;
+	private KualiDecimal ratePerMile;
+	private Integer maxFreeMiles;
+	private Integer totalMiles;
+	private KualiDecimal oneWayCharges;
+	private KualiDecimal insuranceCharges;
+	private KualiDecimal regularCharges;
+	private KualiDecimal towingCharges;
+	private KualiDecimal extraCharges;
+	private KualiDecimal lateReturnFee;
+	private String adjustCode;
+	private KualiDecimal adjustAmount;
+	private String progCode;
+	private KualiDecimal phoneCharges;
+	private KualiDecimal othrCharges;
+	private KualiDecimal totalTaxAmount;
+ // Procurement Card Level 3 Transport data
+	private String passengerName;
+	private Date departDate;
+	private String departureCity;
+	private String agencyCode;
+	private String agencyName;
+	private long ticketNumber;
+	private String customerCode;
+	private Date issueDate;
+	private String issuingCarrier;
+	private KualiDecimal totalFare;
+	private KualiDecimal totalFees;
+	private KualiDecimal totalTaxes;
+	
+	private List<ProcurementCardTranAddItem> procurementCardTranAddItems;
+	private List<ProcurementCardTranNonFuel> procurementCardTranNonFuels;
+	private List<ProcurementCardTranShipSvc> procurementCardTranShipSvcs;
+	private List<ProcurementCardTranTempSvc> procurementCardTranTempSvcs;
+	private List<ProcurementCardTranTransportLeg> procurementCardTranTransportLegs;
+	
+	public ProcurementCardTransaction() {
+		procurementCardTranAddItems = new ArrayList<ProcurementCardTranAddItem>();
+		procurementCardTranNonFuels = new ArrayList<ProcurementCardTranNonFuel>();
+		procurementCardTranShipSvcs = new ArrayList<ProcurementCardTranShipSvc>();
+		procurementCardTranTempSvcs = new ArrayList<ProcurementCardTranTempSvc>();
+		procurementCardTranTransportLegs = new ArrayList<ProcurementCardTranTransportLeg>();
+	}
+
+	public Integer getTransactionSequenceRowNumber() {
+		return transactionSequenceRowNumber;
+	}
+
+	public void setTransactionSequenceRowNumber(Integer transactionSequenceRowNumber) {
+		this.transactionSequenceRowNumber = transactionSequenceRowNumber;
+	}
+
+	public String getTransactionCreditCardNumber() {
+		return transactionCreditCardNumber;
+	}
+
+	public void setTransactionCreditCardNumber(String transactionCreditCardNumber) {
+		this.transactionCreditCardNumber = transactionCreditCardNumber;
+	}
+
+	public KualiDecimal getFinancialDocumentTotalAmount() {
+		return financialDocumentTotalAmount;
+	}
+
+	public void setFinancialDocumentTotalAmount(KualiDecimal financialDocumentTotalAmount) {
+		this.financialDocumentTotalAmount = financialDocumentTotalAmount;
+	}
+
+	public void setFinancialDocumentTotalAmount(String financialDocumentTotalAmount) {
+		if(StringUtils.isNotBlank(financialDocumentTotalAmount)) {
+			this.financialDocumentTotalAmount = new KualiDecimal(financialDocumentTotalAmount);
+		} else {
+			this.financialDocumentTotalAmount = KualiDecimal.ZERO;
+		}
+	}
+	
+	public String getTransactionDebitCreditCode() {
+		return transactionDebitCreditCode;
+	}
+
+	public void setTransactionDebitCreditCode(String transactionDebitCreditCode) {
+		this.transactionDebitCreditCode = transactionDebitCreditCode;
+	}
+
+	public String getChartOfAccountsCode() {
+		return chartOfAccountsCode;
+	}
+
+	public void setChartOfAccountsCode(String chartOfAccountsCode) {
+		this.chartOfAccountsCode = chartOfAccountsCode;
+	}
+
+	public String getAccountNumber() {
+		return accountNumber;
+	}
+
+	public void setAccountNumber(String accountNumber) {
+		this.accountNumber = accountNumber;
+	}
+
+	public String getSubAccountNumber() {
+		return subAccountNumber;
+	}
+
+	public void setSubAccountNumber(String subAccountNumber) {
+		this.subAccountNumber = subAccountNumber;
+	}
+
+	public String getFinancialObjectCode() {
+		return financialObjectCode;
+	}
+
+	public void setFinancialObjectCode(String financialObjectCode) {
+		this.financialObjectCode = financialObjectCode;
+	}
+
+	public String getFinancialSubObjectCode() {
+		return financialSubObjectCode;
+	}
+
+	public void setFinancialSubObjectCode(String financialSubObjectCode) {
+		this.financialSubObjectCode = financialSubObjectCode;
+	}
+
+	public String getProjectCode() {
+		return projectCode;
+	}
+
+	public void setProjectCode(String projectCode) {
+		this.projectCode = projectCode;
+	}
+
+	public Date getTransactionCycleStartDate() {
+		return transactionCycleStartDate;
+	}
+
+	public void setTransactionCycleStartDate(Date transactionCycleStartDate) {
+		this.transactionCycleStartDate = transactionCycleStartDate;
+	}
+	
+	public void setTransactionCycleStartDate(String transactionCycleStartDate) {
+		if(StringUtils.isNotBlank(transactionCycleStartDate)) {
+			this.transactionCycleStartDate = (Date) (new SqlDateConverter()).convert(Date.class, transactionCycleStartDate);
+		}
+	}
+
+	public Date getTransactionCycleEndDate() {
+		return transactionCycleEndDate;
+	}
+
+	public void setTransactionCycleEndDate(Date transactionCycleEndDate) {
+		this.transactionCycleEndDate = transactionCycleEndDate;
+	}
+	
+	public void setTransactionCycleEndDate(String transactionCycleEndDate) {
+		if(StringUtils.isNotBlank(transactionCycleEndDate)) {
+			this.transactionCycleEndDate = (Date) (new SqlDateConverter()).convert(Date.class, transactionCycleEndDate);
+		}
+	}
+
+	public String getCardHolderName() {
+		return cardHolderName;
+	}
+
+	public void setCardHolderName(String cardHolderName) {
+		this.cardHolderName = cardHolderName;
+	}
+
+	public Date getTransactionDate() {
+		return transactionDate;
+	}
+
+	public void setTransactionDate(Date transactionDate) {
+		this.transactionDate = transactionDate;
+	}
+
+	public String getTransactionReferenceNumber() {
+		return transactionReferenceNumber;
+	}
+
+	public void setTransactionReferenceNumber(String transactionReferenceNumber) {
+		this.transactionReferenceNumber = transactionReferenceNumber;
+	}
+
+	public String getTransactionMerchantCategoryCode() {
+		return transactionMerchantCategoryCode;
+	}
+
+	public void setTransactionMerchantCategoryCode(String transactionMerchantCategoryCode) {
+		this.transactionMerchantCategoryCode = transactionMerchantCategoryCode;
+	}
+
+	public Date getTransactionPostingDate() {
+		return transactionPostingDate;
+	}
+
+	public void setTransactionPostingDate(Date transactionPostingDate) {
+		this.transactionPostingDate = transactionPostingDate;
+	}
+
+	public String getTransactionOriginalCurrencyCode() {
+		return transactionOriginalCurrencyCode;
+	}
+
+	public void setTransactionOriginalCurrencyCode(String transactionOriginalCurrencyCode) {
+		this.transactionOriginalCurrencyCode = transactionOriginalCurrencyCode;
+	}
+
+	public String getTransactionBillingCurrencyCode() {
+		return transactionBillingCurrencyCode;
+	}
+
+	public void setTransactionBillingCurrencyCode(String transactionBillingCurrencyCode) {
+		this.transactionBillingCurrencyCode = transactionBillingCurrencyCode;
+	}
+
+	public KualiDecimal getTransactionOriginalCurrencyAmount() {
+		return transactionOriginalCurrencyAmount;
+	}
+
+	public void setTransactionOriginalCurrencyAmount(KualiDecimal transactionOriginalCurrencyAmount) {
+		this.transactionOriginalCurrencyAmount = transactionOriginalCurrencyAmount;
+	}
+	
+	public void setTransactionOriginalCurrencyAmount(String transactionOriginalCurrencyAmount) {
+		if(StringUtils.isNotBlank(transactionOriginalCurrencyAmount)) {
+			this.transactionOriginalCurrencyAmount = new KualiDecimal(transactionOriginalCurrencyAmount);
+		} else {
+			this.transactionOriginalCurrencyAmount = KualiDecimal.ZERO;
+		}
+	}
+
+	public BigDecimal getTransactionCurrencyExchangeRate() {
+		return transactionCurrencyExchangeRate;
+	}
+
+	public void setTransactionCurrencyExchangeRate(BigDecimal transactionCurrencyExchangeRate) {
+		this.transactionCurrencyExchangeRate = transactionCurrencyExchangeRate;
+	}
+
+	public void setTransactionCurrencyExchangeRate(String transactionCurrencyExchangeRate) {
+		if(StringUtils.isNotBlank(transactionCurrencyExchangeRate)) {
+			this.transactionCurrencyExchangeRate = new BigDecimal(transactionCurrencyExchangeRate);
+		} else {
+			this.transactionCurrencyExchangeRate = new BigDecimal(0);
+		}
+	}
+	
+	public KualiDecimal getTransactionSettlementAmount() {
+		return transactionSettlementAmount;
+	}
+
+	public void setTransactionSettlementAmount(KualiDecimal transactionSettlementAmount) {
+		this.transactionSettlementAmount = transactionSettlementAmount;
+	}
+
+	public void setTransactionSettlementAmount(String transactionSettlementAmount) {
+		if(StringUtils.isNotBlank(transactionSettlementAmount)) {
+			this.transactionSettlementAmount = new KualiDecimal(transactionSettlementAmount);
+		} else {
+			this.transactionSettlementAmount = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getTransactionSalesTaxAmount() {
+		return transactionSalesTaxAmount;
+	}
+
+	public void setTransactionSalesTaxAmount(KualiDecimal transactionSalesTaxAmount) {
+		this.transactionSalesTaxAmount = transactionSalesTaxAmount;
+	}
+
+	public void setTransactionSalesTaxAmount(String transactionSalesTaxAmount) {
+		if(StringUtils.isNotBlank(transactionSalesTaxAmount)) {
+			this.transactionSalesTaxAmount = new KualiDecimal(transactionSalesTaxAmount);
+		} else {
+			this.transactionSalesTaxAmount = KualiDecimal.ZERO;
+		}
+	}
+	
+	public boolean getTransactionTaxExemptIndicator() {
+        return transactionTaxExemptIndicator;
+    }
+
+	public void setTransactionTaxExemptIndicator(boolean transactionTaxExemptIndicator) {
+		this.transactionTaxExemptIndicator = transactionTaxExemptIndicator;
+	}
+
+	public void setTransactionTaxExemptIndicator(String transactionTaxExemptIndicator) {
+		if(KFSConstants.ACTIVE_INDICATOR.equals(transactionTaxExemptIndicator)) {
+			this.transactionTaxExemptIndicator = true;
+		} else {
+			this.transactionTaxExemptIndicator = false;
+		}
+	}
+		
+    public boolean getTransactionPurchaseIdentifierIndicator() {
+        return transactionPurchaseIdentifierIndicator;
+    }
+
+	public void setTransactionPurchaseIdentifierIndicator(boolean transactionPurchaseIdentifierIndicator) {
+		this.transactionPurchaseIdentifierIndicator = transactionPurchaseIdentifierIndicator;
+	}
+	
+	public void setTransactionPurchaseIdentifierIndicator(String transactionPurchaseIdentifierIndicator) {
+		if(KFSConstants.ACTIVE_INDICATOR.equals(transactionPurchaseIdentifierIndicator)) {
+			this.transactionPurchaseIdentifierIndicator = true;
+		} else {
+			this.transactionPurchaseIdentifierIndicator = false;
+		}
+	}
+
+	public String getTransactionPurchaseIdentifierDescription() {
+		return transactionPurchaseIdentifierDescription;
+	}
+
+	public void setTransactionPurchaseIdentifierDescription(String transactionPurchaseIdentifierDescription) {
+		this.transactionPurchaseIdentifierDescription = transactionPurchaseIdentifierDescription;
+	}
+
+	public String getTransactionUnitContactName() {
+		return transactionUnitContactName;
+	}
+
+	public void setTransactionUnitContactName(String transactionUnitContactName) {
+		this.transactionUnitContactName = transactionUnitContactName;
+	}
+
+	public String getTransactionTravelAuthorizationCode() {
+		return transactionTravelAuthorizationCode;
+	}
+
+	public void setTransactionTravelAuthorizationCode(String transactionTravelAuthorizationCode) {
+		this.transactionTravelAuthorizationCode = transactionTravelAuthorizationCode;
+	}
+
+	public String getTransactionPointOfSaleCode() {
+		return transactionPointOfSaleCode;
+	}
+
+	public void setTransactionPointOfSaleCode(String transactionPointOfSaleCode) {
+		this.transactionPointOfSaleCode = transactionPointOfSaleCode;
+	}
+
+	public String getVendorName() {
+		return vendorName;
+	}
+
+	public void setVendorName(String vendorName) {
+		this.vendorName = vendorName;
+	}
+
+	public String getVendorLine1Address() {
+		return vendorLine1Address;
+	}
+
+	public void setVendorLine1Address(String vendorLine1Address) {
+		this.vendorLine1Address = vendorLine1Address;
+	}
+
+	public String getVendorLine2Address() {
+		return vendorLine2Address;
+	}
+
+	public void setVendorLine2Address(String vendorLine2Address) {
+		this.vendorLine2Address = vendorLine2Address;
+	}
+
+	public String getVendorCityName() {
+		return vendorCityName;
+	}
+
+	public void setVendorCityName(String vendorCityName) {
+		this.vendorCityName = vendorCityName;
+	}
+
+	public String getVendorStateCode() {
+		return vendorStateCode;
+	}
+
+	public void setVendorStateCode(String vendorStateCode) {
+		this.vendorStateCode = vendorStateCode;
+	}
+
+	public String getVendorZipCode() {
+		return vendorZipCode;
+	}
+
+	public void setVendorZipCode(String vendorZipCode) {
+		this.vendorZipCode = vendorZipCode;
+	}
+
+	public String getVendorOrderNumber() {
+		return vendorOrderNumber;
+	}
+
+	public void setVendorOrderNumber(String vendorOrderNumber) {
+		this.vendorOrderNumber = vendorOrderNumber;
+	}
+
+	public String getVisaVendorIdentifier() {
+		return visaVendorIdentifier;
+	}
+
+	public void setVisaVendorIdentifier(String visaVendorIdentifier) {
+		this.visaVendorIdentifier = visaVendorIdentifier;
+	}
+
+	public String getCardHolderAlternateName() {
+		return cardHolderAlternateName;
+	}
+
+	public void setCardHolderAlternateName(String cardHolderAlternateName) {
+		this.cardHolderAlternateName = cardHolderAlternateName;
+	}
+
+	public String getCardHolderLine1Address() {
+		return cardHolderLine1Address;
+	}
+
+	public void setCardHolderLine1Address(String cardHolderLine1Address) {
+		this.cardHolderLine1Address = cardHolderLine1Address;
+	}
+
+	public String getCardHolderLine2Address() {
+		return cardHolderLine2Address;
+	}
+
+	public void setCardHolderLine2Address(String cardHolderLine2Address) {
+		this.cardHolderLine2Address = cardHolderLine2Address;
+	}
+
+	public String getCardHolderCityName() {
+		return cardHolderCityName;
+	}
+
+	public void setCardHolderCityName(String cardHolderCityName) {
+		this.cardHolderCityName = cardHolderCityName;
+	}
+
+	public String getCardHolderStateCode() {
+		return cardHolderStateCode;
+	}
+
+	public void setCardHolderStateCode(String cardHolderStateCode) {
+		this.cardHolderStateCode = cardHolderStateCode;
+	}
+
+	public String getCardHolderZipCode() {
+		return cardHolderZipCode;
+	}
+
+	public void setCardHolderZipCode(String cardHolderZipCode) {
+		this.cardHolderZipCode = cardHolderZipCode;
+	}
+
+	public String getCardHolderWorkPhoneNumber() {
+		return cardHolderWorkPhoneNumber;
+	}
+
+	public void setCardHolderWorkPhoneNumber(String cardHolderWorkPhoneNumber) {
+		this.cardHolderWorkPhoneNumber = cardHolderWorkPhoneNumber;
+	}
+
+	public KualiDecimal getCardLimit() {
+		return cardLimit;
+	}
+
+	public void setCardLimit(KualiDecimal cardLimit) {
+		this.cardLimit = cardLimit;
+	}
+	
+	public void setCardLimit(String cardLimit) {
+		if (StringUtils.isNotBlank(cardLimit)) {
+			this.cardLimit = new KualiDecimal(cardLimit);
+		} else {
+			this.cardLimit = KualiDecimal.ZERO;
+		}
+	}
+
+	public KualiDecimal getCardCycleAmountLimit() {
+		return cardCycleAmountLimit;
+	}
+
+	public void setCardCycleAmountLimit(KualiDecimal cardCycleAmountLimit) {
+		this.cardCycleAmountLimit = cardCycleAmountLimit;
+	}
+	
+	public void setCardCycleAmountLimit(String cardCycleAmountLimit) {
+		if (StringUtils.isNotBlank(cardCycleAmountLimit)) {
+			this.cardCycleAmountLimit = new KualiDecimal(cardCycleAmountLimit);
+		} else {
+			this.cardCycleAmountLimit = KualiDecimal.ZERO;
+		}
+	}
+
+	public KualiDecimal getCardCycleVolumeLimit() {
+		return cardCycleVolumeLimit;
+	}
+
+	public void setCardCycleVolumeLimit(KualiDecimal cardCycleVolumeLimit) {
+		this.cardCycleVolumeLimit = cardCycleVolumeLimit;
+	}
+
+	public void setCardCycleVolumeLimit(String cardCycleVolumeLimit) {
+		if(StringUtils.isNotBlank(cardCycleVolumeLimit)) {
+			this.cardCycleVolumeLimit = new KualiDecimal(cardCycleVolumeLimit);
+		} else {
+			this.cardCycleVolumeLimit = KualiDecimal.ZERO;
+		}
+	}
+	
+	public String getCardStatusCode() {
+		return cardStatusCode;
+	}
+
+	public void setCardStatusCode(String cardStatusCode) {
+		this.cardStatusCode = cardStatusCode;
+	}
+
+	public String getCardNoteText() {
+		return cardNoteText;
+	}
+
+	public void setCardNoteText(String cardNoteText) {
+		this.cardNoteText = cardNoteText;
+	}
+
+	public String getInvoiceNumber() {
+		return invoiceNumber;
+	}
+
+	public void setInvoiceNumber(String invoiceNumber) {
+		this.invoiceNumber = invoiceNumber;
+	}
+
+	public Date getOrderDate() {
+		return orderDate;
+	}
+
+	public void setOrderDate(Date orderDate) {
+		this.orderDate = orderDate;
+	}
+
+	public void setOrderDate(String orderDate) {
+		if(StringUtils.isNotBlank(orderDate)) {
+			this.orderDate = (Date) (new SqlDateConverter()).convert(Date.class, orderDate);
+		}
+	}
+	
+	public String getPurchaseTime() {
+		return purchaseTime;
+	}
+
+	public void setPurchaseTime(String purchaseTime) {
+		this.purchaseTime = purchaseTime;
+	}
+
+	public String getShipPostal() {
+		return shipPostal;
+	}
+
+	public void setShipPostal(String shipPostal) {
+		this.shipPostal = shipPostal;
+	}
+
+	public String getDestinationPostal() {
+		return destinationPostal;
+	}
+
+	public void setDestinationPostal(String destinationPostal) {
+		this.destinationPostal = destinationPostal;
+	}
+
+	public String getDestinationCountryCode() {
+		return destinationCountryCode;
+	}
+
+	public void setDestinationCountryCode(String destinationCountryCode) {
+		this.destinationCountryCode = destinationCountryCode;
+	}
+
+	public KualiDecimal getTaxAmount() {
+		return taxAmount;
+	}
+
+	public void setTaxAmount(KualiDecimal taxAmount) {
+		this.taxAmount = taxAmount;
+	}
+
+	public void setTaxAmount(String taxAmount) {
+		if(StringUtils.isNotBlank(taxAmount)) {
+			this.taxAmount = new KualiDecimal(taxAmount);
+		} else {
+			this.taxAmount = KualiDecimal.ZERO;
+		}		
+	}
+	
+	public KualiDecimal getTaxRate() {
+		return taxRate;
+	}
+
+	public void setTaxRate(KualiDecimal taxRate) {
+		this.taxRate = taxRate;
+	}
+
+	public void setTaxRate(String taxRate) {
+		if (StringUtils.isNotBlank(taxRate)) {
+			this.taxRate = new KualiDecimal(taxRate);
+		} else {
+			this.taxRate = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getDiscountAmount() {
+		return discountAmount;
+	}
+
+	public void setDiscountAmount(KualiDecimal discountAmount) {
+		this.discountAmount = discountAmount;
+	}
+
+	public void setDiscountAmount(String discountAmount) {
+		if(StringUtils.isNotBlank(discountAmount)) {
+			this.discountAmount = new KualiDecimal(discountAmount);
+		} else {
+			this.discountAmount = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getFreightAmount() {
+		return freightAmount;
+	}
+
+	public void setFreightAmount(KualiDecimal freightAmount) {
+		this.freightAmount = freightAmount;
+	}
+
+	public void setFreightAmount(String freightAmount) {
+		if(StringUtils.isNotBlank(freightAmount)) {
+			this.freightAmount = new KualiDecimal(freightAmount);
+		} else {
+			this.freightAmount = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getDutyAmount() {
+		return dutyAmount;
+	}
+
+	public void setDutyAmount(KualiDecimal dutyAmount) {
+		this.dutyAmount = dutyAmount;
+	}
+
+	public void setDutyAmount(String dutyAmount) {
+		if(StringUtils.isNotBlank(dutyAmount)) {
+			this.dutyAmount = new KualiDecimal(dutyAmount);
+		} else {
+			this.dutyAmount = KualiDecimal.ZERO;
+		}
+	}
+	
+	public Date getUserEffectiveDate() {
+		return userEffectiveDate;
+	}
+
+	public void setUserEffectiveDate(Date userEffectiveDate) {
+		this.userEffectiveDate = userEffectiveDate;
+	}
+
+	public void setUserEffectiveDate(String userEffectiveDate) {
+		if(StringUtils.isNotBlank(userEffectiveDate)) {
+			this.userEffectiveDate = (Date) (new SqlDateConverter()).convert(Date.class, userEffectiveDate);
+		}
+	}
+	
+	public KualiDecimal getUserAmount() {
+		return userAmount;
+	}
+
+	public void setUserAmount(KualiDecimal userAmount) {
+		this.userAmount = userAmount;
+	}
+
+	public void setUserAmount(String userAmount) {
+		if(StringUtils.isNotBlank(userAmount)) {
+			this.userAmount = new KualiDecimal(userAmount);
+		} else {
+			this.userAmount = KualiDecimal.ZERO;
+		}
+	}
+	
+	public String getOilBrandName() {
+		return oilBrandName;
+	}
+
+	public void setOilBrandName(String oilBrandName) {
+		this.oilBrandName = oilBrandName;
+	}
+
+	public String getOdometerReading() {
+		return odometerReading;
+	}
+
+	public void setOdometerReading(String odometerReading) {
+		this.odometerReading = odometerReading;
+	}
+
+	public String getFleetId() {
+		return fleetId;
+	}
+
+	public void setFleetId(String fleetId) {
+		this.fleetId = fleetId;
+	}
+
+	public String getMessageId() {
+		return messageId;
+	}
+
+	public void setMessageId(String messageId) {
+		this.messageId = messageId;
+	}
+
+	public String getUsage() {
+		return usage;
+	}
+
+	public void setUsage(String usage) {
+		this.usage = usage;
+	}
+
+	public String getFuelServiceType() {
+		return fuelServiceType;
+	}
+
+	public void setFuelServiceType(String fuelServiceType) {
+		this.fuelServiceType = fuelServiceType;
+	}
+
+	public String getFuelProductCd() {
+		return fuelProductCd;
+	}
+
+	public void setFuelProductCd(String fuelProductCd) {
+		this.fuelProductCd = fuelProductCd;
+	}
+
+	public String getProductTypeCd() {
+		return productTypeCd;
+	}
+
+	public void setProductTypeCd(String productTypeCd) {
+		this.productTypeCd = productTypeCd;
+	}
+
+	public BigDecimal getFuelQuantity() {
+		return fuelQuantity;
+	}
+
+	public void setFuelQuantity(BigDecimal fuelQuantity) {
+		this.fuelQuantity = fuelQuantity;
+	}
+
+	public void setFuelQuantity(String fuelQuantity) {
+		if(StringUtils.isNotBlank(fuelQuantity)) {
+			this.fuelQuantity = new BigDecimal(fuelQuantity);
+		} else {
+			this.fuelQuantity = BigDecimal.ZERO;
+		}
+	}
+	
+	public Integer getFuelUnitOfMeasure() {
+		return fuelUnitOfMeasure;
+	}
+
+	public void setFuelUnitOfMeasure(Integer fuelUnitOfMeasure) {
+		this.fuelUnitOfMeasure = fuelUnitOfMeasure;
+	}
+
+	public void setFuelUnitOfMeasure(String fuelUnitOfMeasure) {
+		if(StringUtils.isNotBlank(fuelUnitOfMeasure)) {
+			this.fuelUnitOfMeasure = new Integer(fuelUnitOfMeasure);
+		} else {
+			this.fuelUnitOfMeasure = 0;
+		}
+	}
+	
+	public KualiDecimal getFuelUnitPrice() {
+		return fuelUnitPrice;
+	}
+
+	public void setFuelUnitPrice(KualiDecimal fuelUnitPrice) {
+		this.fuelUnitPrice = fuelUnitPrice;
+	}
+
+	public void setFuelUnitPrice(String fuelUnitPrice) {
+		if(StringUtils.isNotBlank(fuelUnitPrice)) {
+			this.fuelUnitPrice = new KualiDecimal(fuelUnitPrice);
+		} else {
+			this.fuelUnitPrice = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getFuelSaleAmount() {
+		return fuelSaleAmount;
+	}
+
+	public void setFuelSaleAmount(KualiDecimal fuelSaleAmount) {
+		this.fuelSaleAmount = fuelSaleAmount;
+	}
+
+	public void setFuelSaleAmount(String fuelSaleAmount) {
+		if(StringUtils.isNotBlank(fuelSaleAmount)) {
+			this.fuelSaleAmount = new KualiDecimal(fuelSaleAmount);
+		} else {
+			this.fuelSaleAmount = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getFuelDiscountAmount() {
+		return fuelDiscountAmount;
+	}
+
+	public void setFuelDiscountAmount(KualiDecimal fuelDiscountAmount) {
+		this.fuelDiscountAmount = fuelDiscountAmount;
+	}
+
+	public void setFuelDiscountAmount(String fuelDiscountAmount) {
+		if(StringUtils.isNotBlank(fuelDiscountAmount)) {
+			this.fuelDiscountAmount = new KualiDecimal(fuelDiscountAmount);
+		} else {
+			this.fuelDiscountAmount = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getTaxAmount1() {
+		return taxAmount1;
+	}
+
+	public void setTaxAmount1(KualiDecimal taxAmount1) {
+		this.taxAmount1 = taxAmount1;
+	}
+
+	public void setTaxAmount1(String taxAmount1) {
+		if(StringUtils.isNotBlank(taxAmount1)) {
+			this.taxAmount1 = new KualiDecimal(taxAmount1);
+		} else {
+			this.taxAmount1 = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getTaxAmount2() {
+		return taxAmount2;
+	}
+
+	public void setTaxAmount2(KualiDecimal taxAmount2) {
+		this.taxAmount2 = taxAmount2;
+	}
+
+	public void setTaxAmount2(String taxAmount2) {
+		if(StringUtils.isNotBlank(taxAmount2)) {
+			this.taxAmount2 = new KualiDecimal(taxAmount2);
+		} else {
+			this.taxAmount2 = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getTotalAmount() {
+		return totalAmount;
+	}
+
+	public void setTotalAmount(KualiDecimal totalAmount) {
+		this.totalAmount = totalAmount;
+	}
+
+	public void setTotalAmount(String totalAmount) {
+		if(StringUtils.isNotBlank(totalAmount)) {
+			this.totalAmount = new KualiDecimal(totalAmount);
+		} else {
+			this.totalAmount = KualiDecimal.ZERO;
+		}
+	}
+	
+	public Date getGenericEffectiveDate() {
+		return genericEffectiveDate;
+	}
+
+	public void setGenericEffectiveDate(Date genericEffectiveDate) {
+		this.genericEffectiveDate = genericEffectiveDate;
+	}
+	
+	public void setGenericEffectiveDate(String genericEffectiveDate) {
+		if(StringUtils.isNotBlank(genericEffectiveDate)) {
+			this.genericEffectiveDate = (Date) (new SqlDateConverter()).convert(Date.class, genericEffectiveDate);
+		}
+	}
+
+	public String getGenericData() {
+		return genericData;
+	}
+
+	public void setGenericData(String genericData) {
+		this.genericData = genericData;
+	}
+
+	public Date getArriveDate() {
+		return arriveDate;
+	}
+
+	public void setArriveDate(Date arriveDate) {
+		this.arriveDate = arriveDate;
+	}
+
+	public void setArriveDate(String arriveDate) {
+		if(StringUtils.isNotBlank(arriveDate)) {
+			this.arriveDate = (Date) (new SqlDateConverter()).convert(Date.class, arriveDate);
+		}
+	}
+	
+	public Date getDepartureDate() {
+		return departureDate;
+	}
+
+	public void setDepartureDate(Date departureDate) {
+		this.departureDate = departureDate;
+	}
+
+	public void setDepartureDate(String departureDate) {
+		if(StringUtils.isNotBlank(departureDate)) {
+			this.departureDate = (Date) (new SqlDateConverter()).convert(Date.class, departureDate);
+		}
+	}
+	
+	public String getFolioNum() {
+		return folioNum;
+	}
+
+	public void setFolioNum(String folioNum) {
+		this.folioNum = folioNum;
+	}
+
+	public String getPropertyPhoneNum() {
+		return propertyPhoneNum;
+	}
+
+	public void setPropertyPhoneNum(String propertyPhoneNum) {
+		this.propertyPhoneNum = propertyPhoneNum;
+	}
+
+	public String getCustomerServiceNum() {
+		return customerServiceNum;
+	}
+
+	public void setCustomerServiceNum(String customerServiceNum) {
+		this.customerServiceNum = customerServiceNum;
+	}
+
+	public KualiDecimal getPrePaidAmt() {
+		return prePaidAmt;
+	}
+
+	public void setPrePaidAmt(KualiDecimal prePaidAmt) {
+		this.prePaidAmt = prePaidAmt;
+	}
+
+	public void setPrePaidAmt(String prePaidAmt) {
+		if(StringUtils.isNotBlank(prePaidAmt)) {
+			this.prePaidAmt = new KualiDecimal(prePaidAmt);
+		} else {
+			this.prePaidAmt = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getRoomRate() {
+		return roomRate;
+	}
+
+	public void setRoomRate(KualiDecimal roomRate) {
+		this.roomRate = roomRate;
+	}
+
+	public void setRoomRate(String roomRate) {
+		if(StringUtils.isNotBlank(roomRate)) {
+			this.roomRate = new KualiDecimal(roomRate);
+		} else {
+			this.roomRate = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getRoomTax() {
+		return roomTax;
+	}
+
+	public void setRoomTax(KualiDecimal roomTax) {
+		this.roomTax = roomTax;
+	}
+	
+	public void setRoomTax(String roomTax) {
+		if(StringUtils.isNotBlank(roomTax)) {
+			this.roomTax = new KualiDecimal(roomTax);
+		} else {
+			this.roomTax = KualiDecimal.ZERO;
+		}
+	}
+
+	public String getProgramCode() {
+		return programCode;
+	}
+
+	public void setProgramCode(String programCode) {
+		this.programCode = programCode;
+	}
+
+	public KualiDecimal getCallCharges() {
+		return callCharges;
+	}
+
+	public void setCallCharges(KualiDecimal callCharges) {
+		this.callCharges = callCharges;
+	}
+
+	public void setCallCharges(String callCharges) {
+		if(StringUtils.isNotBlank(callCharges)) {
+			this.callCharges = new KualiDecimal(callCharges);
+		} else {
+			this.callCharges = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getFoodSvcCharges() {
+		return foodSvcCharges;
+	}
+
+	public void setFoodSvcCharges(KualiDecimal foodSvcCharges) {
+		this.foodSvcCharges = foodSvcCharges;
+	}
+
+	public void setFoodSvcCharges(String foodSvcCharges) {
+		if(StringUtils.isNotBlank(foodSvcCharges)) {
+			this.foodSvcCharges = new KualiDecimal(foodSvcCharges);
+		} else {
+			this.foodSvcCharges = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getMiniBarCharges() {
+		return miniBarCharges;
+	}
+
+	public void setMiniBarCharges(KualiDecimal miniBarCharges) {
+		this.miniBarCharges = miniBarCharges;
+	}
+
+	public void setMiniBarCharges(String miniBarCharges) {
+		if(StringUtils.isNotBlank(miniBarCharges)) {
+			this.miniBarCharges = new KualiDecimal(miniBarCharges);
+		} else {
+			this.miniBarCharges = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getGiftShopCharges() {
+		return giftShopCharges;
+	}
+
+	public void setGiftShopCharges(KualiDecimal giftShopCharges) {
+		this.giftShopCharges = giftShopCharges;
+	}
+
+	public void setGiftShopCharges(String giftShopCharges) {
+		if(StringUtils.isNotBlank(giftShopCharges)) {
+			this.giftShopCharges = new KualiDecimal(giftShopCharges);
+		} else {
+			this.giftShopCharges = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getLaundryCharges() {
+		return laundryCharges;
+	}
+
+	public void setLaundryCharges(KualiDecimal laundryCharges) {
+		this.laundryCharges = laundryCharges;
+	}
+
+	public void setLaundryCharges(String laundryCharges) {
+		if(StringUtils.isNotBlank(laundryCharges)) {
+			this.laundryCharges = new KualiDecimal(laundryCharges);
+		} else {
+			this.laundryCharges = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getHealthClubCharges() {
+		return healthClubCharges;
+	}
+
+	public void setHealthClubCharges(KualiDecimal healthClubCharges) {
+		this.healthClubCharges = healthClubCharges;
+	}
+
+	public void setHealthClubCharges(String healthClubCharges) {
+		if(StringUtils.isNotBlank(healthClubCharges)) {
+			this.healthClubCharges = new KualiDecimal(healthClubCharges);
+		} else {
+			this.healthClubCharges = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getMovieCharges() {
+		return movieCharges;
+	}
+
+	public void setMovieCharges(KualiDecimal movieCharges) {
+		this.movieCharges = movieCharges;
+	}
+
+	public void setMovieCharges(String movieCharges) {
+		if(StringUtils.isNotBlank(movieCharges)) {
+			this.movieCharges = new KualiDecimal(movieCharges);
+		} else {
+			this.movieCharges = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getBusCtrCharges() {
+		return busCtrCharges;
+	}
+
+	public void setBusCtrCharges(KualiDecimal busCtrCharges) {
+		this.busCtrCharges = busCtrCharges;
+	}
+
+	public void setBusCtrCharges(String busCtrCharges) {
+		if(StringUtils.isNotBlank(busCtrCharges)) {
+			this.busCtrCharges = new KualiDecimal(busCtrCharges);
+		} else {
+			this.busCtrCharges = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getParkingCharges() {
+		return parkingCharges;
+	}
+
+	public void setParkingCharges(KualiDecimal parkingCharges) {
+		this.parkingCharges = parkingCharges;
+	}
+
+	public void setParkingCharges(String parkingCharges) {
+		if(StringUtils.isNotBlank(parkingCharges)) {
+			this.parkingCharges = new KualiDecimal(parkingCharges);
+		} else {
+			this.parkingCharges = KualiDecimal.ZERO;
+		}
+	}
+	
+	public String getOtherCode() {
+		return otherCode;
+	}
+
+	public void setOtherCode(String otherCode) {
+		this.otherCode = otherCode;
+	}
+
+	public KualiDecimal getOtherCharges() {
+		return otherCharges;
+	}
+
+	public void setOtherCharges(KualiDecimal otherCharges) {
+		this.otherCharges = otherCharges;
+	}
+	
+	public void setOtherCharges(String otherCharges) {
+		if(StringUtils.isNotBlank(otherCharges)) {
+			this.otherCharges = new KualiDecimal(otherCharges);
+		} else {
+			this.otherCharges = KualiDecimal.ZERO;
+		}
+	}
+
+	public KualiDecimal getAdjustmentAmount() {
+		return adjustmentAmount;
+	}
+
+	public void setAdjustmentAmount(KualiDecimal adjustmentAmount) {
+		this.adjustmentAmount = adjustmentAmount;
+	}
+
+	public void setAdjustmentAmount(String adjustmentAmount) {
+		if(StringUtils.isNotBlank(adjustmentAmount)) {
+			this.adjustmentAmount = new KualiDecimal(adjustmentAmount);
+		} else {
+			this.adjustmentAmount = KualiDecimal.ZERO;
+		}
+	}
+	
+	public Date getCheckOutDate() {
+		return checkOutDate;
+	}
+
+	public void setCheckOutDate(Date checkOutDate) {
+		this.checkOutDate = checkOutDate;
+	}
+
+	public void setCheckOutDate(String checkOutDate) {
+		if(StringUtils.isNotBlank(checkOutDate)) {
+			this.checkOutDate = (Date) (new SqlDateConverter()).convert(Date.class, checkOutDate);
+		}
+	}
+	
+	public String getRentalAgreementNum() {
+		return rentalAgreementNum;
+	}
+
+	public void setRentalAgreementNum(String rentalAgreementNum) {
+		this.rentalAgreementNum = rentalAgreementNum;
+	}
+
+	public String getRenterName() {
+		return renterName;
+	}
+
+	public void setRenterName(String renterName) {
+		this.renterName = renterName;
+	}
+
+	public String getReturnCity() {
+		return returnCity;
+	}
+
+	public void setReturnCity(String returnCity) {
+		this.returnCity = returnCity;
+	}
+
+	public String getReturnState() {
+		return returnState;
+	}
+	
+	public void setReturnState(String returnState) {
+		this.returnState = returnState;
+	}
+	
+	public String getReturnCountry() {
+		return returnCountry;
+	}
+
+	public void setReturnCountry(String returnCountry) {
+		this.returnCountry = returnCountry;
+	}
+
+	public Date getReturnDate() {
+		return returnDate;
+	}
+
+	public void setReturnDate(Date returnDate) {
+		this.returnDate = returnDate;
+	}
+
+	public void setReturnDate(String returnDate) {
+		if(StringUtils.isNotBlank(returnDate)) {
+			this.returnDate = (Date) (new SqlDateConverter()).convert(Date.class, returnDate);
+		}
+	}
+	
+	public String getReturnLocation() {
+		return returnLocation;
+	}
+
+	public void setReturnLocation(String returnLocation) {
+		this.returnLocation = returnLocation;
+	}
+
+	public String getCustomerSvcNum() {
+		return customerSvcNum;
+	}
+
+	public void setCustomerSvcNum(String customerSvcNum) {
+		this.customerSvcNum = customerSvcNum;
+	}
+
+	public String getRentalClass() {
+		return rentalClass;
+	}
+
+	public void setRentalClass(String rentalClass) {
+		this.rentalClass = rentalClass;
+	}
+
+	public KualiDecimal getDailyRate() {
+		return dailyRate;
+	}
+
+	public void setDailyRate(KualiDecimal dailyRate) {
+		this.dailyRate = dailyRate;
+	}
+
+	public void setDailyRate(String dailyRate) {
+		if(StringUtils.isNotBlank(dailyRate)) {
+			this.dailyRate = new KualiDecimal(dailyRate);
+		} else {
+			this.dailyRate = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getWeeklyRate() {
+		return weeklyRate;
+	}
+
+	public void setWeeklyRate(KualiDecimal weeklyRate) {
+		this.weeklyRate = weeklyRate;
+	}
+
+	public void setWeeklyRate(String weeklyRate) {
+		if(StringUtils.isNotBlank(weeklyRate)) {
+			this.weeklyRate = new KualiDecimal(weeklyRate);
+		} else {
+			this.weeklyRate = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getRatePerMile() {
+		return ratePerMile;
+	}
+
+	public void setRatePerMile(KualiDecimal ratePerMile) {
+		this.ratePerMile = ratePerMile;
+	}
+
+	public void setRatePerMile(String ratePerMile) {
+		if(StringUtils.isNotBlank(ratePerMile)) {
+			this.ratePerMile = new KualiDecimal(ratePerMile);
+		} else {
+			this.ratePerMile = KualiDecimal.ZERO;
+		}
+	}
+	
+	public Integer getMaxFreeMiles() {
+		return maxFreeMiles;
+	}
+
+	public void setMaxFreeMiles(Integer maxFreeMiles) {
+		this.maxFreeMiles = maxFreeMiles;
+	}
+
+	public void setMaxFreeMiles(String maxFreeMiles) {
+		if(StringUtils.isNotBlank(maxFreeMiles)) {
+			this.maxFreeMiles = new Integer(maxFreeMiles);
+		} else {
+			this.maxFreeMiles = 0;
+		}
+	}
+	
+	public Integer getTotalMiles() {
+		return totalMiles;
+	}
+
+	public void setTotalMiles(Integer totalMiles) {
+		this.totalMiles = totalMiles;
+	}
+
+	public void setTotalMiles(String totalMiles) {
+		if(StringUtils.isNotBlank(totalMiles)) {
+			this.totalMiles = new Integer(totalMiles);
+		} else {
+			this.totalMiles = 0;
+		}
+	}
+	
+	public KualiDecimal getOneWayCharges() {
+		return oneWayCharges;
+	}
+
+	public void setOneWayCharges(KualiDecimal oneWayCharges) {
+		this.oneWayCharges = oneWayCharges;
+	}
+
+	public void setOneWayCharges(String oneWayCharges) {
+		if(StringUtils.isNotBlank(oneWayCharges)) {
+			this.oneWayCharges = new KualiDecimal(oneWayCharges);
+		} else {
+			this.oneWayCharges = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getInsuranceCharges() {
+		return insuranceCharges;
+	}
+
+	public void setInsuranceCharges(KualiDecimal insuranceCharges) {
+		this.insuranceCharges = insuranceCharges;
+	}
+
+	public void setInsuranceCharges(String insuranceCharges) {
+		if(StringUtils.isNotBlank(insuranceCharges)) {
+			this.insuranceCharges = new KualiDecimal(insuranceCharges);
+		} else {
+			this.insuranceCharges = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getRegularCharges() {
+		return regularCharges;
+	}
+
+	public void setRegularCharges(KualiDecimal regularCharges) {
+		this.regularCharges = regularCharges;
+	}
+
+	public void setRegularCharges(String regularCharges) {
+		if(StringUtils.isNotBlank(regularCharges)) {
+			this.regularCharges = new KualiDecimal(regularCharges);
+		} else {
+			this.regularCharges = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getTowingCharges() {
+		return towingCharges;
+	}
+
+	public void setTowingCharges(KualiDecimal towingCharges) {
+		this.towingCharges = towingCharges;
+	}
+
+	public void setTowingCharges(String towingCharges) {
+		if(StringUtils.isNotBlank(towingCharges)) {
+			this.towingCharges = new KualiDecimal(towingCharges);
+		} else {
+			this.towingCharges = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getExtraCharges() {
+		return extraCharges;
+	}
+
+	public void setExtraCharges(KualiDecimal extraCharges) {
+		this.extraCharges = extraCharges;
+	}
+
+	public void setExtraCharges(String extraCharges) {
+		if(StringUtils.isNotBlank(extraCharges)) {
+			this.extraCharges = new KualiDecimal(extraCharges);
+		} else {
+			this.extraCharges = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getLateReturnFee() {
+		return lateReturnFee;
+	}
+
+	public void setLateReturnFee(KualiDecimal lateReturnFee) {
+		this.lateReturnFee = lateReturnFee;
+	}
+
+	public void setLateReturnFee(String lateReturnFee) {
+		if(StringUtils.isNotBlank(lateReturnFee)) {
+			this.lateReturnFee = new KualiDecimal(lateReturnFee);
+		} else {
+			this.lateReturnFee = KualiDecimal.ZERO;
+		}
+	}
+	
+	public String getAdjustCode() {
+		return adjustCode;
+	}
+
+	public void setAdjustCode(String adjustCode) {
+		this.adjustCode = adjustCode;
+	}
+
+	public KualiDecimal getAdjustAmount() {
+		return adjustAmount;
+	}
+
+	public void setAdjustAmount(KualiDecimal adjustAmount) {
+		this.adjustAmount = adjustAmount;
+	}
+
+	public void setAdjustAmount(String adjustAmount) {
+		if(StringUtils.isNotBlank(adjustAmount)) {
+			this.adjustAmount = new KualiDecimal(adjustAmount);
+		} else {
+			this.adjustAmount = KualiDecimal.ZERO;
+		}
+	}
+	
+	public String getProgCode() {
+		return progCode;
+	}
+
+	public void setProgCode(String progCode) {
+		this.progCode = progCode;
+	}
+
+	public KualiDecimal getPhoneCharges() {
+		return phoneCharges;
+	}
+
+	public void setPhoneCharges(KualiDecimal phoneCharges) {
+		this.phoneCharges = phoneCharges;
+	}
+	
+	public void setPhoneCharges(String phoneCharges) {
+		if(StringUtils.isNotBlank(phoneCharges)) {
+			this.phoneCharges = new KualiDecimal(phoneCharges);
+		} else {
+			this.phoneCharges = KualiDecimal.ZERO;
+		}
+	}
+
+	public KualiDecimal getOthrCharges() {
+		return othrCharges;
+	}
+
+	public void setOthrCharges(KualiDecimal othrCharges) {
+		this.othrCharges = othrCharges;
+	}
+
+	public void setOthrCharges(String othrCharges) {
+		if(StringUtils.isNotBlank(othrCharges)) {
+			this.othrCharges = new KualiDecimal(othrCharges);
+		} else {
+			this.othrCharges = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getTotalTaxAmount() {
+		return totalTaxAmount;
+	}
+
+	public void setTotalTaxAmount(KualiDecimal totalTaxAmount) {
+		this.totalTaxAmount = totalTaxAmount;
+	}
+
+	public void setTotalTaxAmount(String totalTaxAmount) {
+		if(StringUtils.isNotBlank(totalTaxAmount)) {
+			this.totalTaxAmount = new KualiDecimal(totalTaxAmount);
+		} else {
+			this.totalTaxAmount = KualiDecimal.ZERO;
+		}
+	}
+	
+	public String getPassengerName() {
+		return passengerName;
+	}
+
+	public void setPassengerName(String passengerName) {
+		this.passengerName = passengerName;
+	}
+
+	public Date getDepartDate() {
+		return departDate;
+	}
+
+	public void setDepartDate(Date departDate) {
+		this.departDate = departDate;
+	}
+
+	public void setDepartDate(String departDate) {
+		if(StringUtils.isNotBlank(departDate)) {
+			this.departDate = (Date) (new SqlDateConverter()).convert(Date.class, departDate);
+		}
+	}
+	
+	public String getDepartureCity() {
+		return departureCity;
+	}
+
+	public void setDepartureCity(String departureCity) {
+		this.departureCity = departureCity;
+	}
+
+	public String getAgencyCode() {
+		return agencyCode;
+	}
+
+	public void setAgencyCode(String agencyCode) {
+		this.agencyCode = agencyCode;
+	}
+
+	public String getAgencyName() {
+		return agencyName;
+	}
+
+	public void setAgencyName(String agencyName) {
+		this.agencyName = agencyName;
+	}
+
+	public long getTicketNumber() {
+		return ticketNumber;
+	}
+
+	public void setTicketNumber(long ticketNumber) {
+		this.ticketNumber = ticketNumber;
+	}
+
+	public void setTicketNumber(String ticketNumber) {
+		if(StringUtils.isNotBlank(ticketNumber)) {
+			this.ticketNumber = new Long(ticketNumber).longValue();
+		} else {
+			this.ticketNumber = 0;
+		}
+	}
+	
+	public String getCustomerCode() {
+		return customerCode;
+	}
+
+	public void setCustomerCode(String customerCode) {
+		this.customerCode = customerCode;
+	}
+
+	public Date getIssueDate() {
+		return issueDate;
+	}
+
+	public void setIssueDate(Date issueDate) {
+		this.issueDate = issueDate;
+	}
+
+	public void setIssueDate(String issueDate) {
+		if(StringUtils.isNotBlank(issueDate)) {
+			this.issueDate = (Date) (new SqlDateConverter()).convert(Date.class, issueDate);
+		}
+	}
+	
+	public String getIssuingCarrier() {
+		return issuingCarrier;
+	}
+
+	public void setIssuingCarrier(String issuingCarrier) {
+		this.issuingCarrier = issuingCarrier;
+	}
+
+	public KualiDecimal getTotalFare() {
+		return totalFare;
+	}
+
+	public void setTotalFare(KualiDecimal totalFare) {
+		this.totalFare = totalFare;
+	}
+
+	public void setTotalFare(String totalFare) {
+		if(StringUtils.isNotBlank(totalFare)) {
+			this.totalFare = new KualiDecimal(totalFare);
+		} else {
+			this.totalFare = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getTotalFees() {
+		return totalFees;
+	}
+
+	public void setTotalFees(KualiDecimal totalFees) {
+		this.totalFees = totalFees;
+	}
+
+	public void setTotalFees(String totalFees) {
+		if(StringUtils.isNotBlank(totalFees)) {
+			this.totalFees = new KualiDecimal(totalFees);
+		} else {
+			this.totalFees = KualiDecimal.ZERO;
+		}
+	}
+	
+	public KualiDecimal getTotalTaxes() {
+		return totalTaxes;
+	}
+
+	public void setTotalTaxes(KualiDecimal totalTaxes) {
+		this.totalTaxes = totalTaxes;
+	}
+
+	public void setTotalTaxes(String totalTaxes) {
+		if (StringUtils.isNotBlank(totalTaxes)) {
+			this.totalTaxes = new KualiDecimal(totalTaxes);
+		} else {
+			this.totalTaxes = KualiDecimal.ZERO;
+		}
+	}
+	
+	public List<ProcurementCardTranAddItem> getProcurementCardTranAddItems() {
+		return procurementCardTranAddItems;
+	}
+
+	public void setProcurementCardTranAddItems(List<ProcurementCardTranAddItem> procurementCardTranAddItems) {
+		this.procurementCardTranAddItems = procurementCardTranAddItems;
+	}
+	
+	/**
+	 * This is a convenience method that adds a populated ProcurementCardTranAddItem object directly
+	 * to the contained ArrayList.
+	 * 
+	 * It's primarily used by the Procurement Card Load batch process, for each of XML batch file
+	 * digesting, though it can be used generally.
+	 * 
+	 * NOTE that it will attempt to wire the parent/child relationship by setting the
+	 * procurementCardTranAddItem.transactionSequenceRowNumber to the transactionSequenceRowNumber of 'this', if the number isn't
+	 * already set.
+	 * 
+	 * @param procurementCardTranAddItem
+	 */
+	public void addProcurementCardTranAddItem(ProcurementCardTranAddItem procurementCardTranAddItem) {
+		// do nothing if passed-in procurementCardTranAddItem is null
+		if(procurementCardTranAddItem == null) {
+			return;
+		}
+		
+		// wire the Addendum Item to ensure a valid parent/child relationship
+		if(procurementCardTranAddItem.getTransactionSequenceRowNumber() ==  null) {
+			if(this.transactionSequenceRowNumber != null) {
+				procurementCardTranAddItem.setTransactionSequenceRowNumber(this.transactionSequenceRowNumber);
+			}
+		}
+		
+		this.procurementCardTranAddItems.add(procurementCardTranAddItem);
+	}
+
+	public List<ProcurementCardTranNonFuel> getProcurementCardTranNonFuels() {
+		return procurementCardTranNonFuels;
+	}
+
+	public void setProcurementCardTranNonFuels(List<ProcurementCardTranNonFuel> procurementCardTranNonFuels) {
+		this.procurementCardTranNonFuels = procurementCardTranNonFuels;
+	}
+
+	/**
+	 * This is a convenience method that adds a populated ProcurementCardTranNonFuel object directly
+	 * to the contained ArrayList.
+	 * 
+	 * It's primarily used by the Procurement Card Load batch process, for each XML batch file
+	 * digesting, though it can be used generally.
+	 * 
+	 * NOTE that it will attempt to wire the parent/child relationship by setting the 
+	 * procurementCardTranNonFuel.transactionSequenceRowNumber to the transactionSequenceRowNumber of 'this', if the number isn't
+	 * already set.
+	 * 
+	 * @return procurementCardTranNonFuel
+	 */
+	public void addProcurementCardTranNonFuel(ProcurementCardTranNonFuel procurementCardTranNonFuel) {
+		// do nothing if passed-in procurementCardTranNonFuel is null
+		if (procurementCardTranNonFuel == null) {
+			return;
+		}
+		
+		// wire the Non Fuel Service to ensure a valid parent/child relationship
+		if(procurementCardTranNonFuel.getTransactionSequenceRowNumber() == null) {
+			if(this.transactionSequenceRowNumber != null) {
+				procurementCardTranNonFuel.setTransactionSequenceRowNumber(this.transactionSequenceRowNumber);
+			}
+		}
+		
+		this.procurementCardTranNonFuels.add(procurementCardTranNonFuel);
+	}
+	
+	
+	public List<ProcurementCardTranShipSvc> getProcurementCardTranShipSvcs() {
+		return procurementCardTranShipSvcs;
+	}
+
+	public void setProcurementCardTranShipSvcs(List<ProcurementCardTranShipSvc> procurementCardTranShipSvcs) {
+		this.procurementCardTranShipSvcs = procurementCardTranShipSvcs;
+	}
+
+	/**
+	 * This is a convenience method that adds a populated ProcurementCardTranShipSvc object directly
+	 * to the contained ArrayList.
+	 * 
+	 * It's primarily used by the Procurement Card Load batch process, for each of XML batch file
+	 * digesting, though it can be used generally.
+	 * 
+	 * NOTE that it will attempt to wire the parent/child relationship by setting the
+	 * procurementCardTranShipSvc.transactionSequenceRowNumber to the transactionSequenceRowNumber of 'this', if the number isn't
+	 * already set.
+	 * 
+	 * @param procurementCardTranShipSvc
+	 */
+	public void addProcurementCardTranShipSvc(ProcurementCardTranShipSvc procurementCardTranShipSvc) {
+		// do nothing if passed-in procurementCardTranShipSvc is null
+		if (procurementCardTranShipSvc == null) {
+			return;
+		}
+		
+		// wire the Shipping Service to ensure a valid parent/child relationship
+		if (procurementCardTranShipSvc.getTransactionSequenceRowNumber() ==  null) {
+			if (this.transactionSequenceRowNumber != null) {
+				procurementCardTranShipSvc.setTransactionSequenceRowNumber(this.transactionSequenceRowNumber);
+			}
+		}
+		
+		this.procurementCardTranShipSvcs.add(procurementCardTranShipSvc);
+	}
+	
+	public List<ProcurementCardTranTempSvc> getProcurementCardTranTempSvcs() {
+		return procurementCardTranTempSvcs;
+	}
+
+	public void setProcurementCardTranTempSvcs(List<ProcurementCardTranTempSvc> procurementCardTranTempSvcs) {
+		this.procurementCardTranTempSvcs = procurementCardTranTempSvcs;
+	}
+
+	/**
+	 * This is a convenience method that adds a populated ProcurementCardTranTempSvc object directly
+	 * to the contained ArrayList.
+	 * 
+	 * It's primarily used by the ProcurementCard Load batch process, for each of XML batch file
+	 * digesting, though it can be used generally.
+	 * 
+	 * NOTE that it will attempt to wire the parent/child relationship by setting the
+	 * procurementCardTranTempSvc.transactionSequenceRowNumber to the transactionSequenceRowNumber of 'this', if the number isn't
+	 * already set.
+	 * 
+	 * @param procurementCardTranTempSvc
+	 */
+	public void addProcurementCardTranTempSvc(ProcurementCardTranTempSvc procurementCardTranTempSvc) {
+		// do nothing if passed-in procurementCardTranTempSvc is null
+		if (procurementCardTranTempSvc == null) {
+			return;
+		}
+		
+		// wire the Temp Service to ensure a valid parent/child relationship
+		if (procurementCardTranTempSvc.getTransactionSequenceRowNumber() == null) {
+			if (this.transactionSequenceRowNumber != null) {
+				procurementCardTranTempSvc.setTransactionSequenceRowNumber(this.transactionSequenceRowNumber);
+			}
+		}
+		
+		this.procurementCardTranTempSvcs.add(procurementCardTranTempSvc);
+	}
+	
+	public List<ProcurementCardTranTransportLeg> getProcurementCardTranTransportLegs() {
+		return procurementCardTranTransportLegs;
+	}
+
+	public void setProcurementCardTranTransportLegs(List<ProcurementCardTranTransportLeg> procurementCardTranTransportLegs) {
+		this.procurementCardTranTransportLegs = procurementCardTranTransportLegs;
+	}
+	
+	/**
+	 * This is a convenience method that adds a populated ProcurementCardTranTransportLeg object directly
+	 * to the contained ArrayList.
+	 * 
+	 * It's primarily used by the Procurement Card Load batch process, for each of XML batch file
+	 * digesting, though it can be used generally.
+	 * 
+	 * NOTE that it will attempt to wire the parent/child relationship by setting the 
+	 * procurementCardTranTransportLeg.transactionSequenceRowNumber to the transactionSequenceRowNumber of 'this', if the number isn't
+	 * already set.
+	 * 
+	 * @param procurementCardTranTransportLeg
+	 */
+	public void addProcurementCardTranTransportLeg(ProcurementCardTranTransportLeg procurementCardTranTransportLeg) {
+		// do nothing if passed-in procurementCardTranTransportLeg is null
+		if (procurementCardTranTransportLeg == null) {
+			return;
+		}
+		
+		// wire the Transport Leg to ensure a valid parent/child relationship
+		if (procurementCardTranTransportLeg.getTransactionSequenceRowNumber() == null) {
+			if (this.transactionSequenceRowNumber != null) {
+				procurementCardTranTransportLeg.setTransactionSequenceRowNumber(this.transactionSequenceRowNumber);
+			}
+		}
+		
+		this.procurementCardTranTransportLegs.add(procurementCardTranTransportLeg);
+	}
+	
+	protected LinkedHashMap<String, String> toStringMapper() {
+		LinkedHashMap<String, String> m = new LinkedHashMap<String, String>();
+		if (this.transactionSequenceRowNumber != null) {
+			m.put("transactionSequenceRowNumber", this.transactionSequenceRowNumber.toString());
+		}
+		return m;
+	}
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardTransactionDetail.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/ProcurementCardTransactionDetail.java
@@ -1,0 +1,138 @@
+package edu.arizona.kfs.fp.businessobject;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+
+public class ProcurementCardTransactionDetail extends org.kuali.kfs.fp.businessobject.ProcurementCardTransactionDetail {
+
+	//Procurement Card Level Three Objects
+	private ProcurementCardLevel3Add	    procurementCardLevel3Add;
+	private ProcurementCardLevel3AddUser	procurementCardLevel3AddUser;
+	private ProcurementCardLevel3Fuel	    procurementCardLevel3Fuel;
+	private ProcurementCardLevel3Generic	procurementCardLevel3Generic;
+	private ProcurementCardLevel3Lodging	procurementCardLevel3Lodging;
+	private ProcurementCardLevel3Rental	    procurementCardLevel3Rental;
+	private ProcurementCardLevel3Transport	procurementCardLevel3Transport;
+	
+	private List<ProcurementCardLevel3AddItem>	procurementCardLevel3AddItems;
+	private List<ProcurementCardLevel3NonFuel>	procurementCardLevel3NonFuels;
+	private List<ProcurementCardLevel3ShipSvc>	procurementCardLevel3ShipSvcs;
+	private List<ProcurementCardLevel3TempSvc>	procurementCardLevel3TempSvcs;
+	private List<ProcurementCardLevel3TransportLeg>	procurementCardLevel3TransportLegs;
+	
+	public ProcurementCardTransactionDetail() {
+		super();
+		procurementCardLevel3AddItems = new ArrayList<ProcurementCardLevel3AddItem>();
+		procurementCardLevel3NonFuels = new ArrayList<ProcurementCardLevel3NonFuel>();
+		procurementCardLevel3ShipSvcs = new ArrayList<ProcurementCardLevel3ShipSvc>();
+		procurementCardLevel3TempSvcs = new ArrayList<ProcurementCardLevel3TempSvc>();
+		procurementCardLevel3TransportLegs = new ArrayList<ProcurementCardLevel3TransportLeg>();
+	}
+
+	public ProcurementCardLevel3Add getProcurementCardLevel3Add() {
+		return procurementCardLevel3Add;
+	}
+
+	public void setProcurementCardLevel3Add(ProcurementCardLevel3Add procurementCardLevel3Add) {
+		this.procurementCardLevel3Add = procurementCardLevel3Add;
+	}
+
+	public ProcurementCardLevel3AddUser getProcurementCardLevel3AddUser() {
+		return procurementCardLevel3AddUser;
+	}
+
+	public void setProcurementCardLevel3AddUser(ProcurementCardLevel3AddUser procurementCardLevel3AddUser) {
+		this.procurementCardLevel3AddUser = procurementCardLevel3AddUser;
+	}
+
+	public ProcurementCardLevel3Fuel getProcurementCardLevel3Fuel() {
+		return procurementCardLevel3Fuel;
+	}
+
+	public void setProcurementCardLevel3Fuel(ProcurementCardLevel3Fuel procurementCardLevel3Fuel) {
+		this.procurementCardLevel3Fuel = procurementCardLevel3Fuel;
+	}
+
+	public ProcurementCardLevel3Generic getProcurementCardLevel3Generic() {
+		return procurementCardLevel3Generic;
+	}
+
+	public void setProcurementCardLevel3Generic(ProcurementCardLevel3Generic procurementCardLevel3Generic) {
+		this.procurementCardLevel3Generic = procurementCardLevel3Generic;
+	}
+
+	public ProcurementCardLevel3Lodging getProcurementCardLevel3Lodging() {
+		return procurementCardLevel3Lodging;
+	}
+
+	public void setProcurementCardLevel3Lodging(ProcurementCardLevel3Lodging procurementCardLevel3Lodging) {
+		this.procurementCardLevel3Lodging = procurementCardLevel3Lodging;
+	}
+
+	public ProcurementCardLevel3Rental getProcurementCardLevel3Rental() {
+		return procurementCardLevel3Rental;
+	}
+
+	public void setProcurementCardLevel3Rental(ProcurementCardLevel3Rental procurementCardLevel3Rental) {
+		this.procurementCardLevel3Rental = procurementCardLevel3Rental;
+	}
+
+	public ProcurementCardLevel3Transport getProcurementCardLevel3Transport() {
+		return procurementCardLevel3Transport;
+	}
+
+	public void setProcurementCardLevel3Transport(ProcurementCardLevel3Transport procurementCardLevel3Transport) {
+		this.procurementCardLevel3Transport = procurementCardLevel3Transport;
+	}
+
+	public List<ProcurementCardLevel3AddItem> getProcurementCardLevel3AddItems() {
+		return procurementCardLevel3AddItems;
+	}
+
+	public void setProcurementCardLevel3AddItems(List<ProcurementCardLevel3AddItem> procurementCardLevel3AddItems) {
+		this.procurementCardLevel3AddItems = procurementCardLevel3AddItems;
+	}
+
+	public List<ProcurementCardLevel3NonFuel> getProcurementCardLevel3NonFuels() {
+		return procurementCardLevel3NonFuels;
+	}
+
+	public void setProcurementCardLevel3NonFuels(List<ProcurementCardLevel3NonFuel> procurementCardLevel3NonFuels) {
+		this.procurementCardLevel3NonFuels = procurementCardLevel3NonFuels;
+	}
+
+	public List<ProcurementCardLevel3ShipSvc> getProcurementCardLevel3ShipSvcs() {
+		return procurementCardLevel3ShipSvcs;
+	}
+
+	public void setProcurementCardLevel3ShipSvcs(List<ProcurementCardLevel3ShipSvc> procurementCardLevel3ShipSvcs) {
+		this.procurementCardLevel3ShipSvcs = procurementCardLevel3ShipSvcs;
+	}
+
+	public List<ProcurementCardLevel3TempSvc> getProcurementCardLevel3TempSvcs() {
+		return procurementCardLevel3TempSvcs;
+	}
+
+	public void setProcurementCardLevel3TempSvcs(List<ProcurementCardLevel3TempSvc> procurementCardLevel3TempSvcs) {
+		this.procurementCardLevel3TempSvcs = procurementCardLevel3TempSvcs;
+	}
+
+	public List<ProcurementCardLevel3TransportLeg> getProcurementCardLevel3TransportLegs() {
+		return procurementCardLevel3TransportLegs;
+	}
+
+	public void setProcurementCardLevel3TransportLegs(List<ProcurementCardLevel3TransportLeg> procurementCardLevel3TransportLegs) {
+		this.procurementCardLevel3TransportLegs = procurementCardLevel3TransportLegs;
+	}
+
+	protected LinkedHashMap<String, String> toStringMapper() {
+		LinkedHashMap<String, String> m = new LinkedHashMap<String, String>();
+		m.put(KFSPropertyConstants.DOCUMENT_NUMBER, this.getDocumentNumber());
+		m.put("financialDocumentTransactionLineNumber", this.getFinancialDocumentTransactionLineNumber().toString());
+		return m;
+	}
+}

--- a/kfs-core/src/main/java/org/kuali/kfs/fp/batch/service/impl/ProcurementCardCreateDocumentServiceImpl.java
+++ b/kfs-core/src/main/java/org/kuali/kfs/fp/batch/service/impl/ProcurementCardCreateDocumentServiceImpl.java
@@ -62,14 +62,13 @@ import org.kuali.kfs.fp.businessobject.ProcurementCardDefault;
 import org.kuali.kfs.fp.businessobject.ProcurementCardHolder;
 import org.kuali.kfs.fp.businessobject.ProcurementCardSourceAccountingLine;
 import org.kuali.kfs.fp.businessobject.ProcurementCardTargetAccountingLine;
-import org.kuali.kfs.fp.businessobject.ProcurementCardTransaction;
-import org.kuali.kfs.fp.businessobject.ProcurementCardTransactionDetail;
 import org.kuali.kfs.fp.businessobject.ProcurementCardVendor;
 import org.kuali.kfs.fp.document.ProcurementCardDocument;
 import org.kuali.kfs.fp.document.validation.impl.ProcurementCardDocumentRuleConstants;
 import org.kuali.kfs.integration.cab.CapitalAssetBuilderModuleService;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.kfs.sys.businessobject.AccountingLine;
 import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.kfs.sys.document.service.AccountingLineRuleHelperService;
 import org.kuali.kfs.sys.document.service.FinancialSystemDocumentService;
@@ -95,7 +94,23 @@ import org.kuali.rice.krad.util.ObjectUtils;
 import org.kuali.rice.krad.workflow.service.WorkflowDocumentService;
 import org.springframework.transaction.annotation.Transactional;
 
-
+import edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Add;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3AddItem;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3AddUser;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Fuel;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Generic;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Lodging;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3NonFuel;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Rental;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3ShipSvc;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Transport;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3TransportLeg;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardTranAddItem;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardTranNonFuel;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardTranShipSvc;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardTranTransportLeg;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardTransaction;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardTransactionDetail;
 
 /**
  * This is the default implementation of the ProcurementCardCreateDocumentService interface.
@@ -656,7 +671,7 @@ public class ProcurementCardCreateDocumentServiceImpl implements ProcurementCard
         transactionDetail.setDocumentNumber(pcardDocument.getDocumentNumber());
         transactionDetail.setFinancialDocumentTransactionLineNumber(transactionLineNumber);
         transactionDetail.setTransactionDate(transaction.getTransactionDate());
-        transactionDetail.setTransactionReferenceNumber(transaction.getTransactionReferenceNumber());
+        transactionDetail.setTransactionReferenceNumber(new Long(transaction.getTransactionReferenceNumber()).toString());        
         transactionDetail.setTransactionBillingCurrencyCode(transaction.getTransactionBillingCurrencyCode());
         transactionDetail.setTransactionCurrencyExchangeRate(transaction.getTransactionCurrencyExchangeRate());
         transactionDetail.setTransactionDate(transaction.getTransactionDate());
@@ -681,6 +696,18 @@ public class ProcurementCardCreateDocumentServiceImpl implements ProcurementCard
 
         // create transaction vendor record
         createTransactionVendorRecord(pcardDocument, transaction, transactionDetail);
+        
+        createTransactionLevel3AddRecord(pcardDocument, transaction, transactionDetail);
+        createTransactionLevel3ItemsRecords(pcardDocument, transaction, transactionDetail);
+        createTransactionLevel3AddUserRecord(pcardDocument, transaction, transactionDetail);
+        createTransactionLevel3FuelRecord(pcardDocument, transaction, transactionDetail);
+        createTransactionLevel3GenericRecord(pcardDocument, transaction, transactionDetail);
+        createTransactionLevel3LodgingRecord(pcardDocument, transaction, transactionDetail);
+        createTransactionLevel3NonFuelRecords(pcardDocument, transaction, transactionDetail);
+        createTransactionLevel3RentalRecord(pcardDocument, transaction, transactionDetail);
+        createTransactionLevel3ShipSvcRecords(pcardDocument, transaction, transactionDetail);
+        createTransactionLevel3TransportRecord(pcardDocument, transaction, transactionDetail);
+        createTransactionLevel3TransLegRecords(pcardDocument, transaction, transactionDetail);
 
         // add transaction detail to document
         pcardDocument.getTransactionEntries().add(transactionDetail);
@@ -714,7 +741,400 @@ public class ProcurementCardCreateDocumentServiceImpl implements ProcurementCard
 
         transactionDetail.setProcurementCardVendor(transactionVendor);
     }
-
+    
+    /**
+     * Creates a transaction level 3 addendum record and adds it to the transaction detail.
+     * 
+     * @param pcardDocument The procurement card document to retrieve values from.
+     * @param transaction Transaction to set fields from.
+     * @param transactionDetail The transaction detail to set the level 3 addendum record on.
+     */
+    protected void createTransactionLevel3AddRecord(ProcurementCardDocument pcardDocument, ProcurementCardTransaction transaction, ProcurementCardTransactionDetail transactionDetail) {
+        if (ObjectUtils.isNotNull(transaction.getOrderDate())) {
+            ProcurementCardLevel3Add procurementCardLevel3Add = new ProcurementCardLevel3Add();
+    
+            procurementCardLevel3Add.setDocumentNumber(pcardDocument.getDocumentNumber());
+            procurementCardLevel3Add.setFinancialDocumentTransactionLineNumber(transactionDetail.getFinancialDocumentTransactionLineNumber());
+            procurementCardLevel3Add.setInvoiceNumber(transaction.getInvoiceNumber());
+            procurementCardLevel3Add.setOrderDate(transaction.getOrderDate());
+            procurementCardLevel3Add.setPurchaseTime(transaction.getPurchaseTime());
+            procurementCardLevel3Add.setShipPostal(transaction.getShipPostal());
+            procurementCardLevel3Add.setDestinationPostal(transaction.getDestinationPostal());
+            procurementCardLevel3Add.setDestinationCountryCode(transaction.getDestinationCountryCode());
+            procurementCardLevel3Add.setTaxAmount(transaction.getTaxAmount());
+            procurementCardLevel3Add.setTaxRate(transaction.getTaxRate());
+            procurementCardLevel3Add.setDiscountAmount(transaction.getDiscountAmount());
+            procurementCardLevel3Add.setFreightAmount(transaction.getFreightAmount());
+            procurementCardLevel3Add.setDutyAmount(transaction.getDutyAmount());
+            
+            transactionDetail.setProcurementCardLevel3Add(procurementCardLevel3Add);
+        }
+    }
+    
+    /**
+     * Creates transaction level 3 item records and adds them to the transaction detail.
+     * 
+     * @param pcardDocument The procurement card document to retrieve values from.
+     * @param transaction Transaction to set fields from.
+     * @param transactionDetail The transaction detail to set the level 3 item records on.
+     */
+    protected void createTransactionLevel3ItemsRecords(ProcurementCardDocument pcardDocument, ProcurementCardTransaction transaction, ProcurementCardTransactionDetail transactionDetail) {
+    	List<ProcurementCardTranAddItem> procurementCardTranAddItems = new ArrayList<ProcurementCardTranAddItem>();
+        List<ProcurementCardLevel3AddItem> procurementCardLevel3AddItems = new ArrayList<ProcurementCardLevel3AddItem>();
+        ProcurementCardLevel3AddItem procurementCardLevel3AddItem;
+        int sequenceNumber = 1;
+        
+        procurementCardTranAddItems = (List<ProcurementCardTranAddItem>) businessObjectService.findAll(ProcurementCardTranAddItem.class);
+        
+        for (ProcurementCardTranAddItem procurementCardTranAddItem: procurementCardTranAddItems) {
+            if (procurementCardTranAddItem.getTransactionSequenceRowNumber().intValue() == transaction.getTransactionSequenceRowNumber().intValue()) {
+                procurementCardLevel3AddItem = new ProcurementCardLevel3AddItem();
+                procurementCardLevel3AddItem.setDocumentNumber(pcardDocument.getDocumentNumber());
+                procurementCardLevel3AddItem.setFinancialDocumentTransactionLineNumber(transactionDetail.getFinancialDocumentTransactionLineNumber());
+                procurementCardLevel3AddItem.setSequenceNumber(sequenceNumber);
+                procurementCardLevel3AddItem.setItemCommodityCode(procurementCardTranAddItem.getItemCommodityCode());
+                procurementCardLevel3AddItem.setItemProductCode(procurementCardTranAddItem.getItemProductCode());
+                procurementCardLevel3AddItem.setItemDescription(procurementCardTranAddItem.getItemDescription());
+                procurementCardLevel3AddItem.setItemQuantity(procurementCardTranAddItem.getItemQuantity());
+                procurementCardLevel3AddItem.setItemUnitCode(procurementCardTranAddItem.getItemUnitCode());
+                procurementCardLevel3AddItem.setItemAmount(procurementCardTranAddItem.getItemAmount());
+                procurementCardLevel3AddItem.setItemDebitCreditCode(procurementCardTranAddItem.getItemDebitCreditCode());
+                procurementCardLevel3AddItem.setItemTaxRate(procurementCardTranAddItem.getItemTaxRate());
+                procurementCardLevel3AddItem.setItemTaxAmount(procurementCardTranAddItem.getItemTaxAmount());
+                procurementCardLevel3AddItem.setItemDiscountAmount(procurementCardTranAddItem.getItemDiscountAmount());
+                procurementCardLevel3AddItem.setItemExtendedAmount(procurementCardTranAddItem.getItemExtendedAmount());
+                procurementCardLevel3AddItems.add(procurementCardLevel3AddItem);     
+                sequenceNumber++;
+            }            
+        }
+        if (ObjectUtils.isNotNull(procurementCardLevel3AddItems)) {
+            transactionDetail.setProcurementCardLevel3AddItems(procurementCardLevel3AddItems);
+        }
+    }
+    
+    /**
+     * Creates a transaction level 3 addendum user record and adds it to the transaction detail.
+     * 
+     * @param pcardDocument The procurement card document to retrieve values from.
+     * @param transaction Transaction to set fields from.
+     * @param transactionDetail The transaction detail to set the level 3 addendum user record on.
+     */
+    protected void createTransactionLevel3AddUserRecord(ProcurementCardDocument pcardDocument, ProcurementCardTransaction transaction, ProcurementCardTransactionDetail transactionDetail) {
+        if (ObjectUtils.isNotNull(transaction.getUserEffectiveDate())) {        
+            ProcurementCardLevel3AddUser procurementCardLevel3AddUser = new ProcurementCardLevel3AddUser();
+    
+            procurementCardLevel3AddUser.setDocumentNumber(pcardDocument.getDocumentNumber());
+            procurementCardLevel3AddUser.setFinancialDocumentTransactionLineNumber(transactionDetail.getFinancialDocumentTransactionLineNumber());
+            procurementCardLevel3AddUser.setUserEffectiveDate(transaction.getUserEffectiveDate());
+            procurementCardLevel3AddUser.setUserAmount(transaction.getUserAmount());
+            
+            transactionDetail.setProcurementCardLevel3AddUser(procurementCardLevel3AddUser);
+        }
+    }
+    
+    /**
+     * Creates a transaction level 3 fuel record and adds it to the transaction detail.
+     * 
+     * @param pcardDocument The procurement card document to retrieve values from.
+     * @param transaction Transaction to set fields from.
+     * @param transactionDetail The transaction detail to set the level 3 fuel record on.
+     */
+    protected void createTransactionLevel3FuelRecord(ProcurementCardDocument pcardDocument, ProcurementCardTransaction transaction, ProcurementCardTransactionDetail transactionDetail) {
+        if (ObjectUtils.isNotNull(transaction.getFuelSaleAmount())) {    
+            ProcurementCardLevel3Fuel procurementCardLevel3Fuel = new ProcurementCardLevel3Fuel();
+    
+            procurementCardLevel3Fuel.setDocumentNumber(pcardDocument.getDocumentNumber());
+            procurementCardLevel3Fuel.setFinancialDocumentTransactionLineNumber(transactionDetail.getFinancialDocumentTransactionLineNumber());
+            procurementCardLevel3Fuel.setOilBrandName(transaction.getOilBrandName());
+            procurementCardLevel3Fuel.setOdometerReading(transaction.getOdometerReading());
+            procurementCardLevel3Fuel.setFleetId(transaction.getFleetId());
+            procurementCardLevel3Fuel.setMessageId(transaction.getMessageId());
+            procurementCardLevel3Fuel.setUsage(transaction.getUsage());
+            procurementCardLevel3Fuel.setFuelServiceType(transaction.getFuelServiceType());
+            procurementCardLevel3Fuel.setFuelProductCd(transaction.getFuelProductCd());
+            procurementCardLevel3Fuel.setProductTypeCd(transaction.getProductTypeCd());
+            procurementCardLevel3Fuel.setFuelQuantity(transaction.getFuelQuantity());
+            procurementCardLevel3Fuel.setFuelUnitOfMeasure(transaction.getFuelUnitOfMeasure());
+            procurementCardLevel3Fuel.setFuelUnitPrice(transaction.getFuelUnitPrice());
+            procurementCardLevel3Fuel.setFuelSaleAmount(transaction.getFuelSaleAmount());
+            procurementCardLevel3Fuel.setFuelDiscountAmount(transaction.getFuelDiscountAmount());
+            procurementCardLevel3Fuel.setTaxAmount1(transaction.getTaxAmount1());
+            procurementCardLevel3Fuel.setTaxAmount2(transaction.getTaxAmount2());
+            procurementCardLevel3Fuel.setTotalAmount(transaction.getTotalAmount());
+            
+            transactionDetail.setProcurementCardLevel3Fuel(procurementCardLevel3Fuel);
+        }
+    }
+    
+    /**
+     * Creates a transaction level 3 generic record and adds it to the transaction detail.
+     * 
+     * @param pcardDocument The procurement card document to retrieve values from.
+     * @param transaction Transaction to set fields from.
+     * @param transactionDetail The transaction detail to set the level 3 generic user record on.
+     */
+    protected void createTransactionLevel3GenericRecord(ProcurementCardDocument pcardDocument, ProcurementCardTransaction transaction, ProcurementCardTransactionDetail transactionDetail) {
+        if (ObjectUtils.isNotNull(transaction.getGenericEffectiveDate())) {    
+            ProcurementCardLevel3Generic procurementCardLevel3Generic = new ProcurementCardLevel3Generic();
+    
+            procurementCardLevel3Generic.setDocumentNumber(pcardDocument.getDocumentNumber());
+            procurementCardLevel3Generic.setFinancialDocumentTransactionLineNumber(transactionDetail.getFinancialDocumentTransactionLineNumber());
+            procurementCardLevel3Generic.setGenericEffectiveDate(transaction.getGenericEffectiveDate());
+            procurementCardLevel3Generic.setGenericData(transaction.getGenericData());
+            
+            transactionDetail.setProcurementCardLevel3Generic(procurementCardLevel3Generic);
+        }
+    }
+    
+    /**
+     * Creates a transaction level 3 lodging record and adds it to the transaction detail.
+     * 
+     * @param pcardDocument The procurement card document to retrieve values from.
+     * @param transaction Transaction to set fields from.
+     * @param transactionDetail The transaction detail to set the level 3 lodging record on.
+     */
+    protected void createTransactionLevel3LodgingRecord(ProcurementCardDocument pcardDocument, ProcurementCardTransaction transaction, ProcurementCardTransactionDetail transactionDetail) {
+        if (ObjectUtils.isNotNull(transaction.getArriveDate())) {    
+            ProcurementCardLevel3Lodging procurementCardLevel3Lodging = new ProcurementCardLevel3Lodging();
+    
+            procurementCardLevel3Lodging.setDocumentNumber(pcardDocument.getDocumentNumber());
+            procurementCardLevel3Lodging.setFinancialDocumentTransactionLineNumber(transactionDetail.getFinancialDocumentTransactionLineNumber());
+            procurementCardLevel3Lodging.setArriveDate(transaction.getArriveDate());
+            procurementCardLevel3Lodging.setDepartureDate(transaction.getDepartureDate());
+            procurementCardLevel3Lodging.setFolioNum(transaction.getFolioNum());
+            procurementCardLevel3Lodging.setPropertyPhoneNum(transaction.getPropertyPhoneNum());
+            procurementCardLevel3Lodging.setCustomerServiceNum(transaction.getCustomerServiceNum());
+            procurementCardLevel3Lodging.setPrePaidAmt(transaction.getPrePaidAmt());
+            procurementCardLevel3Lodging.setRoomRate(transaction.getRoomRate());
+            procurementCardLevel3Lodging.setRoomTax(transaction.getRoomTax());
+            procurementCardLevel3Lodging.setProgramCode(transaction.getProgramCode());
+            procurementCardLevel3Lodging.setCallCharges(transaction.getCallCharges());
+            procurementCardLevel3Lodging.setFoodSvcCharges(transaction.getFoodSvcCharges());
+            procurementCardLevel3Lodging.setMiniBarCharges(transaction.getMiniBarCharges());
+            procurementCardLevel3Lodging.setGiftShopCharges(transaction.getGiftShopCharges());
+            procurementCardLevel3Lodging.setLaundryCharges(transaction.getLaundryCharges());
+            procurementCardLevel3Lodging.setHealthClubCharges(transaction.getHealthClubCharges());
+            procurementCardLevel3Lodging.setMovieCharges(transaction.getMovieCharges());
+            procurementCardLevel3Lodging.setBusCtrCharges(transaction.getBusCtrCharges());
+            procurementCardLevel3Lodging.setParkingCharges(transaction.getParkingCharges());
+            procurementCardLevel3Lodging.setOtherCode(transaction.getOtherCode());
+            procurementCardLevel3Lodging.setOtherCharges(transaction.getOtherCharges());
+            procurementCardLevel3Lodging.setAdjustmentAmount(transaction.getAdjustmentAmount());
+            
+            transactionDetail.setProcurementCardLevel3Lodging(procurementCardLevel3Lodging);
+        }
+    }
+    
+    /**
+     * Creates transaction level 3 item records and adds them to the transaction detail.
+     * 
+     * @param pcardDocument The procurement card document to retrieve values from.
+     * @param transaction Transaction to set fields from.
+     * @param transactionDetail The transaction detail to set the level 3 item records on.
+     */
+    protected void createTransactionLevel3NonFuelRecords(ProcurementCardDocument pcardDocument, ProcurementCardTransaction transaction, ProcurementCardTransactionDetail transactionDetail) {
+    	List<ProcurementCardTranNonFuel> procurementCardTranNonFuels = new ArrayList<ProcurementCardTranNonFuel>();
+        List<ProcurementCardLevel3NonFuel> procurementCardLevel3NonFuels = new ArrayList<ProcurementCardLevel3NonFuel>();
+        ProcurementCardLevel3NonFuel procurementCardLevel3NonFuel;
+        int sequenceNumber = 1;
+        
+        procurementCardTranNonFuels = (List<ProcurementCardTranNonFuel>) businessObjectService.findAll(ProcurementCardTranNonFuel.class);
+        
+        for (ProcurementCardTranNonFuel procurementCardTranNonFuel: procurementCardTranNonFuels) {
+            if (procurementCardTranNonFuel.getTransactionSequenceRowNumber().intValue() == transaction.getTransactionSequenceRowNumber().intValue()) {
+                procurementCardLevel3NonFuel = new ProcurementCardLevel3NonFuel();
+                procurementCardLevel3NonFuel.setDocumentNumber(pcardDocument.getDocumentNumber());
+                procurementCardLevel3NonFuel.setFinancialDocumentTransactionLineNumber(transactionDetail.getFinancialDocumentTransactionLineNumber());
+                procurementCardLevel3NonFuel.setSequenceNumber(sequenceNumber);
+                procurementCardLevel3NonFuel.setNonFuelProductCode(procurementCardTranNonFuel.getNonFuelProductCode());
+                procurementCardLevel3NonFuel.setItemDesc(procurementCardTranNonFuel.getItemDesc());
+                procurementCardLevel3NonFuel.setItemQuant(procurementCardTranNonFuel.getItemQuant());
+                procurementCardLevel3NonFuel.setItemUnitOfMeasure(procurementCardTranNonFuel.getItemUnitOfMeasure());
+                procurementCardLevel3NonFuel.setTaxRateApplied(procurementCardTranNonFuel.getTaxRateApplied());
+                procurementCardLevel3NonFuel.setItemTaxAmt(procurementCardTranNonFuel.getItemTaxAmt());
+                procurementCardLevel3NonFuel.setAlternateTaxId(procurementCardTranNonFuel.getAlternateTaxId());
+                procurementCardLevel3NonFuel.setItemDiscountAmt(procurementCardTranNonFuel.getItemDiscountAmt());
+                procurementCardLevel3NonFuel.setItemTotal(procurementCardTranNonFuel.getItemTotal());                
+                procurementCardLevel3NonFuels.add(procurementCardLevel3NonFuel);     
+                sequenceNumber++;
+            }            
+        }
+        if (ObjectUtils.isNotNull(procurementCardLevel3NonFuels)) {
+            transactionDetail.setProcurementCardLevel3NonFuels(procurementCardLevel3NonFuels);
+        }
+    }
+    
+    /**
+     * Creates a transaction level 3 rental record and adds it to the transaction detail.
+     * 
+     * @param pcardDocument The procurement card document to retrieve values from.
+     * @param transaction Transaction to set fields from.
+     * @param transactionDetail The transaction detail to set the level 3 rental record on.
+     */
+    protected void createTransactionLevel3RentalRecord(ProcurementCardDocument pcardDocument, ProcurementCardTransaction transaction, ProcurementCardTransactionDetail transactionDetail) {
+        if (ObjectUtils.isNotNull(transaction.getRegularCharges())) {  
+            ProcurementCardLevel3Rental procurementCardLevel3Rental = new ProcurementCardLevel3Rental();
+    
+            procurementCardLevel3Rental.setDocumentNumber(pcardDocument.getDocumentNumber());
+            procurementCardLevel3Rental.setFinancialDocumentTransactionLineNumber(transactionDetail.getFinancialDocumentTransactionLineNumber());
+            procurementCardLevel3Rental.setCheckOutDate(transaction.getCheckOutDate());
+            procurementCardLevel3Rental.setRentalAgreementNum(transaction.getRentalAgreementNum());
+            procurementCardLevel3Rental.setRenterName(transaction.getRenterName());
+            procurementCardLevel3Rental.setReturnCity(transaction.getReturnCity());
+            procurementCardLevel3Rental.setReturnState(transaction.getReturnState());
+            procurementCardLevel3Rental.setReturnCountry(transaction.getReturnCountry());
+            procurementCardLevel3Rental.setReturnDate(transaction.getReturnDate());
+            procurementCardLevel3Rental.setReturnLocation(transaction.getReturnLocation());
+            procurementCardLevel3Rental.setCustomerSvcNum(transaction.getCustomerSvcNum());
+            procurementCardLevel3Rental.setRentalClass(transaction.getRentalClass());
+            procurementCardLevel3Rental.setDailyRate(transaction.getDailyRate());
+            procurementCardLevel3Rental.setWeeklyRate(transaction.getWeeklyRate());
+            procurementCardLevel3Rental.setRatePerMile(transaction.getRatePerMile());
+            procurementCardLevel3Rental.setMaxFreeMiles(transaction.getMaxFreeMiles());
+            procurementCardLevel3Rental.setTotalMiles(transaction.getTotalMiles());
+            procurementCardLevel3Rental.setOneWayCharges(transaction.getOneWayCharges());
+            procurementCardLevel3Rental.setInsuranceCharges(transaction.getInsuranceCharges());
+            procurementCardLevel3Rental.setRegularCharges(transaction.getRegularCharges());
+            procurementCardLevel3Rental.setTowingCharges(transaction.getTowingCharges());
+            procurementCardLevel3Rental.setExtraCharges(transaction.getExtraCharges());
+            procurementCardLevel3Rental.setLateReturnFee(transaction.getLateReturnFee());
+            procurementCardLevel3Rental.setAdjustCode(transaction.getAdjustCode());
+            procurementCardLevel3Rental.setAdjustAmount(transaction.getAdjustAmount());
+            procurementCardLevel3Rental.setProgCode(transaction.getProgCode());
+            procurementCardLevel3Rental.setPhoneCharges(transaction.getPhoneCharges());
+            procurementCardLevel3Rental.setOthrCharges(transaction.getOthrCharges());
+            procurementCardLevel3Rental.setTotalTaxAmount(transaction.getTotalTaxAmount());
+        
+            transactionDetail.setProcurementCardLevel3Rental(procurementCardLevel3Rental);
+        }
+    }
+    
+    /**
+     * Creates transaction level 3 ship services records and adds them to the transaction detail.
+     * 
+     * @param pcardDocument The procurement card document to retrieve values from.
+     * @param transaction Transaction to set fields from.
+     * @param transactionDetail The transaction detail to set the level 3 ship services records on.
+     */
+    protected void createTransactionLevel3ShipSvcRecords(ProcurementCardDocument pcardDocument, ProcurementCardTransaction transaction, ProcurementCardTransactionDetail transactionDetail) {
+    	List<ProcurementCardTranShipSvc> procurementCardTranShipSvcs = new ArrayList<ProcurementCardTranShipSvc>();
+        List<ProcurementCardLevel3ShipSvc> procurementCardLevel3ShipSvcs = new ArrayList<ProcurementCardLevel3ShipSvc>();
+        ProcurementCardLevel3ShipSvc procurementCardLevel3ShipSvc;
+        int sequenceNumber = 1;
+        
+        procurementCardTranShipSvcs = (List<ProcurementCardTranShipSvc>) businessObjectService.findAll(ProcurementCardTranShipSvc.class);
+        
+        for (ProcurementCardTranShipSvc procurementCardTranShipSvc: procurementCardTranShipSvcs) {
+            if (procurementCardTranShipSvc.getTransactionSequenceRowNumber().intValue() == transaction.getTransactionSequenceRowNumber().intValue()) {
+                procurementCardLevel3ShipSvc = new ProcurementCardLevel3ShipSvc();
+                procurementCardLevel3ShipSvc.setDocumentNumber(pcardDocument.getDocumentNumber());
+                procurementCardLevel3ShipSvc.setFinancialDocumentTransactionLineNumber(transactionDetail.getFinancialDocumentTransactionLineNumber());
+                procurementCardLevel3ShipSvc.setSequenceNumber(sequenceNumber);
+                procurementCardLevel3ShipSvc.setCourierName(procurementCardTranShipSvc.getCourierName());
+                procurementCardLevel3ShipSvc.setTrackingNumber(procurementCardTranShipSvc.getTrackingNumber());
+                procurementCardLevel3ShipSvc.setServiceDescription(procurementCardTranShipSvc.getServiceDescription());
+                procurementCardLevel3ShipSvc.setPickupDate(procurementCardTranShipSvc.getPickupDate());
+                procurementCardLevel3ShipSvc.setOriginZip(procurementCardTranShipSvc.getOriginZip());
+                procurementCardLevel3ShipSvc.setOriginCountryCd(procurementCardTranShipSvc.getOriginCountryCd());
+                procurementCardLevel3ShipSvc.setDestinationZip(procurementCardTranShipSvc.getDestinationZip());
+                procurementCardLevel3ShipSvc.setDestinationCountryCd(procurementCardTranShipSvc.getDestinationCountryCd());
+                procurementCardLevel3ShipSvc.setNetAmount(procurementCardTranShipSvc.getNetAmount());
+                procurementCardLevel3ShipSvc.setTaxAmt(procurementCardTranShipSvc.getTaxAmt());
+                procurementCardLevel3ShipSvc.setDiscAmt(procurementCardTranShipSvc.getDiscAmt());
+                procurementCardLevel3ShipSvc.setNumberOfPackages(procurementCardTranShipSvc.getNumberOfPackages());
+                procurementCardLevel3ShipSvc.setWeight(procurementCardTranShipSvc.getWeight());
+                procurementCardLevel3ShipSvc.setUnitsOfMeasure(procurementCardTranShipSvc.getUnitsOfMeasure());
+                procurementCardLevel3ShipSvc.setSenderName(procurementCardTranShipSvc.getSenderName());
+                procurementCardLevel3ShipSvc.setSenderAddress(procurementCardTranShipSvc.getSenderAddress());
+                procurementCardLevel3ShipSvc.setReceiverName(procurementCardTranShipSvc.getReceiverName());
+                procurementCardLevel3ShipSvc.setReceiverAddress(procurementCardTranShipSvc.getReceiverAddress());
+                procurementCardLevel3ShipSvc.setCustomerRefNumber(procurementCardTranShipSvc.getCustomerRefNumber());
+                procurementCardLevel3ShipSvcs.add(procurementCardLevel3ShipSvc);     
+                sequenceNumber++;
+            }            
+        }
+        if (ObjectUtils.isNotNull(procurementCardLevel3ShipSvcs)) {
+            transactionDetail.setProcurementCardLevel3ShipSvcs(procurementCardLevel3ShipSvcs);
+        }
+    }
+    
+    /**
+     * Creates a transaction level 3 transport record and adds it to the transaction detail.
+     * 
+     * @param pcardDocument The procurement card document to retrieve values from.
+     * @param transaction Transaction to set fields from.
+     * @param transactionDetail The transaction detail to set the level 3 transport record on.
+     */
+    protected void createTransactionLevel3TransportRecord(ProcurementCardDocument pcardDocument, ProcurementCardTransaction transaction, ProcurementCardTransactionDetail transactionDetail) {
+        if (ObjectUtils.isNotNull(transaction.getPassengerName())) {  
+            ProcurementCardLevel3Transport procurementCardLevel3Transport = new ProcurementCardLevel3Transport();
+    
+            procurementCardLevel3Transport.setDocumentNumber(pcardDocument.getDocumentNumber());
+            procurementCardLevel3Transport.setFinancialDocumentTransactionLineNumber(transactionDetail.getFinancialDocumentTransactionLineNumber());
+            procurementCardLevel3Transport.setPassengerName(transaction.getPassengerName());
+            procurementCardLevel3Transport.setDepartDate(transaction.getDepartDate());
+            procurementCardLevel3Transport.setDepartureCity(transaction.getDepartureCity());
+            procurementCardLevel3Transport.setAgencyCode(transaction.getAgencyCode());
+            procurementCardLevel3Transport.setAgencyName(transaction.getAgencyName());
+            procurementCardLevel3Transport.setTicketNumber(transaction.getTicketNumber());
+            procurementCardLevel3Transport.setCustomerCode(transaction.getCustomerCode());
+            procurementCardLevel3Transport.setIssueDate(transaction.getIssueDate());
+            procurementCardLevel3Transport.setIssuingCarrier(transaction.getIssuingCarrier());
+            procurementCardLevel3Transport.setTotalFare(transaction.getTotalFare());
+            procurementCardLevel3Transport.setTotalFees(transaction.getTotalFees());
+            procurementCardLevel3Transport.setTotalTaxes(transaction.getTotalTaxes());
+            
+            transactionDetail.setProcurementCardLevel3Transport(procurementCardLevel3Transport);
+        }
+    }
+    
+    /**
+     * Creates transaction level 3 transport leg records and adds them to the transaction detail.
+     * 
+     * @param pcardDocument The procurement card document to retrieve values from.
+     * @param transaction Transaction to set fields from.
+     * @param transactionDetail The transaction detail to set the level 3 transport leg records on.
+     */
+    protected void createTransactionLevel3TransLegRecords(ProcurementCardDocument pcardDocument, ProcurementCardTransaction transaction, ProcurementCardTransactionDetail transactionDetail) {
+    	List<ProcurementCardTranTransportLeg> procurementCardTranTransportLegs = new ArrayList<ProcurementCardTranTransportLeg>();
+        List<ProcurementCardLevel3TransportLeg> procurementCardLevel3TransportLegs = new ArrayList<ProcurementCardLevel3TransportLeg>();
+        ProcurementCardLevel3TransportLeg procurementCardLevel3TransportLeg;
+        int sequenceNumber = 1;
+        
+        procurementCardTranTransportLegs = (List<ProcurementCardTranTransportLeg>) businessObjectService.findAll(ProcurementCardTranTransportLeg.class);
+        
+        for (ProcurementCardTranTransportLeg procurementCardTranTransportLeg: procurementCardTranTransportLegs) {
+            if (procurementCardTranTransportLeg.getTransactionSequenceRowNumber().intValue() == transaction.getTransactionSequenceRowNumber().intValue()) {
+                procurementCardLevel3TransportLeg = new ProcurementCardLevel3TransportLeg();
+                procurementCardLevel3TransportLeg.setDocumentNumber(pcardDocument.getDocumentNumber());
+                procurementCardLevel3TransportLeg.setFinancialDocumentTransactionLineNumber(transactionDetail.getFinancialDocumentTransactionLineNumber());
+                procurementCardLevel3TransportLeg.setSequenceNumber(sequenceNumber);
+                procurementCardLevel3TransportLeg.setCarrierCode(procurementCardTranTransportLeg.getCarrierCode());
+                procurementCardLevel3TransportLeg.setServiceClass(procurementCardTranTransportLeg.getServiceClass());
+                procurementCardLevel3TransportLeg.setDepartCity(procurementCardTranTransportLeg.getDepartCity());
+                procurementCardLevel3TransportLeg.setConjunctionTicket(procurementCardTranTransportLeg.getConjunctionTicket());
+                procurementCardLevel3TransportLeg.setExchangeTicket(procurementCardTranTransportLeg.getExchangeTicket());
+                procurementCardLevel3TransportLeg.setDestinationCity(procurementCardTranTransportLeg.getDestinationCity());
+                procurementCardLevel3TransportLeg.setFareBasisCode(procurementCardTranTransportLeg.getFareBasisCode());
+                procurementCardLevel3TransportLeg.setFlightNumber(procurementCardTranTransportLeg.getFlightNumber());
+                procurementCardLevel3TransportLeg.setDepartTime(procurementCardTranTransportLeg.getDepartTime());
+                procurementCardLevel3TransportLeg.setDepartTimeSegment(procurementCardTranTransportLeg.getDepartTimeSegment());
+                procurementCardLevel3TransportLeg.setArriveTime(procurementCardTranTransportLeg.getArriveTime());
+                procurementCardLevel3TransportLeg.setArriveTimeSegment(procurementCardTranTransportLeg.getArriveTimeSegment());
+                procurementCardLevel3TransportLeg.setFare(procurementCardTranTransportLeg.getFare());
+                procurementCardLevel3TransportLeg.setFees(procurementCardTranTransportLeg.getFees());
+                procurementCardLevel3TransportLeg.setTaxes(procurementCardTranTransportLeg.getTaxes());
+                procurementCardLevel3TransportLeg.setEndorsements(procurementCardTranTransportLeg.getEndorsements());
+                procurementCardLevel3TransportLeg.setControlCode(procurementCardTranTransportLeg.getControlCode());
+                procurementCardLevel3TransportLegs.add(procurementCardLevel3TransportLeg);     
+                sequenceNumber++;
+            }            
+        }
+        if (ObjectUtils.isNotNull(procurementCardLevel3TransportLegs)) {
+            transactionDetail.setProcurementCardLevel3TransportLegs(procurementCardLevel3TransportLegs);
+        }
+    }
+        
     /**
      * From the transaction accounting attributes, creates source and target accounting lines. Attributes are validated first, and
      * replaced with default and error values if needed. There will be 1 source and 1 target line generated.

--- a/kfs-core/src/main/java/org/kuali/kfs/fp/document/ProcurementCardDocument.java
+++ b/kfs-core/src/main/java/org/kuali/kfs/fp/document/ProcurementCardDocument.java
@@ -27,7 +27,6 @@ import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.fp.businessobject.ProcurementCardHolder;
 import org.kuali.kfs.fp.businessobject.ProcurementCardSourceAccountingLine;
 import org.kuali.kfs.fp.businessobject.ProcurementCardTargetAccountingLine;
-import org.kuali.kfs.fp.businessobject.ProcurementCardTransactionDetail;
 import org.kuali.kfs.integration.cam.CapitalAssetManagementModuleService;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.businessobject.AccountingLine;
@@ -42,6 +41,8 @@ import org.kuali.rice.kew.framework.postprocessor.DocumentRouteStatusChange;
 import org.kuali.rice.kns.service.DataDictionaryService;
 import org.kuali.rice.krad.rules.rule.event.KualiDocumentEvent;
 import org.kuali.rice.krad.rules.rule.event.SaveDocumentEvent;
+
+import edu.arizona.kfs.fp.businessobject.ProcurementCardTransactionDetail;
 
 /**
  * This is the Procurement Card Document Class. The procurement cards distributes expenses from clearing accounts. It is a two-sided

--- a/kfs-core/src/main/java/org/kuali/kfs/fp/document/web/struts/ProcurementCardForm.java
+++ b/kfs-core/src/main/java/org/kuali/kfs/fp/document/web/struts/ProcurementCardForm.java
@@ -30,7 +30,6 @@ import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.fp.businessobject.CapitalAssetInformation;
 import org.kuali.kfs.fp.businessobject.ProcurementCardTargetAccountingLine;
-import org.kuali.kfs.fp.businessobject.ProcurementCardTransactionDetail;
 import org.kuali.kfs.fp.document.CapitalAssetEditable;
 import org.kuali.kfs.fp.document.ProcurementCardDocument;
 import org.kuali.kfs.sys.KFSConstants;
@@ -46,6 +45,8 @@ import org.kuali.rice.kns.service.DataDictionaryService;
 import org.kuali.rice.krad.datadictionary.DataDictionary;
 import org.kuali.rice.krad.util.GlobalVariables;
 import org.kuali.rice.krad.util.KRADConstants;
+
+import edu.arizona.kfs.fp.businessobject.ProcurementCardTransactionDetail;
 
 /**
  * This class is the form class for the ProcurementCard document. This method extends the parent KualiTransactionalDocumentFormBase

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/batch/pcdoLevel3DigesterRules.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/batch/pcdoLevel3DigesterRules.xml
@@ -1,0 +1,279 @@
+<?xml version="1.0"?>
+<!--
+ Copyright 2007 The Kuali Foundation
+ 
+ Licensed under the Educational Community License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.opensource.org/licenses/ecl2.php
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<!DOCTYPE digester-rules 
+    PUBLIC "-//Jakarta Apache //DTD digester-rules XML V1.0//EN" 
+    "http://jakarta.apache.org/commons/digester/dtds/digester-rules.dtd">
+
+<digester-rules>
+    <pattern value="transactions">
+        <object-create-rule classname="java.util.ArrayList" />
+
+        <pattern value="transaction">
+            <object-create-rule classname="edu.arizona.kfs.fp.businessobject.ProcurementCardTransaction" />
+
+            <call-method-rule pattern="transactionCreditCardNumber" methodname="setTransactionCreditCardNumber" paramcount="0" />
+            <call-method-rule pattern="financialDocumentTotalAmount" methodname="setFinancialDocumentTotalAmount" paramcount="0" />
+            <call-method-rule pattern="transactionDebitCreditCode" methodname="setTransactionDebitCreditCode" paramcount="0" />
+            <call-method-rule pattern="chartOfAccountsCode" methodname="setChartOfAccountsCode" paramcount="0" />
+            <call-method-rule pattern="accountNumber" methodname="setAccountNumber" paramcount="0" />
+            <call-method-rule pattern="subAccountNumber" methodname="setSubAccountNumber" paramcount="0" />
+            <call-method-rule pattern="financialObjectCode" methodname="setFinancialObjectCode" paramcount="0" />
+            <call-method-rule pattern="financialSubObjectCode" methodname="setFinancialSubObjectCode" paramcount="0" />
+            <call-method-rule pattern="projectCode" methodname="setProjectCode" paramcount="0" />
+            <call-method-rule pattern="transactionCycleStartDate" methodname="setTransactionCycleStartDate" paramcount="0" />
+            <call-method-rule pattern="transactionCycleEndDate" methodname="setTransactionCycleEndDate" paramcount="0" />
+            <call-method-rule pattern="cardHolderName" methodname="setCardHolderName" paramcount="0" />
+            <call-method-rule pattern="transactionDate" methodname="setTransactionDate" paramcount="0" paramtypes="java.sql.Date" />
+            <call-method-rule pattern="transactionReferenceNumber" methodname="setTransactionReferenceNumber" paramcount="0" />
+            <call-method-rule pattern="transactionMerchantCategoryCode" methodname="setTransactionMerchantCategoryCode" paramcount="0" />
+            <call-method-rule pattern="transactionPostingDate" methodname="setTransactionPostingDate" paramcount="0" paramtypes="java.sql.Date" />
+            <call-method-rule pattern="transactionOriginalCurrencyCode" methodname="setTransactionOriginalCurrencyCode" paramcount="0" />
+            <call-method-rule pattern="transactionBillingCurrencyCode" methodname="setTransactionBillingCurrencyCode" paramcount="0" />
+            <call-method-rule pattern="transactionOriginalCurrencyAmount" methodname="setTransactionOriginalCurrencyAmount" paramcount="0" />
+            <call-method-rule pattern="transactionCurrencyExchangeRate" methodname="setTransactionCurrencyExchangeRate" paramcount="0" />
+            <call-method-rule pattern="transactionSettlementAmount" methodname="setTransactionSettlementAmount" paramcount="0" />
+            <call-method-rule pattern="transactionSalesTaxAmount" methodname="setTransactionSalesTaxAmount" paramcount="0" />
+            <call-method-rule pattern="transactionTaxExemptIndicator" methodname="setTransactionTaxExemptIndicator" paramcount="0" />
+            <call-method-rule pattern="transactionPurchaseIdentifierIndicator" methodname="setTransactionPurchaseIdentifierIndicator" paramcount="0" />
+            <call-method-rule pattern="transactionPurchaseIdentifierDescription" methodname="setTransactionPurchaseIdentifierDescription" paramcount="0" />
+            <call-method-rule pattern="transactionUnitContactName" methodname="setTransactionUnitContactName" paramcount="0" />
+            <call-method-rule pattern="transactionTravelAuthorizationCode" methodname="setTransactionTravelAuthorizationCode" paramcount="0" />
+            <call-method-rule pattern="transactionPointOfSaleCode" methodname="setTransactionPointOfSaleCode" paramcount="0" />
+            <call-method-rule pattern="vendorName" methodname="setVendorName" paramcount="0" />
+            <call-method-rule pattern="vendorLine1Address" methodname="setVendorLine1Address" paramcount="0" />
+            <call-method-rule pattern="vendorLine2Address" methodname="setVendorLine2Address" paramcount="0" />
+            <call-method-rule pattern="vendorCityName" methodname="setVendorCityName" paramcount="0" />
+            <call-method-rule pattern="vendorStateCode" methodname="setVendorStateCode" paramcount="0" />
+            <call-method-rule pattern="vendorZipCode" methodname="setVendorZipCode" paramcount="0" />
+            <call-method-rule pattern="vendorOrderNumber" methodname="setVendorOrderNumber" paramcount="0" />
+            <call-method-rule pattern="visaVendorIdentifier" methodname="setVisaVendorIdentifier" paramcount="0" />
+            <call-method-rule pattern="cardHolderAlternateName" methodname="setCardHolderAlternateName" paramcount="0" />
+            <call-method-rule pattern="cardHolderLine1Address" methodname="setCardHolderLine1Address" paramcount="0" />
+            <call-method-rule pattern="cardHolderLine2Address" methodname="setCardHolderLine2Address" paramcount="0" />
+            <call-method-rule pattern="cardHolderCityName" methodname="setCardHolderCityName" paramcount="0" />
+            <call-method-rule pattern="cardHolderStateCode" methodname="setCardHolderStateCode" paramcount="0" />
+            <call-method-rule pattern="cardHolderZipCode" methodname="setCardHolderZipCode" paramcount="0" />
+            <call-method-rule pattern="cardHolderWorkPhoneNumber" methodname="setCardHolderWorkPhoneNumber" paramcount="0" />
+            <call-method-rule pattern="cardLimit" methodname="setCardLimit" paramcount="0" />
+            <call-method-rule pattern="cardCycleAmountLimit" methodname="setCardCycleAmountLimit" paramcount="0" />
+            <call-method-rule pattern="cardCycleVolumeLimit" methodname="setCardCycleVolumeLimit" paramcount="0" />
+            <call-method-rule pattern="cardStatusCode" methodname="setCardStatusCode" paramcount="0" />
+            <call-method-rule pattern="cardNoteText" methodname="setCardNoteText" paramcount="0" />
+            <call-method-rule pattern="invoiceNumber" methodname="setInvoiceNumber" paramcount="0" />
+            <call-method-rule pattern="orderDate" methodname="setOrderDate" paramcount="0" />
+            <call-method-rule pattern="purchaseTime" methodname="setPurchaseTime" paramcount="0" />
+            <call-method-rule pattern="shipPostal" methodname="setShipPostal" paramcount="0" />
+            <call-method-rule pattern="destinationPostal" methodname="setDestinationPostal" paramcount="0" />
+            <call-method-rule pattern="destinationCountryCode" methodname="setDestinationCountryCode" paramcount="0" />
+            <call-method-rule pattern="taxAmount" methodname="setTaxAmount" paramcount="0" />
+            <call-method-rule pattern="taxRate" methodname="setTaxRate" paramcount="0" />
+            <call-method-rule pattern="discountAmount" methodname="setDiscountAmount" paramcount="0" />
+            <call-method-rule pattern="freightAmount" methodname="setFreightAmount" paramcount="0" />
+            <call-method-rule pattern="dutyAmount" methodname="setDutyAmount" paramcount="0" />   
+            <call-method-rule pattern="userEffectiveDate" methodname="setUserEffectiveDate" paramcount="0" />
+            <call-method-rule pattern="userAmount" methodname="setUserAmount" paramcount="0" />   
+            <call-method-rule pattern="oilBrandName" methodname="setOilBrandName" paramcount="0" />
+            <call-method-rule pattern="odometerReading" methodname="setOdometerReading" paramcount="0" />            
+            <call-method-rule pattern="fleetId" methodname="setFleetId" paramcount="0" />
+            <call-method-rule pattern="messageId" methodname="setMessageId" paramcount="0" />
+            <call-method-rule pattern="usage" methodname="setUsage" paramcount="0" />
+            <call-method-rule pattern="fuelServiceType" methodname="setFuelServiceType" paramcount="0" />            
+            <call-method-rule pattern="fuelProductCd" methodname="setFuelProductCd" paramcount="0" />
+            <call-method-rule pattern="productTypeCd" methodname="setProductTypeCd" paramcount="0" />
+            <call-method-rule pattern="fuelQuantity" methodname="setFuelQuantity" paramcount="0" />
+            <call-method-rule pattern="fuelUnitOfMeasure" methodname="setFuelUnitOfMeasure" paramcount="0" />
+            <call-method-rule pattern="fuelUnitPrice" methodname="setFuelUnitPrice" paramcount="0" />
+            <call-method-rule pattern="fuelSaleAmount" methodname="setFuelSaleAmount" paramcount="0" />
+            <call-method-rule pattern="fuelDiscountAmount" methodname="setFuelDiscountAmount" paramcount="0" />
+            <call-method-rule pattern="taxAmount1" methodname="setTaxAmount1" paramcount="0" />
+            <call-method-rule pattern="taxAmount2" methodname="setTaxAmount2" paramcount="0" />            
+            <call-method-rule pattern="totalAmount" methodname="setTotalAmount" paramcount="0" />  
+            <call-method-rule pattern="genericEffectiveDate" methodname="setGenericEffectiveDate" paramcount="0" />
+            <call-method-rule pattern="genericData" methodname="setGenericData" paramcount="0" />  
+            <call-method-rule pattern="arriveDate" methodname="setArriveDate" paramcount="0" />
+            <call-method-rule pattern="departureDate" methodname="setDepartureDate" paramcount="0" />
+            <call-method-rule pattern="folioNum" methodname="setFolioNum" paramcount="0" />
+            <call-method-rule pattern="propertyPhoneNum" methodname="setPropertyPhoneNum" paramcount="0" />
+            <call-method-rule pattern="customerServiceNum" methodname="setCustomerServiceNum" paramcount="0" />
+            <call-method-rule pattern="prePaidAmt" methodname="setPrePaidAmt" paramcount="0" />            
+            <call-method-rule pattern="roomRate" methodname="setRoomRate" paramcount="0" />
+            <call-method-rule pattern="roomTax" methodname="setRoomTax" paramcount="0" />
+            <call-method-rule pattern="programCode" methodname="setProgramCode" paramcount="0" />
+            <call-method-rule pattern="callCharges" methodname="setCallCharges" paramcount="0" />
+            <call-method-rule pattern="foodSvcCharges" methodname="setFoodSvcCharges" paramcount="0" />
+            <call-method-rule pattern="miniBarCharges" methodname="setMiniBarCharges" paramcount="0" />
+            <call-method-rule pattern="giftShopCharges" methodname="setGiftShopCharges" paramcount="0" />
+            <call-method-rule pattern="laundryCharges" methodname="setLaundryCharges" paramcount="0" />
+            <call-method-rule pattern="healthClubCharges" methodname="setHealthClubCharges" paramcount="0" />
+            <call-method-rule pattern="movieCharges" methodname="setMovieCharges" paramcount="0" />
+            <call-method-rule pattern="busCtrCharges" methodname="setBusCtrCharges" paramcount="0" />
+            <call-method-rule pattern="parkingCharges" methodname="setParkingCharges" paramcount="0" />
+            <call-method-rule pattern="otherCode" methodname="setOtherCode" paramcount="0" />
+            <call-method-rule pattern="otherCharges" methodname="setOtherCharges" paramcount="0" />
+            <call-method-rule pattern="adjustmentAmount" methodname="setAdjustmentAmount" paramcount="0" />  
+            <call-method-rule pattern="checkOutDate" methodname="setCheckOutDate" paramcount="0" />
+            <call-method-rule pattern="rentalAgreementNum" methodname="setRentalAgreementNum" paramcount="0" />
+            <call-method-rule pattern="renterName" methodname="setRenterName" paramcount="0" />
+            <call-method-rule pattern="returnCity" methodname="setReturnCity" paramcount="0" />
+            <call-method-rule pattern="returnState" methodname="setReturnState" paramcount="0" />
+            <call-method-rule pattern="returnCountry" methodname="setReturnCountry" paramcount="0" />
+            <call-method-rule pattern="returnDate" methodname="setReturnDate" paramcount="0" />
+            <call-method-rule pattern="returnLocation" methodname="setReturnLocation" paramcount="0" />
+            <call-method-rule pattern="customerSvcNum" methodname="setCustomerSvcNum" paramcount="0" />
+            <call-method-rule pattern="rentalClass" methodname="setRentalClass" paramcount="0" />
+            <call-method-rule pattern="dailyRate" methodname="setDailyRate" paramcount="0" />
+            <call-method-rule pattern="weeklyRate" methodname="setWeeklyRate" paramcount="0" />
+            <call-method-rule pattern="ratePerMile" methodname="setRatePerMile" paramcount="0" />
+            <call-method-rule pattern="maxFreeMiles" methodname="setMaxFreeMiles" paramcount="0" />
+            <call-method-rule pattern="totalMiles" methodname="setTotalMiles" paramcount="0" />
+            <call-method-rule pattern="oneWayCharges" methodname="setOneWayCharges" paramcount="0" />
+            <call-method-rule pattern="insuranceCharges" methodname="setInsuranceCharges" paramcount="0" />
+            <call-method-rule pattern="regularCharges" methodname="setRegularCharges" paramcount="0" />
+            <call-method-rule pattern="towingCharges" methodname="setTowingCharges" paramcount="0" />
+            <call-method-rule pattern="extraCharges" methodname="setExtraCharges" paramcount="0" />
+            <call-method-rule pattern="lateReturnFee" methodname="setLateReturnFee" paramcount="0" />
+            <call-method-rule pattern="adjustCode" methodname="setAdjustCode" paramcount="0" />
+            <call-method-rule pattern="adjustAmount" methodname="setAdjustAmount" paramcount="0" />
+            <call-method-rule pattern="progCode" methodname="setProgCode" paramcount="0" />
+            <call-method-rule pattern="phoneCharges" methodname="setPhoneCharges" paramcount="0" />
+            <call-method-rule pattern="othrCharges" methodname="setOthrCharges" paramcount="0" />
+            <call-method-rule pattern="totalTaxAmount" methodname="setTotalTaxAmount" paramcount="0" /> 
+            <call-method-rule pattern="passengerName" methodname="setPassengerName" paramcount="0" />
+            <call-method-rule pattern="departDate" methodname="setDepartDate" paramcount="0" />
+            <call-method-rule pattern="departureCity" methodname="setDepartureCity" paramcount="0" />
+            <call-method-rule pattern="agencyCode" methodname="setAgencyCode" paramcount="0" />
+            <call-method-rule pattern="agencyName" methodname="setAgencyName" paramcount="0" />
+            <call-method-rule pattern="ticketNumber" methodname="setTicketNumber" paramcount="0" />
+            <call-method-rule pattern="customerCode" methodname="setCustomerCode" paramcount="0" />
+            <call-method-rule pattern="issueDate" methodname="setIssueDate" paramcount="0" />
+            <call-method-rule pattern="issuingCarrier" methodname="setIssuingCarrier" paramcount="0" />
+            <call-method-rule pattern="totalFare" methodname="setTotalFare" paramcount="0" />
+            <call-method-rule pattern="totalFees" methodname="setTotalFees" paramcount="0" />
+            <call-method-rule pattern="totalTaxes" methodname="setTotalTaxes" paramcount="0" />
+            
+            <pattern value="addItem">
+				<object-create-rule classname="edu.arizona.kfs.fp.businessobject.ProcurementCardTranAddItem" />
+				
+	            <call-method-rule pattern="itemCommodityCode" methodname="setItemCommodityCode" paramcount="0" />
+	            <call-method-rule pattern="itemProductCode" methodname="setItemProductCode" paramcount="0" />
+	            <call-method-rule pattern="itemDescription" methodname="setItemDescription" paramcount="0" />
+	            <call-method-rule pattern="itemQuantity" methodname="setItemQuantity" paramcount="0" />
+	            <call-method-rule pattern="itemUnitCode" methodname="setItemUnitCode" paramcount="0" />
+	            <call-method-rule pattern="itemAmount" methodname="setItemAmount" paramcount="0" />
+	            <call-method-rule pattern="itemDebitCreditCode" methodname="setItemDebitCreditCode" paramcount="0" />
+	            <call-method-rule pattern="itemTaxRate" methodname="setItemTaxRate" paramcount="0" />
+	            <call-method-rule pattern="itemTaxAmount" methodname="setItemTaxAmount" paramcount="0" />
+	            <call-method-rule pattern="itemDiscountAmount" methodname="setItemDiscountAmount" paramcount="0" />
+	            <call-method-rule pattern="itemExtendedAmount" methodname="setItemExtendedAmount" paramcount="0" />
+	           	
+				<set-next-rule methodname="addProcurementCardTranAddItem" />
+			</pattern>   
+			
+			<pattern value="nonFuel">
+				<object-create-rule classname="edu.arizona.kfs.fp.businessobject.ProcurementCardTranNonFuel" />
+				
+	            <call-method-rule pattern="nonFuelProductCode" methodname="setNonFuelProductCode" paramcount="0" />
+	            <call-method-rule pattern="itemDesc" methodname="setItemDesc" paramcount="0" />
+	            <call-method-rule pattern="itemQuant" methodname="setItemQuant" paramcount="0" />
+	            <call-method-rule pattern="itemUnitOfMeasure" methodname="setItemUnitOfMeasure" paramcount="0" />
+	            <call-method-rule pattern="taxRateApplied" methodname="setTaxRateApplied" paramcount="0" />
+	            <call-method-rule pattern="itemTaxAmt" methodname="setItemTaxAmt" paramcount="0" />
+	            <call-method-rule pattern="alternateTaxId" methodname="setAlternateTaxId" paramcount="0" />
+	            <call-method-rule pattern="itemDiscountAmt" methodname="setItemDiscountAmt" paramcount="0" />
+	            <call-method-rule pattern="itemTotal" methodname="setItemTotal" paramcount="0" />	            
+	           	
+				<set-next-rule methodname="addProcurementCardTranNonFuel" />
+			</pattern> 
+			
+			<pattern value="shipService">
+				<object-create-rule classname="edu.arizona.kfs.fp.businessobject.ProcurementCardTranShipSvc" />
+				
+	            <call-method-rule pattern="courierName" methodname="setCourierName" paramcount="0" />
+	            <call-method-rule pattern="trackingNumber" methodname="setTrackingNumber" paramcount="0" />
+	            <call-method-rule pattern="serviceDescription" methodname="setServiceDescription" paramcount="0" />
+	            <call-method-rule pattern="pickupDate" methodname="setPickupDate" paramcount="0" />
+	            <call-method-rule pattern="originZip" methodname="setOriginZip" paramcount="0" />
+	            <call-method-rule pattern="originCountryCd" methodname="setOriginCountryCd" paramcount="0" />
+	            <call-method-rule pattern="destinationZip" methodname="setDestinationZip" paramcount="0" />
+	            <call-method-rule pattern="destinationCountryCd" methodname="setDestinationCountryCd" paramcount="0" />
+	            <call-method-rule pattern="netAmount" methodname="setNetAmount" paramcount="0" />
+	            <call-method-rule pattern="taxAmt" methodname="setTaxAmt" paramcount="0" />	 
+	            <call-method-rule pattern="discAmt" methodname="setDiscAmt" paramcount="0" />	 
+	            <call-method-rule pattern="numberOfPackages" methodname="setNumberOfPackages" paramcount="0" />
+	            <call-method-rule pattern="weight" methodname="setWeight" paramcount="0" />
+	            <call-method-rule pattern="unitsOfMeasure" methodname="setUnitsOfMeasure" paramcount="0" />	 
+	            <call-method-rule pattern="senderName" methodname="setSenderName" paramcount="0" />	 
+	            <call-method-rule pattern="senderAddress" methodname="setSenderAddress" paramcount="0" />
+	            <call-method-rule pattern="receiverName" methodname="setReceiverName" paramcount="0" />
+	            <call-method-rule pattern="receiverAddress" methodname="setReceiverAddress" paramcount="0" />	 
+	            <call-method-rule pattern="customerRefNumber" methodname="setCustomerRefNumber" paramcount="0" />	 
+	                   	
+				<set-next-rule methodname="addProcurementCardTranShipSvc" />
+			</pattern>
+			
+			<pattern value="tempService">
+				<object-create-rule classname="edu.arizona.kfs.fp.businessobject.ProcurementCardTranTempSvc" />
+				
+	            <call-method-rule pattern="weekEndingDate" methodname="setWeekEndingDate" paramcount="0" />
+	            <call-method-rule pattern="serviceDesc" methodname="setServiceDesc" paramcount="0" />
+	            <call-method-rule pattern="employeeName" methodname="setEmployeeName" paramcount="0" />
+	            <call-method-rule pattern="regularRate" methodname="setRegularRate" paramcount="0" />
+	            <call-method-rule pattern="regularHours" methodname="setRegularHours" paramcount="0" />
+	            <call-method-rule pattern="overtimeRate" methodname="setOvertimeRate" paramcount="0" />
+	            <call-method-rule pattern="overtimeHours" methodname="setOvertimeHours" paramcount="0" />
+	            <call-method-rule pattern="miscExpenseAmt" methodname="setMiscExpenseAmt" paramcount="0" />
+	            <call-method-rule pattern="subTotalAmt" methodname="setSubTotalAmt" paramcount="0" />
+	            <call-method-rule pattern="salesTaxAmt" methodname="setSalesTaxAmt" paramcount="0" />	 
+	            <call-method-rule pattern="discountAmt" methodname="setDiscountAmt" paramcount="0" />	 
+	            <call-method-rule pattern="startDate" methodname="setStartDate" paramcount="0" />
+	            <call-method-rule pattern="supervisor" methodname="setSupervisor" paramcount="0" />
+	            <call-method-rule pattern="timeSheetNumber" methodname="setTimeSheetNumber" paramcount="0" />	 
+	            <call-method-rule pattern="commodityCode" methodname="setCommodityCode" paramcount="0" />	 
+	            <call-method-rule pattern="jobCode" methodname="setJobCode" paramcount="0" />
+	           	                   	
+				<set-next-rule methodname="addProcurementCardTranTempSvc" />
+			</pattern>          
+			
+			<pattern value="transportLeg">
+				<object-create-rule classname="edu.arizona.kfs.fp.businessobject.ProcurementCardTranTransportLeg" />
+				
+	            <call-method-rule pattern="carrierCode" methodname="setCarrierCode" paramcount="0" />
+	            <call-method-rule pattern="serviceClass" methodname="setServiceClass" paramcount="0" />
+	            <call-method-rule pattern="departCity" methodname="setDepartCity" paramcount="0" />
+	            <call-method-rule pattern="conjunctionTicket" methodname="setConjunctionTicket" paramcount="0" />
+	            <call-method-rule pattern="exchangeTicket" methodname="setExchangeTicket" paramcount="0" />
+	            <call-method-rule pattern="destinationCity" methodname="setDestinationCity" paramcount="0" />
+	            <call-method-rule pattern="fareBasisCode" methodname="setFareBasisCode" paramcount="0" />
+	            <call-method-rule pattern="flightNumber" methodname="setFlightNumber" paramcount="0" />
+	            <call-method-rule pattern="departTime" methodname="setDepartTime" paramcount="0" />
+	            <call-method-rule pattern="departTimeSegment" methodname="setDepartTimeSegment" paramcount="0" />
+	            <call-method-rule pattern="arriveTime" methodname="setArriveTime" paramcount="0" />
+	            <call-method-rule pattern="arriveTimeSegment" methodname="setArriveTimeSegment" paramcount="0" />
+	            <call-method-rule pattern="fare" methodname="setFare" paramcount="0" />
+	            <call-method-rule pattern="fees" methodname="setFees" paramcount="0" />
+	            <call-method-rule pattern="taxes" methodname="setTaxes" paramcount="0" />
+	            <call-method-rule pattern="endorsements" methodname="setEndorsements" paramcount="0" />
+	            <call-method-rule pattern="controlCode" methodname="setControlCode" paramcount="0" />
+	            	           	
+				<set-next-rule methodname="addProcurementCardTranTransportLeg" />
+			</pattern>                     
+
+            <set-next-rule methodname="add" />
+        </pattern>
+
+    </pattern>
+</digester-rules>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3Add.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3Add.xml
@@ -1,0 +1,159 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+  
+  <bean id="ProcurementCardLevel3Add" parent="ProcurementCardLevel3Add-parentBean" />
+  
+  <bean id="ProcurementCardLevel3Add-parentBean" abstract="true" parent="BusinessObjectEntry">
+  	<property name="businessObjectClass" value="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Add" />
+  	<property name="objectLabel" value="Procurement Card Addendum" />
+  	<property name="attributes" >
+  		<list>
+  			<ref bean="ProcurementCardLevel3Add-documentNumber" />
+  			<ref bean="ProcurementCardLevel3Add-financialDocumentTransactionLineNumber" />
+  			<ref bean="ProcurementCardLevel3Add-invoiceNumber" />
+  			<ref bean="ProcurementCardLevel3Add-orderDate" />
+  			<ref bean="ProcurementCardLevel3Add-purchaseTime" />
+  			<ref bean="ProcurementCardLevel3Add-shipPostal" />
+  			<ref bean="ProcurementCardLevel3Add-destinationPostal" />
+  			<ref bean="ProcurementCardLevel3Add-destinationCountryCode" />
+  			<ref bean="ProcurementCardLevel3Add-taxAmount" />
+  			<ref bean="ProcurementCardLevel3Add-taxRate" />
+  			<ref bean="ProcurementCardLevel3Add-discountAmount" />
+  			<ref bean="ProcurementCardLevel3Add-freightAmount" />
+  			<ref bean="ProcurementCardLevel3Add-dutyAmount" />
+  		</list>
+  	</property>
+  </bean>
+
+<!-- Attribute Definitions -->
+
+  <bean id="ProcurementCardLevel3Add-documentNumber" parent="ProcurementCardLevel3Add-documentNumber-parentBean" />
+  <bean id="ProcurementCardLevel3Add-documentNumber-parentBean" abstract="true" parent="DocumentHeader-documentNumber">
+  	<property name="forceUppercase" value="true"/>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Add-financialDocumentTransactionLineNumber" parent="ProcurementCardLevel3Add-financialDocumentTransactionLineNumber-parentBean" />
+  <bean id="ProcurementCardLevel3Add-financialDocumentTransactionLineNumber-parentBean" abstract="true" parent="ProcurementCardTransactionDetail-financialDocumentTransactionLineNumber"/>
+  
+  <bean id="ProcurementCardLevel3Add-invoiceNumber" parent="ProcurementCardLevel3Add-invoiceNumber-parentBean" />
+  <bean id="ProcurementCardLevel3Add-invoiceNumber-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="invoiceNumber" />
+  	<property name="label" value="VAT Invoice" />
+  	<property name="shortLabel" value="Invoice" />
+  	<property name="maxLength" value="15" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="17" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Add-orderDate" parent="ProcurementCardLevel3Add-orderDate-parentBean" />
+  <bean id="ProcurementCardLevel3Add-orderDate-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="orderDate" />
+  	<property name="label" value="Order Date" />
+  	<property name="shortLabel" value="Date" />
+  	<property name="maxLength" value="10" />
+  	<property name="validationPattern" >
+  		<bean parent="DateValidationPattern" />
+  	</property>
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="12" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Add-purchaseTime" parent="ProcurementCardLevel3Add-purchaseTime-parentBean" />
+  <bean id="ProcurementCardLevel3Add-purchaseTime-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="purchaseTime" />
+  	<property name="label" value="Purchase Time" />
+  	<property name="shortLabel" value="Time" />
+  	<property name="maxLength" value="23" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="25" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Add-shipPostal" parent="ProcurementCardLevel3Add-shipPostal-parentBean" />
+  <bean id="ProcurementCardLevel3Add-shipPostal-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="shipPostal" />
+  	<property name="label" value="Shipping Zip/Postal Code" />
+  	<property name="shortLabel" value="Zip" />
+  	<property name="maxLength" value="10" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="12" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Add-destinationPostal" parent="ProcurementCardLevel3Add-destinationPostal-parentBean" />
+  <bean id="ProcurementCardLevel3Add-destinationPostal-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="destinationPostal" />
+  	<property name="label" value="Destination Zip/Postal Code" />
+  	<property name="shortLabel" value="Zip" />
+  	<property name="maxLength" value="10" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="12" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Add-destinationCountryCode" parent="ProcurementCardLevel3Add-destinationCountryCode-parentBean" />
+  <bean id="ProcurementCardLevel3Add-destinationCountryCode-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="destinationCountryCode" />
+  	<property name="label" value="Destination Contry Code" />
+  	<property name="shortLabel" value="Country Cd" />
+  	<property name="maxLength" value="3" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="5" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Add-taxAmount" parent="ProcurementCardLevel3Add-taxAmount-parentBean" />
+  <bean id="ProcurementCardLevel3Add-taxAmount-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="taxAmount" />
+  	<property name="label" value="VAT Tax Amount" />
+  	<property name="shortLabel" value="Amount" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Add-taxRate" parent="ProcurementCardLevel3Add-taxRate-parentBean" />
+  <bean id="ProcurementCardLevel3Add-taxRate-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="taxRate" />
+  	<property name="label" value="VAT Tax Rate" />
+  	<property name="shortLabel" value="Rate" />
+  	<property name="maxLength" value="7" />
+  	<property name="validationPattern" >
+  		<bean parent="FloatingPointValidationPattern" />
+  	</property>
+  	<property name="control">
+  		<bean parent="TextControlDefinition"
+  			  p:size="9" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Add-discountAmount" parent="ProcurementCardLevel3Add-discountAmount-parentBean" />
+  <bean id="ProcurementCardLevel3Add-discountAmount-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="discountAmount" />
+  	<property name="label" value="Discount Amount" />
+  	<property name="shortLabel" value="Disc Amt" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Add-freightAmount" parent="ProcurementCardLevel3Add-freightAmount-parentBean" />
+  <bean id="ProcurementCardLevel3Add-freightAmount-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="freightAmount" />
+  	<property name="label" value="Freight Amount" />
+  	<property name="shortLabel" value="Frght Amt" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Add-dutyAmount" parent="ProcurementCardLevel3Add-dutyAmount-parentBean" />
+  <bean id="ProcurementCardLevel3Add-dutyAmount-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="dutyAmount" />
+  	<property name="label" value="Duty Amount" />
+  	<property name="shortLabel" value="Duty Amt" />
+  </bean>
+  
+</beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3AddItem.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3AddItem.xml
@@ -1,0 +1,188 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+  <bean id="ProcurementCardLevel3AddItem" parent="ProcurementCardLevel3AddItem-parentBean" />
+  <bean id="ProcurementCardLevel3AddItem-parentBean" abstract="true" parent="BusinessObjectEntry">
+  	<property name="businessObjectClass" value="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3AddItem" />
+  	<property name="inquiryDefinition">
+  		<ref bean="ProcurementCardLevel3AddItem-inquiryDefinition" />
+  	</property>
+  	<property name="objectLabel" value="Procurement Card Addendum Item" />
+  	<property name="attributes">
+  		<list>
+  			<ref bean="ProcurementCardLevel3AddItem-documentNumber" />
+  			<ref bean="ProcurementCardLevel3AddItem-financialDocumentTransactionLineNumber" />
+  			<ref bean="ProcurementCardLevel3AddItem-sequenceNumber" />
+  			<ref bean="ProcurementCardLevel3AddItem-itemCommodityCode" />
+  			<ref bean="ProcurementCardLevel3AddItem-itemProductCode" />
+  			<ref bean="ProcurementCardLevel3AddItem-itemDescription" />
+  			<ref bean="ProcurementCardLevel3AddItem-itemQuantity" />
+  			<ref bean="ProcurementCardLevel3AddItem-itemUnitCode" />
+  			<ref bean="ProcurementCardLevel3AddItem-itemAmount" />
+  			<ref bean="ProcurementCardLevel3AddItem-itemDebitCreditCode" />
+  			<ref bean="ProcurementCardLevel3AddItem-itemTaxRate" />
+  			<ref bean="ProcurementCardLevel3AddItem-itemTaxAmount" />
+  			<ref bean="ProcurementCardLevel3AddItem-itemDiscountAmount" />
+  			<ref bean="ProcurementCardLevel3AddItem-itemExtendedAmount" />
+  		</list>
+  	</property>
+  </bean>
+  
+<!-- Attribute Definitions -->
+  <bean id="ProcurementCardLevel3AddItem-documentNumber" parent="ProcurementCardLevel3AddItem-documentNumber-parentBean"/>
+  <bean id="ProcurementCardLevel3AddItem-documentNumber-parentBean" abstract="true" parent="DocumentHeader-documentNumber">
+  	<property name="forceUppercase" value="true"/>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3AddItem-financialDocumentTransactionLineNumber" parent="ProcurementCardLevel3AddItem-financialDocumentTransactionLineNumber-parentBean" />
+  <bean id="ProcurementCardLevel3AddItem-financialDocumentTransactionLineNumber-parentBean" abstract="true" parent="ProcurementCardTransactionDetail-financialDocumentTransactionLineNumber"/>
+  
+  <bean id="ProcurementCardLevel3AddItem-sequenceNumber" parent="ProcurementCardLevel3AddItem-sequenceNumber-parentBean" />
+  <bean id="ProcurementCardLevel3AddItem-sequenceNumber-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="sequenceNumber" />
+  	<property name="forceUppercase" value="true" />
+  	<property name="label" value="Row" />
+  	<property name="shortLabel" value="Row" />
+  	<property name="maxLength" value="6" />
+  	<property name="validationPattern">
+  		<bean parent="NumericValidationPattern" />
+  	</property>
+  	<property name="control">
+  		<bean parent="TextControlDefinition" 
+  			  p:size="8" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3AddItem-itemCommodityCode" parent="ProcurementCardLevel3AddItem-itemCommodityCode-parentBean" />
+  <bean id="ProcurementCardLevel3AddItem-itemCommodityCode-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="itemCommodityCode" />
+  	<property name="label" value="Commodity Code" />
+  	<property name="shortLabel" value="Comm Cd" />
+  	<property name="maxLength" value="12" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="14" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3AddItem-itemProductCode" parent="ProcurementCardLevel3AddItem-itemProductCode-parentBean" />
+  <bean id="ProcurementCardLevel3AddItem-itemProductCode-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="itemProductCode" />
+  	<property name="label" value="Product Code" />
+  	<property name="shortLabel" value="Prod Cd" />
+  	<property name="maxLength" value="12" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="14" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3AddItem-itemDescription" parent="ProcurementCardLevel3AddItem-itemDescription-parentBean" />
+  <bean id="ProcurementCardLevel3AddItem-itemDescription-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="itemDescription" />
+  	<property name="label" value="Description" />
+  	<property name="shortLabel" value="Desc" />
+  	<property name="maxLength" value="35" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="37" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3AddItem-itemQuantity" parent="ProcurementCardLevel3AddItem-itemQuantity-parentBean" />
+  <bean id="ProcurementCardLevel3AddItem-itemQuantity-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="itemQuantity" />
+  	<property name="forceUppercase" value="true" />
+  	<property name="label" value="Quantity" />
+  	<property name="shortLabel" value="Quantity" />
+  	<property name="maxLength" value="19" />
+  	<property name="validationPattern" >
+  		<bean parent="FloatingPointValidationPattern" />
+  	</property>
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="21" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3AddItem-itemUnitCode" parent="ProcurementCardLevel3AddItem-itemUnitCode-parentBean" />
+  <bean id="ProcurementCardLevel3AddItem-itemUnitCode-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="itemUnitCode" />
+  	<property name="label" value="Unit of Measure" />
+  	<property name="shortLabel" value="Unit" />
+  	<property name="maxLength" value="12" />
+  	<property name="control">
+  		<bean parent="TextControlDefinition"
+  			  p:size="14" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3AddItem-itemAmount" parent="ProcurementCardLevel3AddItem-itemAmount-parentBean" />
+  <bean id="ProcurementCardLevel3AddItem-itemAmount-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="itemAmount" />
+  	<property name="label" value="Price Each" />
+  	<property name="shortLabel" value="Price" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3AddItem-itemDebitCreditCode" parent="ProcurementCardLevel3AddItem-itemDebitCreditCode-parentBean" />
+  <bean id="ProcurementCardLevel3AddItem-itemDebitCreditCode-parentBean" abstract="true" parent="ProcurementCardTransaction-transactionDebitCreditCode">
+  	<property name="name" value="itemDebitCreditCode" />
+  	<property name="label" value="Debit Credit Code" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3AddItem-itemTaxRate" parent="ProcurementCardLevel3AddItem-itemTaxRate-parentBean" />
+  <bean id="ProcurementCardLevel3AddItem-itemTaxRate-parentBean" abstract="true" parent="ProcurementCardLevel3Add-taxRate">
+  	<property name="name" value="itemTaxRate" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3AddItem-itemTaxAmount" parent="ProcurementCardLevel3AddItem-itemTaxAmount-parentBean" />
+  <bean id="ProcurementCardLevel3AddItem-itemTaxAmount-parentBean" abstract="true" parent="ProcurementCardLevel3Add-taxAmount">
+  	<property name="name" value="itemTaxAmount" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3AddItem-itemDiscountAmount" parent="ProcurementCardLevel3AddItem-itemDiscountAmount-parentBean" />
+  <bean id="ProcurementCardLevel3AddItem-itemDiscountAmount-parentBean" abstract="true" parent="ProcurementCardLevel3Add-discountAmount">
+  	<property name="name" value="itemDiscountAmount" />
+  	<property name="label" value="Discount Per Line" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3AddItem-itemExtendedAmount" parent="ProcurementCardLevel3AddItem-itemExtendedAmount-parentBean" />
+  <bean id="ProcurementCardLevel3AddItem-itemExtendedAmount-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="itemExtendedAmount" />
+  	<property name="label" value="Extension" />
+  	<property name="shortLabel" value="Ext Amt" />
+  </bean>
+  
+<!-- Business Object Inquiry Definition -->  
+  <bean id="ProcurementCardLevel3AddItem-inquiryDefinition" parent="ProcurementCardLevel3AddItem-inquiryDefinition-parentBean" />
+  <bean id="ProcurementCardLevel3AddItem-inquiryDefinition-parentBean" abstract="true" parent="InquiryDefinition">
+  	<property name="title" value="Procurement Card Items Inquiry" />
+  	<property name="inquirySections">
+  	  <list>
+  	  	<bean parent="InquirySectionDefinition">
+  	  	  <property name="title" value="Procurement Card Items" />
+  	  	  <property name="numberOfColumns" value="4" />
+  	  	  <property name="inquiryFields" >
+  	  	  	<list>
+  	  	  	  <bean parent="FieldDefinition" p:attributeName="sequenceNumber" />
+  	  	  	  <bean parent="FieldDefinition" p:attributeName="itemCommodityCode" />
+  	  	  	  <bean parent="FieldDefinition" p:attributeName="itemProductCode" />
+  	  	  	  <bean parent="FieldDefinition" p:attributeName="itemDescription" />
+  	  	  	  <bean parent="FieldDefinition" p:attributeName="itemQuantity" />
+  	  	  	  <bean parent="FieldDefinition" p:attributeName="itemUnitCode" />
+  	  	  	  <bean parent="FieldDefinition" p:attributeName="itemAmount" />
+  	  	  	  <bean parent="FieldDefinition" p:attributeName="itemTaxRate" />
+  	  	  	  <bean parent="FieldDefinition" p:attributeName="itemTaxAmount" />
+  	  	  	  <bean parent="FieldDefinition" p:attributeName="itemDiscountAmount" />
+  	  	  	  <bean parent="FieldDefinition" p:attributeName="itemExtendedAmount" />
+  	  	  	</list>
+  	  	  </property>
+  	  	</bean>
+	  </list>
+  	</property>
+  </bean>
+
+</beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3AddUser.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3AddUser.xml
@@ -1,0 +1,53 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+        
+  <bean id="ProcurementCardLevel3AddUser" parent="ProcurementCardLevel3AddUser-parentBean" />
+  
+  <bean id="ProcurementCardLevel3AddUser-parentBean" abstract="true" parent="BusinessObjectEntry">
+  	<property name="businessObjectClass" value="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3AddUser" />
+  	<property name="objectLabel" value="Procurement Card Addendum User" />
+  	<property name="attributes" >
+  		<list>
+  			<ref bean="ProcurementCardLevel3AddUser-documentNumber" />
+  			<ref bean="ProcurementCardLevel3AddUser-financialDocumentTransactionLineNumber" />
+  			<ref bean="ProcurementCardLevel3AddUser-userEffectiveDate" />
+  			<ref bean="ProcurementCardLevel3AddUser-userAmount" />
+  		</list>
+  	</property>
+  </bean>
+  
+<!-- Attribute Definitions -->  
+  <bean id="ProcurementCardLevel3AddUser-documentNumber" parent="ProcurementCardLevel3AddUser-documentNumber-parentBean" />
+  <bean id="ProcurementCardLevel3AddUser-documentNumber-parentBean" abstract="true" parent="DocumentHeader-documentNumber">
+  	<property name="forceUppercase" value="true"/>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3AddUser-financialDocumentTransactionLineNumber" parent="ProcurementCardLevel3AddUser-financialDocumentTransactionLineNumber-parentBean" />
+  <bean id="ProcurementCardLevel3AddUser-financialDocumentTransactionLineNumber-parentBean" abstract="true" parent="ProcurementCardTransactionDetail-financialDocumentTransactionLineNumber" />
+  
+  <bean id="ProcurementCardLevel3AddUser-userEffectiveDate" parent="ProcurementCardLevel3AddUser-userEffectiveDate-parentBean" />
+  <bean id="ProcurementCardLevel3AddUser-userEffectiveDate-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="userEffectiveDate" />
+  	<property name="label" value="Effective Date" />
+  	<property name="shortLabel" value="Date" />
+  	<property name="maxLength" value="10" />
+  	<property name="validationPattern" >
+  		<bean parent="DateValidationPattern" />
+  	</property>
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="12" />
+  	</property>
+  </bean>
+
+  <bean id="ProcurementCardLevel3AddUser-userAmount" parent="ProcurementCardLevel3AddUser-userAmount-parentBean" />
+  <bean id="ProcurementCardLevel3AddUser-userAmount-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="userAmount" />
+  	<property name="label" value="Amount" />
+  	<property name="shortLabel" value="Amount" />
+  </bean>
+
+</beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3Fuel.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3Fuel.xml
@@ -1,0 +1,221 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+  <bean id="ProcurementCardLevel3Fuel" parent="ProcurementCardLevel3Fuel-parentBean" />
+  
+  <bean id="ProcurementCardLevel3Fuel-parentBean" abstract="true" parent="BusinessObjectEntry">
+  	<property name="businessObjectClass" value="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Fuel" />
+  	<property name="objectLabel" value="Procurement Card Fuel" />
+  	<property name="attributes" >
+  		<list>
+  			<ref bean="ProcurementCardLevel3Fuel-documentNumber" />
+  			<ref bean="ProcurementCardLevel3Fuel-financialDocumentTransactionLineNumber" />
+  			<ref bean="ProcurementCardLevel3Fuel-oilBrandName" />
+  			<ref bean="ProcurementCardLevel3Fuel-odometerReading" />
+  			<ref bean="ProcurementCardLevel3Fuel-fleetId" />
+  			<ref bean="ProcurementCardLevel3Fuel-messageId" />
+  			<ref bean="ProcurementCardLevel3Fuel-usage" />
+  			<ref bean="ProcurementCardLevel3Fuel-fuelServiceType" />
+  			<ref bean="ProcurementCardLevel3Fuel-fuelProductCd" />
+  			<ref bean="ProcurementCardLevel3Fuel-productTypeCd" />
+  			<ref bean="ProcurementCardLevel3Fuel-fuelQuantity" />
+  			<ref bean="ProcurementCardLevel3Fuel-fuelUnitOfMeasure" />
+  			<ref bean="ProcurementCardLevel3Fuel-fuelUnitPrice" />
+  			<ref bean="ProcurementCardLevel3Fuel-fuelSaleAmount" />
+  			<ref bean="ProcurementCardLevel3Fuel-fuelDiscountAmount" />
+  			<ref bean="ProcurementCardLevel3Fuel-taxAmount1" />
+  			<ref bean="ProcurementCardLevel3Fuel-taxAmount2" />
+  			<ref bean="ProcurementCardLevel3Fuel-totalAmount" />
+  		</list>
+  	</property>
+  </bean>
+
+<!-- Attribute Definitions -->
+  <bean id="ProcurementCardLevel3Fuel-documentNumber" parent="ProcurementCardLevel3Fuel-documentNumber-parentBean" />
+  <bean id="ProcurementCardLevel3Fuel-documentNumber-parentBean" abstract="true" parent="DocumentHeader-documentNumber">
+  	<property name="forceUppercase" value="true" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Fuel-financialDocumentTransactionLineNumber" parent="ProcurementCardLevel3Fuel-financialDocumentTransactionLineNumber-parentBean" />
+  <bean id="ProcurementCardLevel3Fuel-financialDocumentTransactionLineNumber-parentBean" abstract="true" parent="ProcurementCardTransactionDetail-financialDocumentTransactionLineNumber" />
+  
+  <bean id="ProcurementCardLevel3Fuel-oilBrandName" parent="ProcurementCardLevel3Fuel-oilBrandName-parentBean" />
+  <bean id="ProcurementCardLevel3Fuel-oilBrandName-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="oilBrandName" />
+  	<property name="label" value="Oil Brand Name" />
+  	<property name="shortLabel" value="Name" />
+  	<property name="maxLength" value="10" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="12" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Fuel-odometerReading" parent="ProcurementCardLevel3Fuel-odometerReading-parentBean" />
+  <bean id="ProcurementCardLevel3Fuel-odometerReading-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="odometerReading" />
+  	<property name="label" value="Odometer Reading" />
+  	<property name="shortLabel" value="Odometer" />
+  	<property name="maxLength" value="10" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="12" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Fuel-fleetId" parent="ProcurementCardLevel3Fuel-fleetId-parentBean" />
+  <bean id="ProcurementCardLevel3Fuel-fleetId-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="fleetId" />
+  	<property name="label" value="Fleet ID" />
+  	<property name="shortLabel" value="Fleet ID" />
+  	<property name="maxLength" value="20" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="22" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Fuel-messageId" parent="ProcurementCardLevel3Fuel-messageId-parentBean" />
+  <bean id="ProcurementCardLevel3Fuel-messageId-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="messageId" />
+  	<property name="label" value="Message ID" />
+  	<property name="shortLabel" value="Message ID" />
+  	<property name="maxLength" value="15" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="17" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Fuel-usage" parent="ProcurementCardLevel3Fuel-usage-parentBean" />
+  <bean id="ProcurementCardLevel3Fuel-usage-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="usage" />
+  	<property name="label" value="Usage" />
+  	<property name="shortLabel" value="Usage" />
+  	<property name="maxLength" value="20" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="22" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Fuel-fuelServiceType" parent="ProcurementCardLevel3Fuel-fuelServiceType-parentBean" />
+  <bean id="ProcurementCardLevel3Fuel-fuelServiceType-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="fuelServiceType" />
+  	<property name="label" value="Fuel Service Type" />
+  	<property name="shortLabel" value="Fuel Svc" />
+  	<property name="maxLength" value="1" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="3" />
+  	</property> 
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Fuel-fuelProductCd" parent="ProcurementCardLevel3Fuel-fuelProductCd-parentBean" />
+  <bean id="ProcurementCardLevel3Fuel-fuelProductCd-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="fuelProductCd" />
+  	<property name="label" value="Fuel Product Code" />
+  	<property name="shortLabel" value="Fuel Product" />
+  	<property name="maxLength" value="3" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="5" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Fuel-productTypeCd" parent="ProcurementCardLevel3Fuel-productTypeCd-parentBean" />
+  <bean id="ProcurementCardLevel3Fuel-productTypeCd-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="productTypeCd" />
+  	<property name="label" value="Product Type Code" />
+  	<property name="shortLabel" value="Product Type" />
+  	<property name="maxLength" value="1" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="3" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Fuel-fuelQuantity" parent="ProcurementCardLevel3Fuel-fuelQuantity-parentBean" />
+  <bean id="ProcurementCardLevel3Fuel-fuelQuantity-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="fuelQuantity" />
+  	<property name="label" value="Fuel Quantity" />
+  	<property name="shortLabel" value="Fuel" />
+  	<property name="maxLength" value="19" />
+  	<property name="validationPattern" >
+  		<bean parent="FloatingPointValidationPattern" p:allowNegative="true" />
+  	</property>
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="21" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Fuel-fuelUnitOfMeasure" parent="ProcurementCardLevel3Fuel-fuelUnitOfMeasure-parentBean" />
+  <bean id="ProcurementCardLevel3Fuel-fuelUnitOfMeasure-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="fuelUnitOfMeasure" />
+  	<property name="label" value="Fuel Unit Of Measure" />
+  	<property name="shortLabel" value="Fuel Unit" />
+  	<property name="maxLength" value="1" />
+  	<property name="validationPattern" >
+  		<bean parent="NumericValidationPattern" />
+  	</property>
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="3" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Fuel-fuelUnitPrice" parent="ProcurementCardLevel3Fuel-fuelUnitPrice-parentBean" />
+  <bean id="ProcurementCardLevel3Fuel-fuelUnitPrice-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="fuelUnitPrice" />
+  	<property name="label" value="Fuel Unit Price" />
+  	<property name="shortLabel" value="Fuel Price" />
+  	<property name="maxLength" value="19" />
+  	<property name="validationPattern" >
+  		<bean parent="FloatingPointValidationPattern" p:allowNegative="true" />
+  	</property>
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="21" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Fuel-fuelSaleAmount" parent="ProcurementCardLevel3Fuel-fuelSaleAmount-parentBean" />
+  <bean id="ProcurementCardLevel3Fuel-fuelSaleAmount-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="fuelSaleAmount" />
+  	<property name="label" value="Fuel Sale Amount" />
+  	<property name="shortLabel" value="Sale Amt" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Fuel-fuelDiscountAmount" parent="ProcurementCardLevel3Fuel-fuelDiscountAmount-parentBean" />
+  <bean id="ProcurementCardLevel3Fuel-fuelDiscountAmount-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="fuelDiscountAmount" />
+  	<property name="label" value="Coupon Discount Amount" />
+  	<property name="shortLabel" value="Discount Amt" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Fuel-taxAmount1" parent="ProcurementCardLevel3Fuel-taxAmount1-parentBean" />
+  <bean id="ProcurementCardLevel3Fuel-taxAmount1-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="taxAmount1" />
+  	<property name="label" value="Tax Amount 1" />
+  	<property name="shortLabel" value="Tax Amt1" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Fuel-taxAmount2" parent="ProcurementCardLevel3Fuel-taxAmount2-parentBean" />
+  <bean id="ProcurementCardLevel3Fuel-taxAmount2-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="taxAmount2" />
+  	<property name="label" value="Tax Amount 2" />
+  	<property name="shortLabel" value="Tax Amt2" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Fuel-totalAmount" parent="ProcurementCardLevel3Fuel-totalAmount-parentBean" />
+  <bean id="ProcurementCardLevel3Fuel-totalAmount-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="totalAmount" />
+  	<property name="label" value="Total Amount" />
+  	<property name="shortLabel" value="Total Amt" />
+  </bean>
+
+</beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3Generic.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3Generic.xml
@@ -1,0 +1,58 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+  <bean id="ProcurementCardLevel3Generic" parent="ProcurementCardLevel3Generic-parentBean" />
+  
+  <bean id="ProcurementCardLevel3Generic-parentBean" abstract="true" parent="BusinessObjectEntry">
+  	<property name="businessObjectClass" value="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Generic" />
+  	<property name="objectLabel" value="Procurement Card Addendum Generic" />
+  	<property name="attributes" >
+  		<list>
+  			<ref bean="ProcurementCardLevel3Generic-documentNumber" />
+  			<ref bean="ProcurementCardLevel3Generic-financialDocumentTransactionLineNumber" />
+  			<ref bean="ProcurementCardLevel3Generic-genericEffectiveDate" />
+  			<ref bean="ProcurementCardLevel3Generic-genericData" />
+  		</list>
+  	</property>
+  </bean>
+  
+<!-- Attribute Definitions -->
+  <bean id="ProcurementCardLevel3Generic-documentNumber" parent="ProcurementCardLevel3Generic-documentNumber-parentBean" />
+  <bean id="ProcurementCardLevel3Generic-documentNumber-parentBean" abstract="true" parent="DocumentHeader-documentNumber">
+  	<property name="forceUppercase" value="true"/>
+  </bean> 
+  
+  <bean id="ProcurementCardLevel3Generic-financialDocumentTransactionLineNumber" parent="ProcurementCardLevel3Generic-financialDocumentTransactionLineNumber-parentBean" />
+  <bean id="ProcurementCardLevel3Generic-financialDocumentTransactionLineNumber-parentBean" abstract="true" parent="ProcurementCardTransactionDetail-financialDocumentTransactionLineNumber" />
+  
+  <bean id="ProcurementCardLevel3Generic-genericEffectiveDate" parent="ProcurementCardLevel3Generic-genericEffectiveDate-parentBean" />
+  <bean id="ProcurementCardLevel3Generic-genericEffectiveDate-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="genericEffectiveDate" />
+  	<property name="label" value="Effective Date" />
+  	<property name="shortLabel" value="Date" />
+  	<property name="maxLength" value="10" />
+  	<property name="validationPattern">
+  		<bean parent="DateValidationPattern" />
+  	</property>
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="12" />
+  	</property>  	
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Generic-genericData" parent="ProcurementCardLevel3Generic-genericData-parentBean" />
+  <bean id="ProcurementCardLevel3Generic-genericData-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="genericData" />
+  	<property name="label" value="Generic Data" />
+  	<property name="shortLabel" value="Data" />
+  	<property name="maxLength" value="132" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="135" />
+  	</property>
+  </bean>
+
+</beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3Lodging.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3Lodging.xml
@@ -1,0 +1,222 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+  <bean id="ProcurementCardLevel3Lodging" parent="ProcurementCardLevel3Lodging-parentBean" />
+  
+  <bean id="ProcurementCardLevel3Lodging-parentBean" abstract="true" parent="BusinessObjectEntry">
+  	<property name="businessObjectClass" value="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Lodging" />
+  	<property name="objectLabel" value="Procurement Card Lodging" />
+  	<property name="attributes" >
+  		<list>
+  			<ref bean="ProcurementCardLevel3Lodging-documentNumber" />
+  			<ref bean="ProcurementCardLevel3Lodging-financialDocumentTransactionLineNumber" />
+  			<ref bean="ProcurementCardLevel3Lodging-arriveDate" />
+  			<ref bean="ProcurementCardLevel3Lodging-departureDate" />
+  			<ref bean="ProcurementCardLevel3Lodging-folioNum" />
+  			<ref bean="ProcurementCardLevel3Lodging-propertyPhoneNum" />
+  			<ref bean="ProcurementCardLevel3Lodging-customerServiceNum" />
+  			<ref bean="ProcurementCardLevel3Lodging-prePaidAmt" />
+  			<ref bean="ProcurementCardLevel3Lodging-roomRate" />
+  			<ref bean="ProcurementCardLevel3Lodging-roomTax" />
+  			<ref bean="ProcurementCardLevel3Lodging-programCode" />
+  			<ref bean="ProcurementCardLevel3Lodging-callCharges" />
+  			<ref bean="ProcurementCardLevel3Lodging-foodSvcCharges" />
+  			<ref bean="ProcurementCardLevel3Lodging-miniBarCharges" />
+  			<ref bean="ProcurementCardLevel3Lodging-giftShopCharges" />
+  			<ref bean="ProcurementCardLevel3Lodging-laundryCharges" />
+  			<ref bean="ProcurementCardLevel3Lodging-healthClubCharges" />
+  			<ref bean="ProcurementCardLevel3Lodging-movieCharges" />
+  			<ref bean="ProcurementCardLevel3Lodging-busCtrCharges" />
+  			<ref bean="ProcurementCardLevel3Lodging-parkingCharges" />
+  			<ref bean="ProcurementCardLevel3Lodging-otherCode" />
+  			<ref bean="ProcurementCardLevel3Lodging-otherCharges" />
+  			<ref bean="ProcurementCardLevel3Lodging-adjustmentAmount" />
+  		</list>
+  	</property>
+  </bean>
+  
+<!-- Attribute Definitions -->  
+  <bean id="ProcurementCardLevel3Lodging-documentNumber" parent="ProcurementCardLevel3Lodging-documentNumber-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-documentNumber-parentBean" abstract="true" parent="DocumentHeader-documentNumber">
+  	<property name="forceUppercase" value="true"/>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Lodging-financialDocumentTransactionLineNumber" parent="ProcurementCardLevel3Lodging-financialDocumentTransactionLineNumber-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-financialDocumentTransactionLineNumber-parentBean" abstract="true" parent="ProcurementCardTransactionDetail-financialDocumentTransactionLineNumber"/>
+  
+  <bean id="ProcurementCardLevel3Lodging-arriveDate" parent="ProcurementCardLevel3Lodging-arriveDate-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-arriveDate-parentBean" abstract="true" parent="GenericAttributes-genericDate">
+  	<property name="name" value="arriveDate" />
+  	<property name="label" value="Arrive Date" />
+  	<property name="shortLabel" value="Date" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Lodging-departureDate" parent="ProcurementCardLevel3Lodging-departureDate-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-departureDate-parentBean" abstract="true" parent="GenericAttributes-genericDate">
+  	<property name="name" value="departureDate" />
+  	<property name="label" value="Departure Date" />
+  	<property name="shortLabel" value="Dept Date" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Lodging-folioNum" parent="ProcurementCardLevel3Lodging-folioNum-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-folioNum-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="folioNum" />
+  	<property name="label" value="Folio Number" />
+  	<property name="shortLabel" value="Folio Num" />
+  	<property name="maxLength" value="10" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="12" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Lodging-propertyPhoneNum" parent="ProcurementCardLevel3Lodging-propertyPhoneNum-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-propertyPhoneNum-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="propertyPhoneNum" />
+  	<property name="label" value="Property Phone Number" />
+  	<property name="shortLabel" value="Phone Num" />
+  	<property name="maxLength" value="25" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="27" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Lodging-customerServiceNum" parent="ProcurementCardLevel3Lodging-customerServiceNum-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-customerServiceNum-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="customerServiceNum" />
+  	<property name="label" value="Customer Service Number" />
+  	<property name="shortLabel" value="Cust Svc Num" />
+  	<property name="maxLength" value="25" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="27" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Lodging-prePaidAmt" parent="ProcurementCardLevel3Lodging-prePaidAmt-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-prePaidAmt-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="prePaidAmt" />
+  	<property name="label" value="Prepaid Amount" />
+  	<property name="shortLabel" value="Prepaid Amt"/>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Lodging-roomRate" parent="ProcurementCardLevel3Lodging-roomRate-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-roomRate-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="roomRate" />
+  	<property name="label" value="Room Rate" />
+  	<property name="shortLabel" value="Rate" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Lodging-roomTax" parent="ProcurementCardLevel3Lodging-roomTax-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-roomTax-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="roomTax" />
+  	<property name="label" value="Room Tax" />
+  	<property name="shortLabel" value="Tax" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Lodging-programCode" parent="ProcurementCardLevel3Lodging-programCode-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-programCode-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="programCode" />
+  	<property name="label" value="Program Code" />
+  	<property name="shortLabel" value="Program Cd" />
+  	<property name="maxLength" value="2" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="4" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Lodging-callCharges" parent="ProcurementCardLevel3Lodging-callCharges-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-callCharges-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="callCharges" />
+  	<property name="label" value="Call Charges" />
+  	<property name="shortLabel" value="Call Chg" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Lodging-foodSvcCharges" parent="ProcurementCardLevel3Lodging-foodSvcCharges-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-foodSvcCharges-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="foodSvcCharges" />
+  	<property name="label" value="Food Service Charges" />
+  	<property name="shortLabel" value="Food Svc Chg" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Lodging-miniBarCharges" parent="ProcurementCardLevel3Lodging-miniBarCharges-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-miniBarCharges-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="miniBarCharges" />
+  	<property name="label" value="Bar/Mini Bar Charges" />
+  	<property name="shortLabel" value="Bar Chg" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Lodging-giftShopCharges" parent="ProcurementCardLevel3Lodging-giftShopCharges-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-giftShopCharges-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="giftShopCharges" />
+  	<property name="label" value="Gift Shop Charges" />
+  	<property name="shortLabel" value="Gift Chg" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Lodging-laundryCharges" parent="ProcurementCardLevel3Lodging-laundryCharges-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-laundryCharges-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="laundryCharges" />
+  	<property name="label" value="Laundry Charges" />
+  	<property name="shortLabel" value="Laundry Chg" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Lodging-healthClubCharges" parent="ProcurementCardLevel3Lodging-healthClubCharges-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-healthClubCharges-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="healthClubCharges" />
+  	<property name="label" value="Health Club Charges" />
+  	<property name="shortLabel" value="Health Chg" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Lodging-movieCharges" parent="ProcurementCardLevel3Lodging-movieCharges-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-movieCharges-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="movieCharges" />
+  	<property name="label" value="Movie Charges" />
+  	<property name="shortLabel" value="Movie Chg" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Lodging-busCtrCharges" parent="ProcurementCardLevel3Lodging-busCtrCharges-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-busCtrCharges-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="busCtrCharges" />
+  	<property name="label" value="Business Center Charges" />
+  	<property name="shortLabel" value="Bus Ctr Chg" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Lodging-parkingCharges" parent="ProcurementCardLevel3Lodging-parkingCharges-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-parkingCharges-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="parkingCharges" />
+  	<property name="label" value="Parking Charges" />
+  	<property name="shortLabel" value="Parking Chg" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Lodging-otherCode" parent="ProcurementCardLevel3Lodging-otherCode-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-otherCode-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="otherCode" />
+  	<property name="label" value="Other Code" />
+  	<property name="shortLabel" value="Other Cd" />
+  	<property name="maxLength" value="3" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="5" />
+  	</property>
+  </bean>  
+  
+  <bean id="ProcurementCardLevel3Lodging-otherCharges" parent="ProcurementCardLevel3Lodging-otherCharges-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-otherCharges-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="otherCharges" />
+  	<property name="label" value="Other Charges" />
+  	<property name="shortLabel" value="Other Chg" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Lodging-adjustmentAmount" parent="ProcurementCardLevel3Lodging-adjustmentAmount-parentBean" />
+  <bean id="ProcurementCardLevel3Lodging-adjustmentAmount-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="adjustmentAmount" />
+  	<property name="label" value="Adjustment Amount" />
+  	<property name="shortLabel" value="Adjust Amt" />
+  </bean>
+  
+</beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3NonFuel.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3NonFuel.xml
@@ -1,0 +1,156 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+        
+  <bean id="ProcurementCardLevel3NonFuel" parent="ProcurementCardLevel3NonFuel-parentBean" />
+  <bean id="ProcurementCardLevel3NonFuel-parentBean" abstract="true" parent="BusinessObjectEntry">
+  	<property name="businessObjectClass" value="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3NonFuel" />
+  	<property name="inquiryDefinition" >
+  		<ref bean="ProcurementCardLevel3NonFuel-inquiryDefinition" />
+  	</property>
+  	<property name="objectLabel" value="Procurement Card Non Fuel" />
+  	<property name="attributes" >
+  	  <list>
+  	  	<ref bean="ProcurementCardLevel3AddItem-documentNumber" />
+  	  	<ref bean="ProcurementCardLevel3AddItem-financialDocumentTransactionLineNumber" />
+  	  	<ref bean="ProcurementCardLevel3NonFuel-sequenceNumber" />
+  	  	<ref bean="ProcurementCardLevel3NonFuel-nonFuelProductCode" />
+  	  	<ref bean="ProcurementCardLevel3NonFuel-itemDesc" />
+  	  	<ref bean="ProcurementCardLevel3NonFuel-itemQuant" />
+  	  	<ref bean="ProcurementCardLevel3NonFuel-itemUnitOfMeasure" />
+  	  	<ref bean="ProcurementCardLevel3NonFuel-taxRateApplied" />
+  	  	<ref bean="ProcurementCardLevel3NonFuel-itemTaxAmt" />
+  	  	<ref bean="ProcurementCardLevel3NonFuel-alternateTaxId" />
+  	  	<ref bean="ProcurementCardLevel3NonFuel-itemDiscountAmt" />
+  	  	<ref bean="ProcurementCardLevel3NonFuel-itemTotal" />
+  	  </list>
+  	</property>
+  </bean>
+  
+<!-- Attribute Definitions -->  
+  <bean id="ProcurementCardLevel3NonFuel-documentNumber" parent="ProcurementCardLevel3NonFuel-documentNumber-parentBean" />
+  <bean id="ProcurementCardLevel3NonFuel-documentNumber-parentBean" abstract="true" parent="DocumentHeader-documentNumber">
+  	<property name="forceUppercase" value="true"/>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3NonFuel-financialDocumentTransactionLineNumber" parent="ProcurementCardLevel3NonFuel-financialDocumentTransactionLineNumber-parentBean" />
+  <bean id="ProcurementCardLevel3NonFuel-financialDocumentTransactionLineNumber-parentBean" abstract="true" parent="ProcurementCardTransactionDetail-financialDocumentTransactionLineNumber"/>
+  
+  <bean id="ProcurementCardLevel3NonFuel-sequenceNumber" parent="ProcurementCardLevel3NonFuel-sequenceNumber-parentBean" />
+  <bean id="ProcurementCardLevel3NonFuel-sequenceNumber-parentBean" abstract="true" parent="ProcurementCardLevel3AddItem-sequenceNumber">
+  </bean>
+  
+  <bean id="ProcurementCardLevel3NonFuel-nonFuelProductCode" parent="ProcurementCardLevel3NonFuel-nonFuelProductCode-parentBean" />
+  <bean id="ProcurementCardLevel3NonFuel-nonFuelProductCode-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="nonFuelProductCode" />
+    <property name="label" value="Non Fuel Product Code" />
+    <property name="shortLabel" value="Prod Cd" />
+    <property name="maxLength" value="3" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="5" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3NonFuel-itemDesc" parent="ProcurementCardLevel3NonFuel-itemDesc-parentBean" />
+  <bean id="ProcurementCardLevel3NonFuel-itemDesc-parentBean" abstract="true" parent="ProcurementCardLevel3AddItem-itemDescription">
+  	<property name="name" value="itemDesc" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3NonFuel-itemQuant" parent="ProcurementCardLevel3NonFuel-itemQuant-parentBean" />
+  <bean id="ProcurementCardLevel3NonFuel-itemQuant-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="itemQuant" />
+  	<property name="label" value="Item Quantity" />
+  	<property name="shortLabel" value="Quantity" />
+  	<property name="maxLength" value="6" />
+  	<property name="control" >
+  	  <bean parent="TextControlDefinition"
+  	  		p:size="8" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3NonFuel-itemUnitOfMeasure" parent="ProcurementCardLevel3NonFuel-itemUnitOfMeasure-parentBean" />
+  <bean id="ProcurementCardLevel3NonFuel-itemUnitOfMeasure-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="itemUnitOfMeasure" />
+  	<property name="label" value="Unit of Measure" />
+  	<property name="shortLabel" value="Unit" />
+  	<property name="maxLength" value="3" />
+  	<property name="control">
+  	  <bean parent="TextControlDefinition"
+  	  		p:size="5" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3NonFuel-taxRateApplied" parent="ProcurementCardLevel3NonFuel-taxRateApplied-parentBean" />
+  <bean id="ProcurementCardLevel3NonFuel-taxRateApplied-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="taxRateApplied" />
+  	<property name="label" value="Tax Rate Applied" />
+  	<property name="shortLabel" value="Tax Rate" />
+  	<property name="maxLength" value="5" />
+  	<property name="control" >
+  	  <bean parent="TextControlDefinition"
+  	  		p:size="7" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3NonFuel-itemTaxAmt" parent="ProcurementCardLevel3NonFuel-itemTaxAmt-parentBean" />
+  <bean id="ProcurementCardLevel3NonFuel-itemTaxAmt-parentBean" abstract="true" parent="ProcurementCardLevel3Add-taxAmount">
+  	<property name="name" value="itemTaxAmt" />
+  	<property name="label" value="Tax Amount" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3NonFuel-alternateTaxId" parent="ProcurementCardLevel3NonFuel-alternateTaxId-parentBean" />
+  <bean id="ProcurementCardLevel3NonFuel-alternateTaxId-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="alternateTaxId" />
+  	<property name="label" value="Alternate Tax ID" />
+  	<property name="shortLabel" value="Alt Tax ID" />
+  	<property name="maxLength" value="20" />
+  	<property name="control" >
+  	  <bean parent="TextControlDefinition"
+  	  		p:size="22" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3NonFuel-itemDiscountAmt" parent="ProcurementCardLevel3NonFuel-itemDiscountAmt-parentBean" />
+  <bean id="ProcurementCardLevel3NonFuel-itemDiscountAmt-parentBean" abstract="true" parent="ProcurementCardLevel3Add-discountAmount">
+  	<property name="name" value="itemDiscountAmt" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3NonFuel-itemTotal" parent="ProcurementCardLevel3NonFuel-itemTotal-parentBean" />
+  <bean id="ProcurementCardLevel3NonFuel-itemTotal-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="itemTotal" />
+  	<property name="label" value="Item Total" />
+  	<property name="shortLabel" value="Item Total" />
+  </bean>
+  
+<!-- Business Object Inquiry Definition -->  
+  <bean id="ProcurementCardLevel3NonFuel-inquiryDefinition" parent="ProcurementCardLevel3NonFuel-inquiryDefinition-parentBean" />
+  <bean id="ProcurementCardLevel3NonFuel-inquiryDefinition-parentBean" abstract="true" parent="InquiryDefinition">
+  	<property name="title" value="Procurement Card Non Fuel Inquiry" />
+  	<property name="inquirySections" >
+  	  <list>
+  	  	<bean parent="InquirySectionDefinition">
+  	  	  <property name="title" value="Procurement Card Non Fuel" />
+  	  	  <property name="numberOfColumns" value="4" />
+  	  	  <property name="inquiryFields">
+  	  	  	<list>
+  	  	  	  <bean parent="FieldDefinition" p:attributeName="sequenceNumber" />
+  	  	  	  <bean parent="FieldDefinition" p:attributeName="nonFuelProductCode" />
+  	  	  	  <bean parent="FieldDefinition" p:attributeName="itemDesc" />
+  	  	  	  <bean parent="FieldDefinition" p:attributeName="itemQuant" />
+  	  	  	  <bean parent="FieldDefinition" p:attributeName="itemUnitOfMeasure" />
+  	  	  	  <bean parent="FieldDefinition" p:attributeName="taxRateApplied" />
+  	  	  	  <bean parent="FieldDefinition" p:attributeName="itemTaxAmt" />
+  	  	  	  <bean parent="FieldDefinition" p:attributeName="alternateTaxId" />
+  	  	  	  <bean parent="FieldDefinition" p:attributeName="itemDiscountAmt" />
+  	  	  	  <bean parent="FieldDefinition" p:attributeName="itemTotal" />
+  	  	  	</list>
+  	  	  </property>
+  	  	</bean>
+  	  </list>
+  	</property>
+  </bean>
+  
+</beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3Rental.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3Rental.xml
@@ -1,0 +1,316 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+  <bean id="ProcurementCardLevel3Rental" parent="ProcurementCardLevel3Rental-parentBean" />
+  
+  <bean id="ProcurementCardLevel3Rental-parentBean" abstract="true" parent="BusinessObjectEntry">
+  	<property name="businessObjectClass" value="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Rental" />
+  	<property name="objectLabel" value="Procurement Card Rental" />
+  	<property name="attributes" >
+  		<list>
+  			<ref bean="ProcurementCardLevel3Rental-documentNumber" />
+  			<ref bean="ProcurementCardLevel3Rental-financialDocumentTransactionLineNumber" />
+  			<ref bean="ProcurementCardLevel3Rental-checkOutDate" />
+  			<ref bean="ProcurementCardLevel3Rental-rentalAgreementNum" />
+  			<ref bean="ProcurementCardLevel3Rental-renterName" />
+  			<ref bean="ProcurementCardLevel3Rental-returnCity" />
+  			<ref bean="ProcurementCardLevel3Rental-returnState" />
+  			<ref bean="ProcurementCardLevel3Rental-returnCountry" />
+  			<ref bean="ProcurementCardLevel3Rental-returnDate" />
+  			<ref bean="ProcurementCardLevel3Rental-returnLocation" />
+  			<ref bean="ProcurementCardLevel3Rental-customerSvcNum" />
+  			<ref bean="ProcurementCardLevel3Rental-rentalClass" />
+  			<ref bean="ProcurementCardLevel3Rental-dailyRate" />
+  			<ref bean="ProcurementCardLevel3Rental-weeklyRate" />
+  			<ref bean="ProcurementCardLevel3Rental-ratePerMile" />
+  			<ref bean="ProcurementCardLevel3Rental-maxFreeMiles" />
+  			<ref bean="ProcurementCardLevel3Rental-totalMiles" />
+  			<ref bean="ProcurementCardLevel3Rental-oneWayCharges" />
+  			<ref bean="ProcurementCardLevel3Rental-insuranceCharges" />
+  			<ref bean="ProcurementCardLevel3Rental-regularCharges" />
+  			<ref bean="ProcurementCardLevel3Rental-towingCharges" />
+  			<ref bean="ProcurementCardLevel3Rental-extraCharges" />
+  			<ref bean="ProcurementCardLevel3Rental-lateReturnFee" />
+  			<ref bean="ProcurementCardLevel3Rental-adjustCode" />
+  			<ref bean="ProcurementCardLevel3Rental-adjustAmount" />
+  			<ref bean="ProcurementCardLevel3Rental-progCode" />
+  			<ref bean="ProcurementCardLevel3Rental-phoneCharges" />
+  			<ref bean="ProcurementCardLevel3Rental-othrCharges" />
+  			<ref bean="ProcurementCardLevel3Rental-totalTaxAmount" /> 
+  		</list>
+  	</property>  	
+  </bean>
+  
+<!-- Attribute Definitions -->
+  <bean id="ProcurementCardLevel3Rental-documentNumber" parent="ProcurementCardLevel3Rental-documentNumber-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-documentNumber-parentBean" abstract="true" parent="DocumentHeader-documentNumber">
+  	<property name="forceUppercase" value="true"/>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-financialDocumentTransactionLineNumber" parent="ProcurementCardLevel3Rental-financialDocumentTransactionLineNumber-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-financialDocumentTransactionLineNumber-parentBean" abstract="true" parent="ProcurementCardTransactionDetail-financialDocumentTransactionLineNumber" />
+  
+  <bean id="ProcurementCardLevel3Rental-checkOutDate" parent="ProcurementCardLevel3Rental-checkOutDate-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-checkOutDate-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="checkOutDate" />
+  	<property name="label" value="Checkout Date" />
+  	<property name="shortLabel" value="Date" />
+  	<property name="maxLength" value="10" />
+  	<property name="validationPattern" >
+  		<bean parent="DateValidationPattern" />
+  	</property>
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="12" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-rentalAgreementNum" parent="ProcurementCardLevel3Rental-rentalAgreementNum-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-rentalAgreementNum-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="rentalAgreementNum" />
+  	<property name="label" value="Rental Agreement Number" />
+  	<property name="shortLabel" value="Rental Num" />
+  	<property name="maxLength" value="9" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition" 
+  			  p:size="11" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-renterName" parent="ProcurementCardLevel3Rental-renterName-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-renterName-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="renterName" />
+  	<property name="label" value="Renter Name" />
+  	<property name="shortLabel" value="Renter Name" />
+  	<property name="maxLength" value="40" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="42" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-returnCity" parent="ProcurementCardLevel3Rental-returnCity-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-returnCity-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="returnCity" />
+  	<property name="label" value="Return City" />
+  	<property name="shortLabel" value="Return City" />
+  	<property name="maxLength" value="18" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="20" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-returnState" parent="ProcurementCardLevel3Rental-returnState-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-returnState-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="returnState" />
+  	<property name="label" value="Return State" />
+  	<property name="shortLabel" value="Return St" />
+  	<property name="maxLength" value="3" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="5" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-returnCountry" parent="ProcurementCardLevel3Rental-returnCountry-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-returnCountry-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="returnCountry" />
+  	<property name="label" value="Return Country" />
+  	<property name="shortLabel" value="Return Country" />
+  	<property name="maxLength" value="3" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="5" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-returnDate" parent="ProcurementCardLevel3Rental-returnDate-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-returnDate-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="returnDate" />
+  	<property name="label" value="Return Date" />
+  	<property name="shortLabel" value="Return Dt" />
+  	<property name="maxLength" value="10" />
+  	<property name="validationPattern" >
+  		<bean parent="DateValidationPattern" />
+  	</property>
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="12" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-returnLocation" parent="ProcurementCardLevel3Rental-returnLocation-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-returnLocation-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="returnLocation" />
+  	<property name="label" value="Return Location" />
+  	<property name="shortLabel" value="Return Loc" />
+  	<property name="maxLength" value="10" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="12" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-customerSvcNum" parent="ProcurementCardLevel3Rental-customerSvcNum-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-customerSvcNum-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-customerServiceNum">
+  	<property name="name" value="customerSvcNum" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-rentalClass" parent="ProcurementCardLevel3Rental-rentalClass-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-rentalClass-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="rentalClass" />
+  	<property name="label" value="Rental Class" />
+  	<property name="shortLabel" value="Rental Cls" />
+  	<property name="maxLength" value="2" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="4" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-dailyRate" parent="ProcurementCardLevel3Rental-dailyRate-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-dailyRate-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="dailyRate" />
+  	<property name="label" value="Daily Rate" />
+  	<property name="shortLabel" value="Daily Rate" />	
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-weeklyRate" parent="ProcurementCardLevel3Rental-weeklyRate-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-weeklyRate-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="weeklyRate" />
+  	<property name="label" value="Weekly Rate" />
+  	<property name="shortLabel" value="Weekly Rate" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-ratePerMile" parent="ProcurementCardLevel3Rental-ratePerMile-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-ratePerMile-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="ratePerMile" />
+  	<property name="label" value="Rate Per Mile" />
+  	<property name="shortLabel" value="Rate Mile" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-maxFreeMiles" parent="ProcurementCardLevel3Rental-maxFreeMiles-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-maxFreeMiles-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="maxFreeMiles" />
+  	<property name="label" value="Maximum Free Miles" />
+  	<property name="shortLabel" value="Max Free Miles" />
+  	<property name="maxLength" value="10" />
+  	<property name="validationPattern" >
+  		<bean parent="NumericValidationPattern" />
+  	</property>
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="12" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-totalMiles" parent="ProcurementCardLevel3Rental-totalMiles-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-totalMiles-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="totalMiles" />
+  	<property name="label" value="Total Miles" />
+  	<property name="shortLabel" value="Tot Miles" />
+  	<property name="maxLength" value="10" />
+  	<property name="validationPattern" >
+  		<bean parent="NumericValidationPattern" />
+  	</property>
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="12" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-oneWayCharges" parent="ProcurementCardLevel3Rental-oneWayCharges-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-oneWayCharges-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="oneWayCharges" />
+  	<property name="label" value="One Way Charges" />
+  	<property name="shortLabel" value="One Way Chg" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-insuranceCharges" parent="ProcurementCardLevel3Rental-insuranceCharges-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-insuranceCharges-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="insuranceCharges" />
+  	<property name="label" value="Insurance Charges" />
+  	<property name="shortLabel" value="Insurance Chg" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-regularCharges" parent="ProcurementCardLevel3Rental-regularCharges-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-regularCharges-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="regularCharges" />
+  	<property name="label" value="Regular Mileage Charges" />
+  	<property name="shortLabel" value="Reg Charges" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-towingCharges" parent="ProcurementCardLevel3Rental-towingCharges-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-towingCharges-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="towingCharges" />
+  	<property name="label" value="Towing Charges" />
+  	<property name="shortLabel" value="Towing Chg" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-extraCharges" parent="ProcurementCardLevel3Rental-extraCharges-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-extraCharges-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="extraCharges" />
+  	<property name="label" value="Extra Mileage Charges" />
+  	<property name="shortLabel" value="Extra Chg" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-lateReturnFee" parent="ProcurementCardLevel3Rental-lateReturnFee-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-lateReturnFee-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="lateReturnFee" />
+  	<property name="label" value="Late Return Fee" />
+  	<property name="shortLabel" value="Late Fee" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-adjustCode" parent="ProcurementCardLevel3Rental-adjustCode-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-adjustCode-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="adjustCode" />
+  	<property name="label" value="Adjustment Code" />
+  	<property name="shortLabel" value="Adjust Cd" />
+  	<property name="maxLength" value="1" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="3" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-adjustAmount" parent="ProcurementCardLevel3Rental-adjustAmount-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-adjustAmount-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-adjustmentAmount">
+  	<property name="name" value="adjustAmount" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-progCode" parent="ProcurementCardLevel3Rental-progCode-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-progCode-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="progCode" />
+  	<property name="label" value="Program Code" />
+  	<property name="shortLabel" value="Program Cd" />
+  	<property name="maxLength" value="2" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="4" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-phoneCharges" parent="ProcurementCardLevel3Rental-phoneCharges-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-phoneCharges-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="phoneCharges" />
+  	<property name="label" value="Phone Charges" />
+  	<property name="shortLabel" value="Phone Chg" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-othrCharges" parent="ProcurementCardLevel3Rental-othrCharges-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-othrCharges-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-otherCharges">
+  	<property name="name" value="othrCharges" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Rental-totalTaxAmount" parent="ProcurementCardLevel3Rental-totalTaxAmount-parentBean" />
+  <bean id="ProcurementCardLevel3Rental-totalTaxAmount-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="totalTaxAmount" />
+  	<property name="label" value="Total Tax Amount" />
+  	<property name="shortLabel" value="Tot Tax Amt" />
+  </bean>
+ 
+</beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3ShipSvc.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3ShipSvc.xml
@@ -1,0 +1,302 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+        
+  <bean id="ProcurementCardLevel3ShipSvc" parent="ProcurementCardLevel3ShipSvc-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-parentBean" abstract="true" parent="BusinessObjectEntry">
+  	<property name="businessObjectClass" value="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3ShipSvc" />
+  	<property name="inquiryDefinition">
+  	  <ref bean="ProcurementCardLevel3ShipSvc-inquiryDefinition" />
+  	</property>
+  	<property name="objectLabel" value="Procurement Card Ship Services" />
+  	<property name="attributes" >
+  	  <list>
+  	    <ref bean="ProcurementCardLevel3ShipSvc-documentNumber" />
+  	    <ref bean="ProcurementCardLevel3ShipSvc-financialDocumentTransactionLineNumber" />
+  	    <ref bean="ProcurementCardLevel3ShipSvc-sequenceNumber" />
+  	    <ref bean="ProcurementCardLevel3ShipSvc-courierName" />
+  	    <ref bean="ProcurementCardLevel3ShipSvc-trackingNumber" />
+  	    <ref bean="ProcurementCardLevel3ShipSvc-serviceDescription" />
+  	    <ref bean="ProcurementCardLevel3ShipSvc-pickupDate" />
+  	    <ref bean="ProcurementCardLevel3ShipSvc-originZip" />
+  	    <ref bean="ProcurementCardLevel3ShipSvc-originCountryCd" />
+  	    <ref bean="ProcurementCardLevel3ShipSvc-destinationZip" />
+  	    <ref bean="ProcurementCardLevel3ShipSvc-destinationCountryCd" />
+  	    <ref bean="ProcurementCardLevel3ShipSvc-netAmount" />
+  	    <ref bean="ProcurementCardLevel3ShipSvc-taxAmt" />
+  	    <ref bean="ProcurementCardLevel3ShipSvc-discAmt" />
+  	    <ref bean="ProcurementCardLevel3ShipSvc-numberOfPackages" />
+  	    <ref bean="ProcurementCardLevel3ShipSvc-weight" />
+  	    <ref bean="ProcurementCardLevel3ShipSvc-unitsOfMeasure" />
+  	    <ref bean="ProcurementCardLevel3ShipSvc-senderName" />
+  	    <ref bean="ProcurementCardLevel3ShipSvc-senderAddress" />
+  	    <ref bean="ProcurementCardLevel3ShipSvc-receiverName" />
+  	    <ref bean="ProcurementCardLevel3ShipSvc-receiverAddress" />
+  	    <ref bean="ProcurementCardLevel3ShipSvc-customerRefNumber" />
+  	  </list>
+  	</property>
+  </bean>
+
+<!-- Attribute Definitions -->
+  <bean id="ProcurementCardLevel3ShipSvc-documentNumber" parent="ProcurementCardLevel3ShipSvc-documentNumber-parentBean"/>
+  <bean id="ProcurementCardLevel3ShipSvc-documentNumber-parentBean" abstract="true" parent="DocumentHeader-documentNumber">
+    <property name="forceUppercase" value="true"/>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3ShipSvc-financialDocumentTransactionLineNumber" parent="ProcurementCardLevel3ShipSvc-financialDocumentTransactionLineNumber-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-financialDocumentTransactionLineNumber-parentBean" abstract="true" parent="ProcurementCardTransactionDetail-financialDocumentTransactionLineNumber"/>
+  
+  <bean id="ProcurementCardLevel3ShipSvc-sequenceNumber" parent="ProcurementCardLevel3ShipSvc-sequenceNumber-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-sequenceNumber-parentBean" abstract="true" parent="ProcurementCardLevel3AddItem-sequenceNumber">
+  </bean>
+  
+  <bean id="ProcurementCardLevel3ShipSvc-courierName" parent="ProcurementCardLevel3ShipSvc-courierName-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-courierName-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="courierName" />
+  	<property name="label" value="Courier Name" />
+  	<property name="shortLabel" value="Courier Name" />
+  	<property name="maxLength" value="25" />
+  	<property name="control" >
+  	  <bean parent="TextControlDefinition"
+  	  		p:size="27" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3ShipSvc-trackingNumber" parent="ProcurementCardLevel3ShipSvc-trackingNumber-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-trackingNumber-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="trackingNumber" />
+    <property name="label" value="Tracking Number" />
+    <property name="shortLabel" value="Tracking Num" />
+    <property name="maxLength" value="22" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="24" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3ShipSvc-serviceDescription" parent="ProcurementCardLevel3ShipSvc-serviceDescription-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-serviceDescription-parentBean" abstract="true" parent="ProcurementCardLevel3TempSvc-serviceDesc">
+  	<property name="name" value="serviceDescription" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3ShipSvc-pickupDate" parent="ProcurementCardLevel3ShipSvc-pickupDate-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-pickupDate-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="pickupDate" />
+    <property name="label" value="Pickup Date" />
+    <property name="shortLabel" value="Date" />
+    <property name="maxLength" value="10" />
+    <property name="validationPattern" >
+      <bean parent="DateValidationPattern" />
+    </property>
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="12" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3ShipSvc-originZip" parent="ProcurementCardLevel3ShipSvc-originZip-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-originZip-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="originZip" />
+    <property name="label" value="Origin Zip" />
+    <property name="shortLabel" value="Origin Zip" />
+    <property name="maxLength" value="10" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="12" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3ShipSvc-originCountryCd" parent="ProcurementCardLevel3ShipSvc-originCountryCd-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-originCountryCd-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="originCountryCd" />
+    <property name="label" value="Origin Country" />
+    <property name="shortLabel" value="Origin Cty" />
+    <property name="maxLength" value="3" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="5" />
+    </property>
+  </bean>
+
+  <bean id="ProcurementCardLevel3ShipSvc-destinationZip" parent="ProcurementCardLevel3ShipSvc-destinationZip-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-destinationZip-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="destinationZip" />
+    <property name="label" value="Destination Zip" />
+    <property name="shortLabel" value="Dest Zip" />
+    <property name="maxLength" value="10" />
+    <property name="control">
+      <bean parent="TextControlDefinition"
+      		p:size="12" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3ShipSvc-destinationCountryCd" parent="ProcurementCardLevel3ShipSvc-destinationCountryCd-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-destinationCountryCd-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="destinationCountryCd" />
+    <property name="label" value="Destination Country" />
+    <property name="shortLabel" value="Dest Country" />
+    <property name="maxLength" value="3" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="5" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3ShipSvc-netAmount" parent="ProcurementCardLevel3ShipSvc-netAmount-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-netAmount-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+    <property name="name" value="netAmount" />
+    <property name="label" value="Net Amount" />
+    <property name="shortLabel" value="Net Amt" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3ShipSvc-taxAmt" parent="ProcurementCardLevel3ShipSvc-taxAmt-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-taxAmt-parentBean" abstract="true" parent="ProcurementCardLevel3Add-taxAmount">
+  	<property name="name" value="taxAmt" />
+  	<property name="label" value="Tax Amount" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3ShipSvc-discAmt" parent="ProcurementCardLevel3ShipSvc-discAmt-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-discAmt-parentBean" abstract="true" parent="ProcurementCardLevel3Add-discountAmount">
+  	<property name="name" value="discAmt" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3ShipSvc-numberOfPackages" parent="ProcurementCardLevel3ShipSvc-numberOfPackages-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-numberOfPackages-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="numberOfPackages" />
+    <property name="label" value="Number of Packages" />
+    <property name="shortLabel" value="Packages" />
+    <property name="maxLength" value="6" />
+    <property name="validationPattern" >
+      <bean parent="NumericValidationPattern" />
+    </property>
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="8" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3ShipSvc-weight" parent="ProcurementCardLevel3ShipSvc-weight-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-weight-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="weight" />
+  	<property name="label" value="Weight" />
+  	<property name="shortLabel" value="Weight" />
+  	<property name="maxLength" value="15" />
+  	<property name="control" >
+  	  <bean parent="TextControlDefinition"
+  	  		p:size="17" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3ShipSvc-unitsOfMeasure" parent="ProcurementCardLevel3ShipSvc-unitsOfMeasure-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-unitsOfMeasure-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="unitsOfMeasure" />
+  	<property name="label" value="Units of Measure" />
+  	<property name="shortLabel" value="Units" />
+  	<property name="maxLength" value="3" />
+  	<property name="control" >
+  	  <bean parent="TextControlDefinition"
+  	  		p:size="5" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3ShipSvc-senderName" parent="ProcurementCardLevel3ShipSvc-senderName-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-senderName-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="senderName" />
+    <property name="label" value="Sender Name" />
+    <property name="shortLabel" value="Sender" />
+    <property name="maxLength" value="50" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="52" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3ShipSvc-senderAddress" parent="ProcurementCardLevel3ShipSvc-senderAddress-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-senderAddress-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="senderAddress" />
+    <property name="label" value="Sender Address" />
+    <property name="shortLabel" value="Sender Addr" />
+    <property name="maxLength" value="50" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="52" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3ShipSvc-receiverName" parent="ProcurementCardLevel3ShipSvc-receiverName-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-receiverName-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="receiverName" />
+    <property name="label" value="Receiver Name" />
+    <property name="shortLabel" value="Receiver" />
+    <property name="maxLength" value="50" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="52" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3ShipSvc-receiverAddress" parent="ProcurementCardLevel3ShipSvc-receiverAddress-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-receiverAddress-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="receiverAddress" />
+    <property name="label" value="Receiver Address" />
+    <property name="shortLabel" value="Receiver Addr" />
+    <property name="maxLength" value="50" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="52" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3ShipSvc-customerRefNumber" parent="ProcurementCardLevel3ShipSvc-customerRefNumber-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-customerRefNumber-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="customerRefNumber" />
+    <property name="label" value="Customer Reference Number" />
+    <property name="shortLabel" value="Cust Ref Num" />
+    <property name="maxLength" value="17" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="19" />
+    </property>
+  </bean>
+  
+<!-- Business Object Inquiry Definition -->
+  <bean id="ProcurementCardLevel3ShipSvc-inquiryDefinition" parent="ProcurementCardLevel3ShipSvc-inquiryDefinition-parentBean" />
+  <bean id="ProcurementCardLevel3ShipSvc-inquiryDefinition-parentBean" abstract="true" parent="InquiryDefinition">
+  	<property name="title" value="Procurement Card Ship Services Inquiry" />
+  	<property name="inquirySections" >
+  	  <list>
+  	    <bean parent="InquirySectionDefinition">
+  	      <property name="title" value="Procurement Card Ship Services" />
+  	      <property name="numberOfColumns" value="4" />
+  	      <property name="inquiryFields" >
+  	        <list>
+  	          <bean parent="FieldDefinition" p:attributeName="sequenceNumber" />
+  	          <bean parent="FieldDefinition" p:attributeName="courierName" />
+  	          <bean parent="FieldDefinition" p:attributeName="trackingNumber" />
+  	          <bean parent="FieldDefinition" p:attributeName="serviceDescription" />
+  	          <bean parent="FieldDefinition" p:attributeName="pickupDate" />
+  	          <bean parent="FieldDefinition" p:attributeName="originZip" />
+  	          <bean parent="FieldDefinition" p:attributeName="originCountryCd" />
+  	          <bean parent="FieldDefinition" p:attributeName="destinationZip" />
+  	          <bean parent="FieldDefinition" p:attributeName="destinationCountryCd" />
+  	          <bean parent="FieldDefinition" p:attributeName="netAmount" />
+  	          <bean parent="FieldDefinition" p:attributeName="taxAmt" />
+  	          <bean parent="FieldDefinition" p:attributeName="discAmt" />
+  	          <bean parent="FieldDefinition" p:attributeName="numberOfPackages" />
+  	          <bean parent="FieldDefinition" p:attributeName="weight" />
+  	          <bean parent="FieldDefinition" p:attributeName="unitsOfMeasure" />
+  	          <bean parent="FieldDefinition" p:attributeName="senderName" />
+  	          <bean parent="FieldDefinition" p:attributeName="senderAddress" />
+  	          <bean parent="FieldDefinition" p:attributeName="receiverName" />
+  	          <bean parent="FieldDefinition" p:attributeName="receiverAddress" />
+  	          <bean parent="FieldDefinition" p:attributeName="customerRefNumber" />
+  	        </list>
+  	      </property>
+  	    </bean>
+  	  </list>
+  	</property>
+  </bean>
+  
+</beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3TempSvc.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3TempSvc.xml
@@ -1,0 +1,260 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+  <bean id="ProcurementCardLevel3TempSvc" parent="ProcurementCardLevel3TempSvc-parentBean" />
+  <bean id="ProcurementCardLevel3TempSvc-parentBean" abstract="true" parent="BusinessObjectEntry">
+    <property name="businessObjectClass" value="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3TempSvc" />
+    <property name="inquiryDefinition">
+      <ref bean="ProcurementCardLevel3TempSvc-inquiryDefinition" />
+    </property>
+    <property name="objectLabel" value="Procurement Card Temporary Services" />
+    <property name="attributes" >
+      <list>
+        <ref bean="ProcurementCardLevel3TempSvc-documentNumber" />
+        <ref bean="ProcurementCardLevel3TempSvc-financialDocumentTransactionLineNumber" />
+        <ref bean="ProcurementCardLevel3TempSvc-sequenceNumber" />
+        <ref bean="ProcurementCardLevel3TempSvc-weekEndingDate" />
+        <ref bean="ProcurementCardLevel3TempSvc-serviceDesc" />
+        <ref bean="ProcurementCardLevel3TempSvc-employeeName" />
+        <ref bean="ProcurementCardLevel3TempSvc-regularRate" />
+        <ref bean="ProcurementCardLevel3TempSvc-regularHours" />
+        <ref bean="ProcurementCardLevel3TempSvc-overtimeRate" />
+        <ref bean="ProcurementCardLevel3TempSvc-overtimeHours" />
+        <ref bean="ProcurementCardLevel3TempSvc-miscExpenseAmt" />
+        <ref bean="ProcurementCardLevel3TempSvc-subTotalAmt" />
+        <ref bean="ProcurementCardLevel3TempSvc-salesTaxAmt" />
+        <ref bean="ProcurementCardLevel3TempSvc-discountAmt" />
+        <ref bean="ProcurementCardLevel3TempSvc-startDate" />
+        <ref bean="ProcurementCardLevel3TempSvc-supervisor" />
+        <ref bean="ProcurementCardLevel3TempSvc-timeSheetNumber" />
+        <ref bean="ProcurementCardLevel3TempSvc-commodityCode" />
+        <ref bean="ProcurementCardLevel3TempSvc-jobCode" />
+      </list>
+    </property>
+  </bean>
+  
+<!-- Attribute Definitions --> 
+  <bean id="ProcurementCardLevel3TempSvc-documentNumber" parent="ProcurementCardLevel3TempSvc-documentNumber-parentBean" />
+  <bean id="ProcurementCardLevel3TempSvc-documentNumber-parentBean" abstract="true" parent="DocumentHeader-documentNumber">
+    <property name="forceUppercase" value="true"/>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TempSvc-financialDocumentTransactionLineNumber" parent="ProcurementCardLevel3TempSvc-financialDocumentTransactionLineNumber-parentBean" />
+  <bean id="ProcurementCardLevel3TempSvc-financialDocumentTransactionLineNumber-parentBean" abstract="true" parent="ProcurementCardTransactionDetail-financialDocumentTransactionLineNumber" />
+  
+  <bean id="ProcurementCardLevel3TempSvc-sequenceNumber" parent="ProcurementCardLevel3TempSvc-sequenceNumber-parentBean" />
+  <bean id="ProcurementCardLevel3TempSvc-sequenceNumber-parentBean" abstract="true" parent="ProcurementCardLevel3AddItem-sequenceNumber">
+  </bean>
+
+  <bean id="ProcurementCardLevel3TempSvc-weekEndingDate" parent="ProcurementCardLevel3TempSvc-weekEndingDate-parentBean" />
+  <bean id="ProcurementCardLevel3TempSvc-weekEndingDate-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="weekEndingDate" />
+    <property name="label" value="Week Ending Date" />
+    <property name="shortLabel" value="Date" />
+    <property name="maxLength" value="10" />
+    <property name="validationPattern" >
+      <bean parent="DateValidationPattern" />
+    </property>
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="12" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TempSvc-serviceDesc" parent="ProcurementCardLevel3TempSvc-serviceDesc-parentBean" />
+  <bean id="ProcurementCardLevel3TempSvc-serviceDesc-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="serviceDesc" />
+    <property name="label" value="Description" />
+    <property name="shortLabel" value="Desc" />
+    <property name="maxLength" value="40" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="42" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TempSvc-employeeName" parent="ProcurementCardLevel3TempSvc-employeeName-parentBean" />
+  <bean id="ProcurementCardLevel3TempSvc-employeeName-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="employeeName" />
+    <property name="label" value="Employee Name" />
+    <property name="shortLabel" value="Emp Name" />
+    <property name="maxLength" value="40" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="42" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TempSvc-regularRate" parent="ProcurementCardLevel3TempSvc-regularRate-parentBean" />
+  <bean id="ProcurementCardLevel3TempSvc-regularRate-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+    <property name="name" value="regularRate" />
+    <property name="label" value="Rate" />
+    <property name="shortLabel" value="Rate" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TempSvc-regularHours" parent="ProcurementCardLevel3TempSvc-regularHours-parentBean" />
+  <bean id="ProcurementCardLevel3TempSvc-regularHours-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="regularHours" />
+    <property name="label" value="Regular Hours" />
+    <property name="shortLabel" value="Reg Hours" />
+    <property name="maxLength" value="6" />
+    <property name="validationPattern" >
+      <bean parent="FloatingPointValidationPattern" p:allowNegative="true" />
+    </property>
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="8" />
+    </property>
+  </bean> 
+  
+  <bean id="ProcurementCardLevel3TempSvc-overtimeRate" parent="ProcurementCardLevel3TempSvc-overtimeRate-parentBean" />
+  <bean id="ProcurementCardLevel3TempSvc-overtimeRate-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+    <property name="name" value="overtimeRate" />
+    <property name="label" value="Overtime Rate" />
+    <property name="shortLabel" value="Over Rate" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TempSvc-overtimeHours" parent="ProcurementCardLevel3TempSvc-overtimeHours-parentBean" />
+  <bean id="ProcurementCardLevel3TempSvc-overtimeHours-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="overtimeHours" />
+    <property name="label" value="Overtime Hours" />
+    <property name="shortLabel" value="Over Hours" />
+    <property name="maxLength" value="6" />
+    <property name="validationPattern" >
+      <bean parent="FloatingPointValidationPattern" p:allowNegative="true" />
+    </property>
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="8" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TempSvc-miscExpenseAmt" parent="ProcurementCardLevel3TempSvc-miscExpenseAmt-parentBean" />
+  <bean id="ProcurementCardLevel3TempSvc-miscExpenseAmt-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+    <property name="name" value="miscExpenseAmt" />
+    <property name="label" value="Misc Expense Amount" />
+    <property name="shortLabel" value="Misc Exp Amt" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TempSvc-subTotalAmt" parent="ProcurementCardLevel3TempSvc-subTotalAmt-parentBean" />
+  <bean id="ProcurementCardLevel3TempSvc-subTotalAmt-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+    <property name="name" value="subTotalAmt" />
+    <property name="label" value="Sub Total Amount" />
+    <property name="shortLabel" value="Sub Tot Amt" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TempSvc-salesTaxAmt" parent="ProcurementCardLevel3TempSvc-salesTaxAmt-parentBean" />
+  <bean id="ProcurementCardLevel3TempSvc-salesTaxAmt-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+    <property name="name" value="salesTaxAmt" />
+    <property name="label" value="Sales Tax Amount" />
+    <property name="shortLabel" value="Sales Tax Amt" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TempSvc-discountAmt" parent="ProcurementCardLevel3TempSvc-discountAmt-parentBean" />
+  <bean id="ProcurementCardLevel3TempSvc-discountAmt-parentBean" abstract="true" parent="ProcurementCardLevel3Add-discountAmount">
+    <property name="name" value="discountAmt" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TempSvc-startDate" parent="ProcurementCardLevel3TempSvc-startDate-parentBean" />
+  <bean id="ProcurementCardLevel3TempSvc-startDate-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="startDate" />
+    <property name="label" value="Start Date" />
+    <property name="shortLabel" value="Date" />
+    <property name="maxLength" value="10" />
+    <property name="validationPattern" >
+      <bean parent="DateValidationPattern" />
+    </property>
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="12" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TempSvc-supervisor" parent="ProcurementCardLevel3TempSvc-supervisor-parentBean" />
+  <bean id="ProcurementCardLevel3TempSvc-supervisor-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="supervisor" />
+    <property name="label" value="Supervisor" />
+    <property name="shortLabel" value="Supervisor" />
+    <property name="maxLength" value="40" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="42" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TempSvc-timeSheetNumber" parent="ProcurementCardLevel3TempSvc-timeSheetNumber-parentBean" />
+  <bean id="ProcurementCardLevel3TempSvc-timeSheetNumber-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="timeSheetNumber" />
+    <property name="label" value="Time Sheet Number" />
+    <property name="shortLabel" value="Time Sheet" />
+    <property name="maxLength" value="20" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="22" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TempSvc-commodityCode" parent="ProcurementCardLevel3TempSvc-commodityCode-parentBean" />
+  <bean id="ProcurementCardLevel3TempSvc-commodityCode-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="commodityCode" />
+    <property name="label" value="Commodity Code" />
+    <property name="shortLabel" value="Comm Cd" />
+    <property name="maxLength" value="15" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="17" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TempSvc-jobCode" parent="ProcurementCardLevel3TempSvc-jobCode-parentBean" />
+  <bean id="ProcurementCardLevel3TempSvc-jobCode-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="jobCode" />
+    <property name="label" value="Job Code" />
+    <property name="shortLabel" value="Job Cd" />
+    <property name="maxLength" value="20" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="22" />
+    </property>
+  </bean>
+  
+<!-- Business Object Inquiry Definition -->  
+  
+  <bean id="ProcurementCardLevel3TempSvc-inquiryDefinition" parent="ProcurementCardLevel3TempSvc-inquiryDefinition-parentBean" />
+  <bean id="ProcurementCardLevel3TempSvc-inquiryDefinition-parentBean" abstract="true" parent="InquiryDefinition">
+    <property name="title" value="Procurement Card Temporary Services Inquiry" />
+    <property name="inquirySections" >
+      <list>
+        <bean parent="InquirySectionDefinition">
+          <property name="title" value="Procurement Card Temporary Services" />
+          <property name="numberOfColumns" value="4" />
+          <property name="inquiryFields" >
+            <list>
+              <bean parent="FieldDefinition" p:attributeName="sequenceNumber" />
+              <bean parent="FieldDefinition" p:attributeName="weekEndingDate" />
+              <bean parent="FieldDefinition" p:attributeName="serviceDesc" />
+              <bean parent="FieldDefinition" p:attributeName="employeeName" />
+              <bean parent="FieldDefinition" p:attributeName="regularRate" />
+              <bean parent="FieldDefinition" p:attributeName="regularHours" />
+              <bean parent="FieldDefinition" p:attributeName="overtimeRate" />
+              <bean parent="FieldDefinition" p:attributeName="overtimeHours" />
+              <bean parent="FieldDefinition" p:attributeName="miscExpenseAmt" />
+              <bean parent="FieldDefinition" p:attributeName="subTotalAmt" />
+              <bean parent="FieldDefinition" p:attributeName="salesTaxAmt" />
+              <bean parent="FieldDefinition" p:attributeName="discountAmt" />
+              <bean parent="FieldDefinition" p:attributeName="startDate" />
+              <bean parent="FieldDefinition" p:attributeName="supervisor" />
+              <bean parent="FieldDefinition" p:attributeName="timeSheetNumber" />
+              <bean parent="FieldDefinition" p:attributeName="commodityCode" />
+              <bean parent="FieldDefinition" p:attributeName="jobCode" />
+            </list>
+          </property>
+        </bean>
+      </list>
+    </property>
+  </bean>
+
+</beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3Transport.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3Transport.xml
@@ -1,0 +1,164 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+  <bean id="ProcurementCardLevel3Transport" parent="ProcurementCardLevel3Transport-parentBean" />
+  
+  <bean id="ProcurementCardLevel3Transport-parentBean" abstract="true" parent="BusinessObjectEntry">
+  	<property name="businessObjectClass" value="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Transport" />
+  	<property name="objectLabel" value="Procurement Card Transport" />
+  	<property name="attributes" >
+  		<list>
+  			<ref bean="ProcurementCardLevel3Transport-documentNumber" />
+  			<ref bean="ProcurementCardLevel3Transport-financialDocumentTransactionLineNumber" />
+  			<ref bean="ProcurementCardLevel3Transport-passengerName" />
+  			<ref bean="ProcurementCardLevel3Transport-departDate" />
+  			<ref bean="ProcurementCardLevel3Transport-departureCity" />
+  			<ref bean="ProcurementCardLevel3Transport-agencyCode" />
+  			<ref bean="ProcurementCardLevel3Transport-agencyName" />
+  			<ref bean="ProcurementCardLevel3Transport-ticketNumber" />
+  			<ref bean="ProcurementCardLevel3Transport-customerCode" />
+  			<ref bean="ProcurementCardLevel3Transport-issueDate" />
+  			<ref bean="ProcurementCardLevel3Transport-issuingCarrier" />
+  			<ref bean="ProcurementCardLevel3Transport-totalFare" />
+  			<ref bean="ProcurementCardLevel3Transport-totalFees" />
+  			<ref bean="ProcurementCardLevel3Transport-totalTaxes" />
+  		</list>
+  	</property>
+  </bean>
+
+<!-- Attribute Definitions -->
+  <bean id="ProcurementCardLevel3Transport-documentNumber" parent="ProcurementCardLevel3Transport-documentNumber-parentBean" />
+  <bean id="ProcurementCardLevel3Transport-documentNumber-parentBean" abstract="true" parent="DocumentHeader-documentNumber">
+  	<property name="forceUppercase" value="true"/>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Transport-financialDocumentTransactionLineNumber" parent="ProcurementCardLevel3Transport-financialDocumentTransactionLineNumber-parentBean" />
+  <bean id="ProcurementCardLevel3Transport-financialDocumentTransactionLineNumber-parentBean" abstract="true" parent="ProcurementCardTransactionDetail-financialDocumentTransactionLineNumber" />
+  
+  <bean id="ProcurementCardLevel3Transport-passengerName" parent="ProcurementCardLevel3Transport-passengerName-parentBean" />
+  <bean id="ProcurementCardLevel3Transport-passengerName-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="passengerName" />
+  	<property name="label" value="Passenger Name" />
+  	<property name="shortLabel" value="Name" />
+  	<property name="maxLength" value="25" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="27" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Transport-departDate" parent="ProcurementCardLevel3Transport-departDate-parentBean" />
+  <bean id="ProcurementCardLevel3Transport-departDate-parentBean" abstract="true" parent="GenericAttributes-genericDate">
+  	<property name="name" value="departDate" />
+  	<property name="label" value="Depart Date" />
+  	<property name="shortLabel" value="Date" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Transport-departureCity" parent="ProcurementCardLevel3Transport-departureCity-parentBean" />
+  <bean id="ProcurementCardLevel3Transport-departureCity-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="departureCity" />
+  	<property name="label" value="Depart City" />
+  	<property name="shortLabel" value="City" />
+  	<property name="maxLength" value="5" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="7" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Transport-agencyCode" parent="ProcurementCardLevel3Transport-agencyCode-parentBean" />
+  <bean id="ProcurementCardLevel3Transport-agencyCode-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="agencyCode" />
+  	<property name="label" value="Agency Code" />
+  	<property name="shortLabel" value="Agency Cd" />
+  	<property name="maxLength" value="8" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="10" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Transport-agencyName" parent="ProcurementCardLevel3Transport-agencyName-parentBean" />
+  <bean id="ProcurementCardLevel3Transport-agencyName-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="agencyName" />
+  	<property name="label" value="Agency Name" />
+  	<property name="shortLabel" value="Agency Nm" />
+  	<property name="maxLength" value="25" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="27" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Transport-ticketNumber" parent="ProcurementCardLevel3Transport-ticketNumber-parentBean" />
+  <bean id="ProcurementCardLevel3Transport-ticketNumber-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="ticketNumber" />
+  	<property name="forceUppercase" value="true" />
+  	<property name="label" value="Ticket Number" />
+  	<property name="shortLabel" value="Ticket" />
+  	<property name="maxLength" value="15" />
+  	<property name="validationPattern" >
+  		<bean parent="NumericValidationPattern" />
+  	</property>
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="17" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Transport-customerCode" parent="ProcurementCardLevel3Transport-customerCode-parentBean" />
+  <bean id="ProcurementCardLevel3Transport-customerCode-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="customerCode" />
+  	<property name="label" value="Customer Code" />
+  	<property name="shortLabel" value="Customer Cd" />
+  	<property name="maxLength" value="64" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="66" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Transport-issueDate" parent="ProcurementCardLevel3Transport-issueDate-parentBean" />
+  <bean id="ProcurementCardLevel3Transport-issueDate-parentBean" abstract="true" parent="GenericAttributes-genericDate">
+  	<property name="name" value="issueDate" />
+  	<property name="label" value="Issue Date" />
+  	<property name="shortLabel" value="Date" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Transport-issuingCarrier" parent="ProcurementCardLevel3Transport-issuingCarrier-parentBean" />
+  <bean id="ProcurementCardLevel3Transport-issuingCarrier-parentBean" abstract="true" parent="AttributeDefinition">
+  	<property name="name" value="issuingCarrier" />
+  	<property name="label" value="Issuing Carrier" />
+  	<property name="shortLabel" value="Carrier" />
+  	<property name="maxLength" value="4" />
+  	<property name="control" >
+  		<bean parent="TextControlDefinition"
+  			  p:size="6" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Transport-totalFare" parent="ProcurementCardLevel3Transport-totalFare-parentBean" />
+  <bean id="ProcurementCardLevel3Transport-totalFare-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="totalFare" />
+  	<property name="label" value="Total Fare" />
+  	<property name="shortLabel" value="Fare" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Transport-totalFees" parent="ProcurementCardLevel3Transport-totalFees-parentBean" />
+  <bean id="ProcurementCardLevel3Transport-totalFees-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="totalFees" />
+  	<property name="label" value="Total Fees" />
+  	<property name="shortLabel" value="Fees" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3Transport-totalTaxes" parent="ProcurementCardLevel3Transport-totalTaxes-parentBean" />
+  <bean id="ProcurementCardLevel3Transport-totalTaxes-parentBean" abstract="true" parent="GenericAttributes-genericAmount">
+  	<property name="name" value="totalTaxes" />
+  	<property name="label" value="Total Taxes" />
+  	<property name="shortLabel" value="Taxes" />
+  </bean>
+  
+</beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3TransportLeg.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardLevel3TransportLeg.xml
@@ -1,0 +1,268 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+  <bean id="ProcurementCardLevel3TransportLeg" parent="ProcurementCardLevel3TransportLeg-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-parentBean" abstract="true" parent="BusinessObjectEntry">
+    <property name="businessObjectClass" value="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3TransportLeg" />
+    <property name="inquiryDefinition" >
+      <ref bean="ProcurementCardLevel3TransportLeg-inquiryDefinition" />
+    </property>
+    <property name="objectLabel" value="Procurement Card Transport Leg" />
+    <property name="attributes" >
+      <list>
+        <ref bean="ProcurementCardLevel3TransportLeg-documentNumber" />
+        <ref bean="ProcurementCardLevel3TransportLeg-financialDocumentTransactionLineNumber" />
+        <ref bean="ProcurementCardLevel3TransportLeg-sequenceNumber" />
+        <ref bean="ProcurementCardLevel3TransportLeg-carrierCode" />
+        <ref bean="ProcurementCardLevel3TransportLeg-serviceClass" />
+        <ref bean="ProcurementCardLevel3TransportLeg-departCity" />
+        <ref bean="ProcurementCardLevel3TransportLeg-conjunctionTicket" />
+        <ref bean="ProcurementCardLevel3TransportLeg-exchangeTicket" />
+        <ref bean="ProcurementCardLevel3TransportLeg-destinationCity" />
+        <ref bean="ProcurementCardLevel3TransportLeg-fareBasisCode" />
+        <ref bean="ProcurementCardLevel3TransportLeg-flightNumber" />
+        <ref bean="ProcurementCardLevel3TransportLeg-departTime" />
+        <ref bean="ProcurementCardLevel3TransportLeg-departTimeSegment" />
+        <ref bean="ProcurementCardLevel3TransportLeg-arriveTime" />
+        <ref bean="ProcurementCardLevel3TransportLeg-arriveTimeSegment" />
+        <ref bean="ProcurementCardLevel3TransportLeg-fare" />
+        <ref bean="ProcurementCardLevel3TransportLeg-fees" />
+        <ref bean="ProcurementCardLevel3TransportLeg-taxes" />
+        <ref bean="ProcurementCardLevel3TransportLeg-endorsements" />
+        <ref bean="ProcurementCardLevel3TransportLeg-controlCode" />
+      </list>
+    </property>
+  </bean>
+  
+<!-- Attribute Definitions -->  
+  <bean id="ProcurementCardLevel3TransportLeg-documentNumber" parent="ProcurementCardLevel3TransportLeg-documentNumber-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-documentNumber-parentBean" abstract="true" parent="DocumentHeader-documentNumber">
+    <property name="forceUppercase" value="true" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TransportLeg-financialDocumentTransactionLineNumber" parent="ProcurementCardLevel3TransportLeg-financialDocumentTransactionLineNumber-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-financialDocumentTransactionLineNumber-parentBean" abstract="true" parent="ProcurementCardTransactionDetail-financialDocumentTransactionLineNumber" />
+  
+  <bean id="ProcurementCardLevel3TransportLeg-sequenceNumber" parent="ProcurementCardLevel3TransportLeg-sequenceNumber-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-sequenceNumber-parentBean" abstract="true" parent="ProcurementCardLevel3AddItem-sequenceNumber">
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TransportLeg-carrierCode" parent="ProcurementCardLevel3TransportLeg-carrierCode-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-carrierCode-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="carrierCode" />
+    <property name="label" value="Carrier Code" />
+    <property name="shortLabel" value="Carrier" />
+    <property name="maxLength" value="25" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="27" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TransportLeg-serviceClass" parent="ProcurementCardLevel3TransportLeg-serviceClass-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-serviceClass-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="serviceClass" />
+    <property name="label" value="Service Class" />
+    <property name="shortLabel" value="Svc Class" />
+    <property name="maxLength" value="2" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="4" />
+    </property>
+  </bean>
+
+  <bean id="ProcurementCardLevel3TransportLeg-departCity" parent="ProcurementCardLevel3TransportLeg-departCity-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-departCity-parentBean" abstract="true" parent="ProcurementCardLevel3Transport-departureCity">
+    <property name="name" value="departCity" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TransportLeg-conjunctionTicket" parent="ProcurementCardLevel3TransportLeg-conjunctionTicket-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-conjunctionTicket-parentBean" abstract="true"  parent="AttributeDefinition">
+  	<property name="name" value="conjunctionTicket" />
+  	<property name="label" value="Conjunction Ticket" />
+  	<property name="shortLabel" value="Conj Ticket" />
+  	<property name="maxLength" value="15" />
+  	<property name="control" >
+  	  <bean parent="TextControlDefinition"
+  	  		p:size="17" />
+  	</property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TransportLeg-exchangeTicket" parent="ProcurementCardLevel3TransportLeg-exchangeTicket-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-exchangeTicket-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="exchangeTicket" />
+    <property name="label" value="Exchange Ticket" />
+    <property name="shortLabel" value="Exch Ticket" />
+    <property name="maxLength" value="15" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="17" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TransportLeg-destinationCity" parent="ProcurementCardLevel3TransportLeg-destinationCity-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-destinationCity-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="destinationCity" />
+    <property name="label" value="Destination City" />
+    <property name="shortLabel" value="Dest City" />
+    <property name="maxLength" value="5" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="7" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TransportLeg-fareBasisCode" parent="ProcurementCardLevel3TransportLeg-fareBasisCode-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-fareBasisCode-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="fareBasisCode" />
+    <property name="label" value="Fare Basis Code" />
+    <property name="shortLabel" value="Fare Cd" />
+    <property name="maxLength" value="15" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="17" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TransportLeg-flightNumber" parent="ProcurementCardLevel3TransportLeg-flightNumber-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-flightNumber-parentBean"  abstract="true" parent="AttributeDefinition">
+    <property name="name" value="flightNumber" />
+    <property name="label" value="Flight Number" />
+    <property name="shortLabel" value="Flight Num" />
+    <property name="maxLength" value="5" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="7" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TransportLeg-departTime" parent="ProcurementCardLevel3TransportLeg-departTime-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-departTime-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="departTime" />
+    <property name="label" value="Departure Time" />
+    <property name="shortLabel" value="Depart Time" />
+    <property name="maxLength" value="4" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="6" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TransportLeg-departTimeSegment" parent="ProcurementCardLevel3TransportLeg-departTimeSegment-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-departTimeSegment-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="departTimeSegment" />
+    <property name="label" value="Departure Time Segment" />
+    <property name="shortLabel" value="Depart Time Seg" />
+    <property name="maxLength" value="1" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="3" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TransportLeg-arriveTime" parent="ProcurementCardLevel3TransportLeg-arriveTime-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-arriveTime-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="arriveTime" />
+    <property name="label" value="Arrival Time" />
+    <property name="shortLabel" value="Arrive Time" />
+    <property name="maxLength" value="4" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="6" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TransportLeg-arriveTimeSegment" parent="ProcurementCardLevel3TransportLeg-arriveTimeSegment-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-arriveTimeSegment-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="arriveTimeSegment" />
+    <property name="label" value="Arrival Time Segment" />
+    <property name="shortLabel" value="Arrive Time Seg" />
+    <property name="maxLength" value="1" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="3" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TransportLeg-fare" parent="ProcurementCardLevel3TransportLeg-fare-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-fare-parentBean" abstract="true" parent="ProcurementCardLevel3Transport-totalFare">
+  	<property name="name" value="fare" />
+  	<property name="label" value="Fare" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TransportLeg-fees" parent="ProcurementCardLevel3TransportLeg-fees-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-fees-parentBean" abstract="true" parent="ProcurementCardLevel3Transport-totalFees">
+    <property name="name" value="fees" />
+    <property name="label" value="Fees" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TransportLeg-taxes" parent="ProcurementCardLevel3TransportLeg-taxes-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-taxes-parentBean" abstract="true" parent="ProcurementCardLevel3Transport-totalTaxes">
+    <property name="name" value="taxes" />
+    <property name="label" value="Taxes" />
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TransportLeg-endorsements" parent="ProcurementCardLevel3TransportLeg-endorsements-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-endorsements-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="endorsements" />
+    <property name="label" value="Endorsements" />
+    <property name="shortLabel" value="Endorsements" />
+    <property name="maxLength" value="20" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="22" />
+    </property>
+  </bean>
+  
+  <bean id="ProcurementCardLevel3TransportLeg-controlCode" parent="ProcurementCardLevel3TransportLeg-controlCode-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-controlCode-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="controlCode" />
+    <property name="label" value="Control Number" />
+    <property name="shortLabel" value="Control" />
+    <property name="maxLength" value="13" />
+    <property name="control" >
+      <bean parent="TextControlDefinition"
+      		p:size="15" />
+    </property>
+  </bean>
+  
+<!-- Business Object Inquiry Definition -->  
+  <bean id="ProcurementCardLevel3TransportLeg-inquiryDefinition" parent="ProcurementCardLevel3TransportLeg-inquiryDefinition-parentBean" />
+  <bean id="ProcurementCardLevel3TransportLeg-inquiryDefinition-parentBean" abstract="true" parent="InquiryDefinition">
+    <property name="title" value="Procurement Card Transport Leg Inquiry" />
+    <property name="inquirySections" >
+      <list>
+        <bean parent="InquirySectionDefinition">
+          <property name="title" value="Procurement Card Transport Leg" />
+          <property name="numberOfColumns" value="4" />
+          <property name="inquiryFields" >
+          	<list>
+          	  <bean parent="FieldDefinition" p:attributeName="sequenceNumber" />
+          	  <bean parent="FieldDefinition" p:attributeName="carrierCode" />
+          	  <bean parent="FieldDefinition" p:attributeName="serviceClass" />
+          	  <bean parent="FieldDefinition" p:attributeName="departCity" />
+          	  <bean parent="FieldDefinition" p:attributeName="conjunctionTicket" />
+          	  <bean parent="FieldDefinition" p:attributeName="exchangeTicket" />
+          	  <bean parent="FieldDefinition" p:attributeName="destinationCity" />
+          	  <bean parent="FieldDefinition" p:attributeName="fareBasisCode" />
+          	  <bean parent="FieldDefinition" p:attributeName="flightNumber" />
+          	  <bean parent="FieldDefinition" p:attributeName="departTime" />
+          	  <bean parent="FieldDefinition" p:attributeName="departTimeSegment" />
+          	  <bean parent="FieldDefinition" p:attributeName="arriveTime" />
+          	  <bean parent="FieldDefinition" p:attributeName="arriveTimeSegment" />
+          	  <bean parent="FieldDefinition" p:attributeName="fare" />
+          	  <bean parent="FieldDefinition" p:attributeName="fees" />
+          	  <bean parent="FieldDefinition" p:attributeName="taxes" />
+          	  <bean parent="FieldDefinition" p:attributeName="endorsements" />
+          	  <bean parent="FieldDefinition" p:attributeName="controlCode" />
+          	</list>
+          </property>
+        </bean>
+      </list>
+    </property>
+  </bean>
+
+</beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardTransaction.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardTransaction.xml
@@ -1,0 +1,472 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+        
+  <bean id="ProcurementCardTransaction" parent="ProcurementCardTransaction-parentBean">
+  	<property name="businessObjectClass" value="edu.arizona.kfs.fp.businessobject.ProcurementCardTransaction" />
+  	<property name="attributes" >
+  		<list merge="true">
+  			<ref bean="ProcurementCardTransaction-invoiceNumber" />
+  			<ref bean="ProcurementCardTransaction-orderDate" />
+  			<ref bean="ProcurementCardTransaction-purchaseTime" />
+  			<ref bean="ProcurementCardTransaction-shipPostal" />
+  			<ref bean="ProcurementCardTransaction-destinationPostal" />
+  			<ref bean="ProcurementCardTransaction-destinationCountryCode" />
+  			<ref bean="ProcurementCardTransaction-taxAmount" />
+  			<ref bean="ProcurementCardTransaction-taxRate" />
+  			<ref bean="ProcurementCardTransaction-discountAmount" />
+  			<ref bean="ProcurementCardTransaction-freightAmount" />
+  			<ref bean="ProcurementCardTransaction-dutyAmount" />
+  			<ref bean="ProcurementCardTransaction-userEffectiveDate" />
+  			<ref bean="ProcurementCardTransaction-userAmount" />
+  			<ref bean="ProcurementCardTransaction-oilBrandName" />
+  			<ref bean="ProcurementCardTransaction-odometerReading" />
+  			<ref bean="ProcurementCardTransaction-fleetId" />
+  			<ref bean="ProcurementCardTransaction-messageId" />
+  			<ref bean="ProcurementCardTransaction-usage" />
+  			<ref bean="ProcurementCardTransaction-fuelServiceType" />
+  			<ref bean="ProcurementCardTransaction-fuelProductCd" />
+  			<ref bean="ProcurementCardTransaction-productTypeCd" />
+  			<ref bean="ProcurementCardTransaction-fuelQuantity" />
+  			<ref bean="ProcurementCardTransaction-fuelUnitOfMeasure" />
+  			<ref bean="ProcurementCardTransaction-fuelUnitPrice" />
+  			<ref bean="ProcurementCardTransaction-fuelSaleAmount" />
+  			<ref bean="ProcurementCardTransaction-fuelDiscountAmount" />
+  			<ref bean="ProcurementCardTransaction-taxAmount1" />
+  			<ref bean="ProcurementCardTransaction-taxAmount2" /> 
+  			<ref bean="ProcurementCardTransaction-totalAmount" />
+  			<ref bean="ProcurementCardTransaction-genericEffectiveDate" />
+  			<ref bean="ProcurementCardTransaction-genericData" />
+  			<ref bean="ProcurementCardTransaction-arriveDate" />
+  			<ref bean="ProcurementCardTransaction-departureDate" />
+  			<ref bean="ProcurementCardTransaction-folioNum" />
+  			<ref bean="ProcurementCardTransaction-propertyPhoneNum" />
+  			<ref bean="ProcurementCardTransaction-customerServiceNum" />
+  			<ref bean="ProcurementCardTransaction-prePaidAmt" />
+  			<ref bean="ProcurementCardTransaction-roomRate" />
+  			<ref bean="ProcurementCardTransaction-roomTax" />
+  			<ref bean="ProcurementCardTransaction-programCode" />
+  			<ref bean="ProcurementCardTransaction-callCharges" />
+  			<ref bean="ProcurementCardTransaction-foodSvcCharges" />
+  			<ref bean="ProcurementCardTransaction-miniBarCharges" />
+  			<ref bean="ProcurementCardTransaction-giftShopCharges" />
+  			<ref bean="ProcurementCardTransaction-laundryCharges" />
+  			<ref bean="ProcurementCardTransaction-healthClubCharges" />
+  			<ref bean="ProcurementCardTransaction-movieCharges" />
+  			<ref bean="ProcurementCardTransaction-busCtrCharges" />
+  			<ref bean="ProcurementCardTransaction-parkingCharges" />
+  			<ref bean="ProcurementCardTransaction-otherCode" />
+  			<ref bean="ProcurementCardTransaction-otherCharges" />
+  			<ref bean="ProcurementCardTransaction-adjustmentAmount" />
+  			<ref bean="ProcurementCardTransaction-checkOutDate" />
+  			<ref bean="ProcurementCardTransaction-rentalAgreementNum" />
+  			<ref bean="ProcurementCardTransaction-renterName" />
+  			<ref bean="ProcurementCardTransaction-returnCity" />
+  			<ref bean="ProcurementCardTransaction-returnState" />
+  			<ref bean="ProcurementCardTransaction-returnCountry" />
+  			<ref bean="ProcurementCardTransaction-returnDate" />
+  			<ref bean="ProcurementCardTransaction-returnLocation" />
+  			<ref bean="ProcurementCardTransaction-customerSvcNum" />
+  			<ref bean="ProcurementCardTransaction-rentalClass" />
+  			<ref bean="ProcurementCardTransaction-dailyRate" />
+  			<ref bean="ProcurementCardTransaction-weeklyRate" />
+  			<ref bean="ProcurementCardTransaction-ratePerMile" />
+  			<ref bean="ProcurementCardTransaction-maxFreeMiles" />
+  			<ref bean="ProcurementCardTransaction-totalMiles" />
+  			<ref bean="ProcurementCardTransaction-oneWayCharges" />
+  			<ref bean="ProcurementCardTransaction-insuranceCharges" />
+  			<ref bean="ProcurementCardTransaction-regularCharges" />
+  			<ref bean="ProcurementCardTransaction-towingCharges" />
+  			<ref bean="ProcurementCardTransaction-extraCharges" />
+  			<ref bean="ProcurementCardTransaction-lateReturnFee" />
+  			<ref bean="ProcurementCardTransaction-adjustCode" />
+  			<ref bean="ProcurementCardTransaction-adjustAmount" />
+  			<ref bean="ProcurementCardTransaction-progCode" />
+  			<ref bean="ProcurementCardTransaction-phoneCharges" />
+  			<ref bean="ProcurementCardTransaction-othrCharges" />
+  			<ref bean="ProcurementCardTransaction-totalTaxAmount" />
+  			<ref bean="ProcurementCardTransaction-passengerName" />
+  			<ref bean="ProcurementCardTransaction-departDate" />
+  			<ref bean="ProcurementCardTransaction-departureCity" />
+  			<ref bean="ProcurementCardTransaction-agencyCode" />
+  			<ref bean="ProcurementCardTransaction-agencyName" />
+  			<ref bean="ProcurementCardTransaction-ticketNumber" />
+  			<ref bean="ProcurementCardTransaction-customerCode" />
+  			<ref bean="ProcurementCardTransaction-issueDate" />
+  			<ref bean="ProcurementCardTransaction-issuingCarrier" />
+  			<ref bean="ProcurementCardTransaction-totalFare" />
+  			<ref bean="ProcurementCardTransaction-totalFees" />
+  			<ref bean="ProcurementCardTransaction-totalTaxes" />
+  		</list>
+  	</property>
+  </bean>
+  
+<!-- Attribute Definitions -->  
+
+  <bean id="ProcurementCardTransaction-invoiceNumber" parent="ProcurementCardTransaction-invoiceNumber-parentBean" />
+  <bean id="ProcurementCardTransaction-invoiceNumber-parentBean" abstract="true" parent="ProcurementCardLevel3Add-invoiceNumber-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-orderDate" parent="ProcurementCardTransaction-orderDate-parentBean" />
+  <bean id="ProcurementCardTransaction-orderDate-parentBean" abstract="true" parent="ProcurementCardLevel3Add-orderDate-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-purchaseTime" parent="ProcurementCardTransaction-purchaseTime-parentBean" />
+  <bean id="ProcurementCardTransaction-purchaseTime-parentBean" abstract="true" parent="ProcurementCardLevel3Add-purchaseTime-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-shipPostal" parent="ProcurementCardTransaction-shipPostal-parentBean" />
+  <bean id="ProcurementCardTransaction-shipPostal-parentBean" abstract="true" parent="ProcurementCardLevel3Add-shipPostal-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-destinationPostal" parent="ProcurementCardTransaction-destinationPostal-parentBean" />
+  <bean id="ProcurementCardTransaction-destinationPostal-parentBean" abstract="true" parent="ProcurementCardLevel3Add-destinationPostal-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-destinationCountryCode" parent="ProcurementCardTransaction-destinationCountryCode-parentBean" />
+  <bean id="ProcurementCardTransaction-destinationCountryCode-parentBean" abstract="true" parent="ProcurementCardLevel3Add-destinationCountryCode-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-taxAmount" parent="ProcurementCardTransaction-taxAmount-parentBean" />
+  <bean id="ProcurementCardTransaction-taxAmount-parentBean" abstract="true" parent="ProcurementCardLevel3Add-taxAmount-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-taxRate" parent="ProcurementCardTransaction-taxRate-parentBean" />
+  <bean id="ProcurementCardTransaction-taxRate-parentBean" abstract="true" parent="ProcurementCardLevel3Add-taxRate-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-discountAmount" parent="ProcurementCardTransaction-discountAmount-parentBean" />
+  <bean id="ProcurementCardTransaction-discountAmount-parentBean" abstract="true" parent="ProcurementCardLevel3Add-discountAmount-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-freightAmount" parent="ProcurementCardTransaction-freightAmount-parentBean" />
+  <bean id="ProcurementCardTransaction-freightAmount-parentBean" abstract="true" parent="ProcurementCardLevel3Add-freightAmount-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-dutyAmount" parent="ProcurementCardTransaction-dutyAmount-parentBean" />
+  <bean id="ProcurementCardTransaction-dutyAmount-parentBean" abstract="true" parent="ProcurementCardLevel3Add-dutyAmount-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-userEffectiveDate" parent="ProcurementCardTransaction-userEffectiveDate-parentBean" />
+  <bean id="ProcurementCardTransaction-userEffectiveDate-parentBean" abstract="true" parent="ProcurementCardLevel3AddUser-userEffectiveDate-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-userAmount" parent="ProcurementCardTransaction-userAmount-parentBean" />
+  <bean id="ProcurementCardTransaction-userAmount-parentBean" abstract="true" parent="ProcurementCardLevel3AddUser-userAmount-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-oilBrandName" parent="ProcurementCardTransaction-oilBrandName-parentBean" />
+  <bean id="ProcurementCardTransaction-oilBrandName-parentBean" abstract="true" parent="ProcurementCardLevel3Fuel-oilBrandName-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-odometerReading" parent="ProcurementCardTransaction-odometerReading-parentBean" />
+  <bean id="ProcurementCardTransaction-odometerReading-parentBean" abstract="true" parent="ProcurementCardLevel3Fuel-odometerReading-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-fleetId" parent="ProcurementCardTransaction-fleetId-parentBean" />
+  <bean id="ProcurementCardTransaction-fleetId-parentBean" abstract="true" parent="ProcurementCardLevel3Fuel-fleetId-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-messageId" parent="ProcurementCardTransaction-messageId-parentBean" />
+  <bean id="ProcurementCardTransaction-messageId-parentBean" abstract="true" parent="ProcurementCardLevel3Fuel-messageId-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-usage" parent="ProcurementCardTransaction-usage-parentBean" />
+  <bean id="ProcurementCardTransaction-usage-parentBean" abstract="true" parent="ProcurementCardLevel3Fuel-usage-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-fuelServiceType" parent="ProcurementCardTransaction-fuelServiceType-parentBean" />
+  <bean id="ProcurementCardTransaction-fuelServiceType-parentBean" abstract="true" parent="ProcurementCardLevel3Fuel-fuelServiceType-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-fuelProductCd" parent="ProcurementCardTransaction-fuelProductCd-parentBean" />
+  <bean id="ProcurementCardTransaction-fuelProductCd-parentBean" abstract="true" parent="ProcurementCardLevel3Fuel-fuelProductCd-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-productTypeCd" parent="ProcurementCardTransaction-productTypeCd-parentBean" />
+  <bean id="ProcurementCardTransaction-productTypeCd-parentBean" abstract="true" parent="ProcurementCardLevel3Fuel-productTypeCd-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-fuelQuantity" parent="ProcurementCardTransaction-fuelQuantity-parentBean" />
+  <bean id="ProcurementCardTransaction-fuelQuantity-parentBean" abstract="true" parent="ProcurementCardLevel3Fuel-fuelQuantity-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-fuelUnitOfMeasure" parent="ProcurementCardTransaction-fuelUnitOfMeasure-parentBean" />
+  <bean id="ProcurementCardTransaction-fuelUnitOfMeasure-parentBean" abstract="true" parent="ProcurementCardLevel3Fuel-fuelUnitOfMeasure-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-fuelUnitPrice" parent="ProcurementCardTransaction-fuelUnitPrice-parentBean" />
+  <bean id="ProcurementCardTransaction-fuelUnitPrice-parentBean" abstract="true" parent="ProcurementCardLevel3Fuel-fuelUnitPrice-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-fuelSaleAmount" parent="ProcurementCardTransaction-fuelSaleAmount-parentBean" />
+  <bean id="ProcurementCardTransaction-fuelSaleAmount-parentBean" abstract="true" parent="ProcurementCardLevel3Fuel-fuelSaleAmount-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-fuelDiscountAmount" parent="ProcurementCardTransaction-fuelDiscountAmount-parentBean" />
+  <bean id="ProcurementCardTransaction-fuelDiscountAmount-parentBean" abstract="true" parent="ProcurementCardLevel3Fuel-fuelDiscountAmount-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-taxAmount1" parent="ProcurementCardTransaction-taxAmount1-parentBean" />
+  <bean id="ProcurementCardTransaction-taxAmount1-parentBean" abstract="true" parent="ProcurementCardLevel3Fuel-taxAmount1-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-taxAmount2" parent="ProcurementCardTransaction-taxAmount2-parentBean" />
+  <bean id="ProcurementCardTransaction-taxAmount2-parentBean" abstract="true" parent="ProcurementCardLevel3Fuel-taxAmount2-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-totalAmount" parent="ProcurementCardTransaction-totalAmount-parentBean" />
+  <bean id="ProcurementCardTransaction-totalAmount-parentBean" abstract="true" parent="ProcurementCardLevel3Fuel-totalAmount-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-genericEffectiveDate" parent="ProcurementCardTransaction-genericEffectiveDate-parentBean" />
+  <bean id="ProcurementCardTransaction-genericEffectiveDate-parentBean" abstract="true" parent="ProcurementCardLevel3Generic-genericEffectiveDate-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-genericData" parent="ProcurementCardTransaction-genericData-parentBean" />
+  <bean id="ProcurementCardTransaction-genericData-parentBean" abstract="true" parent="ProcurementCardLevel3Generic-genericData-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-arriveDate" parent="ProcurementCardTransaction-arriveDate-parentBean" />
+  <bean id="ProcurementCardTransaction-arriveDate-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-arriveDate-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-departureDate" parent="ProcurementCardTransaction-departureDate-parentBean" />
+  <bean id="ProcurementCardTransaction-departureDate-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-departureDate-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-folioNum" parent="ProcurementCardTransaction-folioNum-parentBean" />
+  <bean id="ProcurementCardTransaction-folioNum-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-folioNum-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-propertyPhoneNum" parent="ProcurementCardTransaction-propertyPhoneNum-parentBean" />
+  <bean id="ProcurementCardTransaction-propertyPhoneNum-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-propertyPhoneNum-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-customerServiceNum" parent="ProcurementCardTransaction-customerServiceNum-parentBean" />
+  <bean id="ProcurementCardTransaction-customerServiceNum-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-customerServiceNum-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-prePaidAmt" parent="ProcurementCardTransaction-prePaidAmt-parentBean" />
+  <bean id="ProcurementCardTransaction-prePaidAmt-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-prePaidAmt-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-roomRate" parent="ProcurementCardTransaction-roomRate-parentBean" />
+  <bean id="ProcurementCardTransaction-roomRate-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-roomRate-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-roomTax" parent="ProcurementCardTransaction-roomTax-parentBean" />
+  <bean id="ProcurementCardTransaction-roomTax-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-roomTax-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-programCode" parent="ProcurementCardTransaction-programCode-parentBean" />
+  <bean id="ProcurementCardTransaction-programCode-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-programCode-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-callCharges" parent="ProcurementCardTransaction-callCharges-parentBean" />
+  <bean id="ProcurementCardTransaction-callCharges-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-callCharges-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-foodSvcCharges" parent="ProcurementCardTransaction-foodSvcCharges-parentBean"/>
+  <bean id="ProcurementCardTransaction-foodSvcCharges-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-foodSvcCharges-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-miniBarCharges" parent="ProcurementCardTransaction-miniBarCharges-parentBean" />
+  <bean id="ProcurementCardTransaction-miniBarCharges-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-miniBarCharges-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-giftShopCharges" parent="ProcurementCardTransaction-giftShopCharges-parentBean" />
+  <bean id="ProcurementCardTransaction-giftShopCharges-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-giftShopCharges-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-laundryCharges" parent="ProcurementCardTransaction-laundryCharges-parentBean" />
+  <bean id="ProcurementCardTransaction-laundryCharges-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-laundryCharges-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-healthClubCharges" parent="ProcurementCardTransaction-healthClubCharges-parentBean" />
+  <bean id="ProcurementCardTransaction-healthClubCharges-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-healthClubCharges-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-movieCharges" parent="ProcurementCardTransaction-movieCharges-parentBean" />
+  <bean id="ProcurementCardTransaction-movieCharges-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-movieCharges-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-busCtrCharges" parent="ProcurementCardTransaction-busCtrCharges-parentBean" />
+  <bean id="ProcurementCardTransaction-busCtrCharges-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-busCtrCharges-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-parkingCharges" parent="ProcurementCardTransaction-parkingCharges-parentBean" />
+  <bean id="ProcurementCardTransaction-parkingCharges-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-parkingCharges-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-otherCode" parent="ProcurementCardTransaction-otherCode-parentBean" />
+  <bean id="ProcurementCardTransaction-otherCode-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-otherCode-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-otherCharges" parent="ProcurementCardTransaction-otherCharges-parentBean" />
+  <bean id="ProcurementCardTransaction-otherCharges-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-otherCharges-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-adjustmentAmount" parent="ProcurementCardTransaction-adjustmentAmount-parentBean" />
+  <bean id="ProcurementCardTransaction-adjustmentAmount-parentBean" abstract="true" parent="ProcurementCardLevel3Lodging-adjustmentAmount-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-checkOutDate" parent="ProcurementCardTransaction-checkOutDate-parentBean" />
+  <bean id="ProcurementCardTransaction-checkOutDate-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-checkOutDate-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-rentalAgreementNum" parent="ProcurementCardTransaction-rentalAgreementNum-parentBean" />
+  <bean id="ProcurementCardTransaction-rentalAgreementNum-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-rentalAgreementNum-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-renterName" parent="ProcurementCardTransaction-renterName-parentBean" />
+  <bean id="ProcurementCardTransaction-renterName-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-renterName-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-returnCity" parent="ProcurementCardTransaction-returnCity-parentBean" />
+  <bean id="ProcurementCardTransaction-returnCity-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-returnCity-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-returnState" parent="ProcurementCardTransaction-returnState-parentBean" />
+  <bean id="ProcurementCardTransaction-returnState-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-returnState-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-returnCountry" parent="ProcurementCardTransaction-returnCountry-parentBean" />
+  <bean id="ProcurementCardTransaction-returnCountry-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-returnCountry-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-returnDate" parent="ProcurementCardTransaction-returnDate-parentBean" />
+  <bean id="ProcurementCardTransaction-returnDate-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-returnDate-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-returnLocation" parent="ProcurementCardTransaction-returnLocation-parentBean" />
+  <bean id="ProcurementCardTransaction-returnLocation-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-returnLocation-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-customerSvcNum" parent="ProcurementCardTransaction-customerSvcNum-parentBean" />
+  <bean id="ProcurementCardTransaction-customerSvcNum-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-customerSvcNum-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-rentalClass" parent="ProcurementCardTransaction-rentalClass-parentBean" />
+  <bean id="ProcurementCardTransaction-rentalClass-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-rentalClass-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-dailyRate" parent="ProcurementCardTransaction-dailyRate-parentBean" />
+  <bean id="ProcurementCardTransaction-dailyRate-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-dailyRate-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-weeklyRate" parent="ProcurementCardTransaction-weeklyRate-parentBean" />
+  <bean id="ProcurementCardTransaction-weeklyRate-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-weeklyRate-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-ratePerMile" parent="ProcurementCardTransaction-ratePerMile-parentBean" />
+  <bean id="ProcurementCardTransaction-ratePerMile-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-ratePerMile-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-maxFreeMiles" parent="ProcurementCardTransaction-maxFreeMiles-parentBean" />
+  <bean id="ProcurementCardTransaction-maxFreeMiles-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-maxFreeMiles-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-totalMiles" parent="ProcurementCardTransaction-totalMiles-parentBean" />
+  <bean id="ProcurementCardTransaction-totalMiles-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-totalMiles-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-oneWayCharges" parent="ProcurementCardTransaction-oneWayCharges-parentBean" />
+  <bean id="ProcurementCardTransaction-oneWayCharges-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-oneWayCharges-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-insuranceCharges" parent="ProcurementCardTransaction-insuranceCharges-parentBean" />
+  <bean id="ProcurementCardTransaction-insuranceCharges-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-insuranceCharges-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-regularCharges" parent="ProcurementCardTransaction-regularCharges-parentBean" />
+  <bean id="ProcurementCardTransaction-regularCharges-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-regularCharges-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-towingCharges" parent="ProcurementCardTransaction-towingCharges-parentBean" />
+  <bean id="ProcurementCardTransaction-towingCharges-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-towingCharges-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-extraCharges" parent="ProcurementCardTransaction-extraCharges-parentBean" />
+  <bean id="ProcurementCardTransaction-extraCharges-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-extraCharges-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-lateReturnFee" parent="ProcurementCardTransaction-lateReturnFee-parentBean" />
+  <bean id="ProcurementCardTransaction-lateReturnFee-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-lateReturnFee-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-adjustCode" parent="ProcurementCardTransaction-adjustCode-parentBean" />
+  <bean id="ProcurementCardTransaction-adjustCode-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-adjustCode-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-adjustAmount" parent="ProcurementCardTransaction-adjustAmount-parentBean" />
+  <bean id="ProcurementCardTransaction-adjustAmount-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-adjustAmount-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-progCode" parent="ProcurementCardTransaction-progCode-parentBean" />
+  <bean id="ProcurementCardTransaction-progCode-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-progCode-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-phoneCharges" parent="ProcurementCardTransaction-phoneCharges-parentBean" />
+  <bean id="ProcurementCardTransaction-phoneCharges-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-phoneCharges-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-othrCharges" parent="ProcurementCardTransaction-othrCharges-parentBean" />
+  <bean id="ProcurementCardTransaction-othrCharges-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-othrCharges-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-totalTaxAmount" parent="ProcurementCardTransaction-totalTaxAmount-parentBean" />
+  <bean id="ProcurementCardTransaction-totalTaxAmount-parentBean" abstract="true" parent="ProcurementCardLevel3Rental-totalTaxAmount-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-passengerName" parent="ProcurementCardTransaction-passengerName-parentBean" />
+  <bean id="ProcurementCardTransaction-passengerName-parentBean" abstract="true" parent="ProcurementCardLevel3Transport-passengerName-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-departDate" parent="ProcurementCardTransaction-departDate-parentBean" />
+  <bean id="ProcurementCardTransaction-departDate-parentBean" abstract="true" parent="ProcurementCardLevel3Transport-departDate-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-departureCity" parent="ProcurementCardTransaction-departureCity-parentBean" />
+  <bean id="ProcurementCardTransaction-departureCity-parentBean" abstract="true" parent="ProcurementCardLevel3Transport-departureCity-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-agencyCode" parent="ProcurementCardTransaction-agencyCode-parentBean" />
+  <bean id="ProcurementCardTransaction-agencyCode-parentBean" abstract="true" parent="ProcurementCardLevel3Transport-agencyCode-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-agencyName" parent="ProcurementCardTransaction-agencyName-parentBean" />
+  <bean id="ProcurementCardTransaction-agencyName-parentBean" abstract="true" parent="ProcurementCardLevel3Transport-agencyName-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-ticketNumber" parent="ProcurementCardTransaction-ticketNumber-parentBean" />
+  <bean id="ProcurementCardTransaction-ticketNumber-parentBean" abstract="true" parent="ProcurementCardLevel3Transport-ticketNumber-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-customerCode" parent="ProcurementCardTransaction-customerCode-parentBean" />
+  <bean id="ProcurementCardTransaction-customerCode-parentBean" abstract="true" parent="ProcurementCardLevel3Transport-customerCode-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-issueDate" parent="ProcurementCardTransaction-issueDate-parentBean" />
+  <bean id="ProcurementCardTransaction-issueDate-parentBean" abstract="true" parent="ProcurementCardLevel3Transport-issueDate-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-issuingCarrier" parent="ProcurementCardTransaction-issuingCarrier-parentBean" />
+  <bean id="ProcurementCardTransaction-issuingCarrier-parentBean" abstract="true" parent="ProcurementCardLevel3Transport-issuingCarrier-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-totalFare" parent="ProcurementCardTransaction-totalFare-parentBean" />
+  <bean id="ProcurementCardTransaction-totalFare-parentBean" abstract="true" parent="ProcurementCardLevel3Transport-totalFare-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-totalFees" parent="ProcurementCardTransaction-totalFees-parentBean" />
+  <bean id="ProcurementCardTransaction-totalFees-parentBean" abstract="true" parent="ProcurementCardLevel3Transport-totalFees-parentBean">
+  </bean>
+  
+  <bean id="ProcurementCardTransaction-totalTaxes" parent="ProcurementCardTransaction-totalTaxes-parentBean" />
+  <bean id="ProcurementCardTransaction-totalTaxes-parentBean" abstract="true" parent="ProcurementCardLevel3Transport-totalTaxes-parentBean">
+  </bean>
+  
+</beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardTransactionDetail.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardTransactionDetail.xml
@@ -1,0 +1,882 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xmlns:dd="http://rice.kuali.org/dd"
+    xsi:schemaLocation="
+http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+http://rice.kuali.org/dd http://rice.kuali.org/dd/dd.xsd">
+
+<bean id="ProcurementCardTransactionDetail" parent="ProcurementCardTransactionDetail-parentBean">
+	<property name="businessObjectClass" value="edu.arizona.kfs.fp.businessobject.ProcurementCardTransactionDetail"/>
+	<property name="attributes">
+		<list merge="true">
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Add.invoiceNumber" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Add.orderDate" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Add.purchaseTime" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Add.shipPostal" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Add.destinationPostal" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Add.destinationCountryCode" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Add.taxAmount" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Add.taxRate" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Add.discountAmount" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Add.freightAmount" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Add.dutyAmount" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3AddUser.userEffectiveDate" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3AddUser.userAmount" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.oilBrandName" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.odometerReading" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fleetId" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.messageId" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.usage" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelServiceType" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelProductCd" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.productTypeCd" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelQuantity" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelUnitOfMeasure" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelUnitPrice" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelSaleAmount" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelDiscountAmount" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.taxAmount1" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.taxAmount2" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.totalAmount" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Generic.genericEffectiveDate" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Generic.genericData" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.arriveDate" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.departureDate" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.folioNum" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.propertyPhoneNum" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.customerServiceNum" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.prePaidAmt" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.roomRate" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.roomTax" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.programCode" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.callCharges" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.foodSvcCharges" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.miniBarCharges" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.giftShopCharges" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.laundryCharges" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.healthClubCharges" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.movieCharges" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.busCtrCharges" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.parkingCharges" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.otherCode" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.otherCharges" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.adjustmentAmount" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.checkOutDate" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.rentalAgreementNum" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.renterName" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.returnCity" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.returnState" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.returnCountry" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.returnDate" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.returnLocation" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.customerSvcNum" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.rentalClass" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.dailyRate" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.weeklyRate" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.ratePerMile" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.maxFreeMiles" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.totalMiles" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.oneWayCharges" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.insuranceCharges" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.regularCharges" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.towingCharges" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.extraCharges" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.lateReturnFee" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.adjustCode" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.adjustAmount" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.progCode" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.phoneCharges" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.othrCharges" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Rental.totalTaxAmount" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Transport.passengerName"/>
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Transport.departDate" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Transport.departureCity" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Transport.agencyCode" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Transport.agencyName" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Transport.ticketNumber" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Transport.customerCode" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Transport.issueDate" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Transport.issuingCarrier" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Transport.totalFare" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Transport.totalFees" />
+			<ref bean="ProcurementCardTransactionDetail-procurementCardLevel3Transport.totalTaxes" />
+		</list>
+	</property>
+</bean>
+
+<!-- Attribute Definitions -->
+
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.invoiceNumber" parent="ProcurementCardTransactionDetail-procurementCardLevel3Add.invoiceNumber-parentBean" />  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.invoiceNumber-parentBean" parent="ProcurementCardLevel3Add-invoiceNumber" abstract="true">
+  	<property name="name" value="procurementCardLevel3Add.invoiceNumber" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.orderDate" parent="ProcurementCardTransactionDetail-procurementCardLevel3Add.orderDate-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.orderDate-parentBean" parent="ProcurementCardLevel3Add-orderDate" abstract="true">
+  	<property name="name" value="procurementCardLevel3Add.orderDate" />
+  </bean>
+
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.purchaseTime" parent="ProcurementCardTransactionDetail-procurementCardLevel3Add.purchaseTime-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.purchaseTime-parentBean" parent="ProcurementCardLevel3Add-purchaseTime" abstract="true">
+  	<property name="name" value="procurementCardLevel3Add.purchaseTime" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.shipPostal" parent="ProcurementCardTransactionDetail-procurementCardLevel3Add.shipPostal-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.shipPostal-parentBean" parent="ProcurementCardLevel3Add-shipPostal" abstract="true">
+  	<property name="name" value="procurementCardLevel3Add.shipPostal" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.destinationPostal" parent="ProcurementCardTransactionDetail-procurementCardLevel3Add.destinationPostal-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.destinationPostal-parentBean" parent="ProcurementCardLevel3Add-destinationPostal" abstract="true">
+  	<property name="name" value="procurementCardLevel3Add.destinationPostal" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.destinationCountryCode" parent="ProcurementCardTransactionDetail-procurementCardLevel3Add.destinationCountryCode-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.destinationCountryCode-parentBean" parent="ProcurementCardLevel3Add-destinationCountryCode" abstract="true">
+  	<property name="name" value="procurementCardLevel3Add.destinationCountryCode" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.taxAmount" parent="ProcurementCardTransactionDetail-procurementCardLevel3Add.taxAmount-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.taxAmount-parentBean" parent="ProcurementCardLevel3Add-taxAmount" abstract="true">
+  	<property name="name" value="procurementCardLevel3Add.taxAmount" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.taxRate" parent="ProcurementCardTransactionDetail-procurementCardLevel3Add.taxRate-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.taxRate-parentBean" parent="ProcurementCardLevel3Add-taxRate" abstract="true">
+  	<property name="name" value="procurementCardLevel3Add.taxRate" />
+  </bean>
+
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.discountAmount" parent="ProcurementCardTransactionDetail-procurementCardLevel3Add.discountAmount-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.discountAmount-parentBean" parent="ProcurementCardLevel3Add-discountAmount" abstract="true">
+  	<property name="name" value="procurementCardLevel3Add.discountAmount" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.freightAmount" parent="ProcurementCardTransactionDetail-procurementCardLevel3Add.freightAmount-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.freightAmount-parentBean" parent="ProcurementCardLevel3Add-freightAmount" abstract="true">
+  	<property name="name" value="procurementCardLevel3Add.freightAmount" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.dutyAmount" parent="ProcurementCardTransactionDetail-procurementCardLevel3Add.dutyAmount-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.dutyAmount-parentBean" parent="ProcurementCardLevel3Add-dutyAmount" abstract="true">
+  	<property name="name" value="procurementCardLevel3Add.dutyAmount" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3AddUser.userEffectiveDate" parent="ProcurementCardTransactionDetail-procurementCardLevel3AddUser.userEffectiveDate-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3AddUser.userEffectiveDate-parentBean" parent="ProcurementCardLevel3AddUser-userEffectiveDate" abstract="true">
+  	<property name="name" value="procurementCardLevel3AddUser.userEffectiveDate" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3AddUser.userAmount" parent="ProcurementCardTransactionDetail-procurementCardLevel3AddUser.userAmount-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3AddUser.userAmount-parentBean" parent="ProcurementCardLevel3AddUser-userAmount" abstract="true">
+  	<property name="name" value="procurementCardLevel3AddUser.userAmount" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.oilBrandName" parent="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.oilBrandName-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.oilBrandName-parentBean" parent="ProcurementCardLevel3Fuel-oilBrandName" abstract="true">
+  	<property name="name" value="procurementCardLevel3Fuel.oilBrandName" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.odometerReading" parent="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.odometerReading-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.odometerReading-parentBean" parent="ProcurementCardLevel3Fuel-odometerReading" abstract="true">
+  	<property name="name" value="procurementCardLevel3Fuel.odometerReading" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fleetId" parent="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fleetId-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fleetId-parentBean" parent="ProcurementCardLevel3Fuel-fleetId" abstract="true">
+  	<property name="name" value="procurementCardLevel3Fuel.fleetId" />
+  </bean>
+
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.messageId" parent="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.messageId-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.messageId-parentBean" parent="ProcurementCardLevel3Fuel-messageId" abstract="true">
+  	<property name="name" value="procurementCardLevel3Fuel.messageId" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.usage" parent="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.usage-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.usage-parentBean" parent="ProcurementCardLevel3Fuel-usage" abstract="true">
+  	<property name="name" value="procurementCardLevel3Fuel.usage" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelServiceType" parent="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelServiceType-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelServiceType-parentBean" parent="ProcurementCardLevel3Fuel-fuelServiceType" abstract="true">
+  	<property name="name" value="procurementCardLevel3Fuel.fuelServiceType" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelProductCd" parent="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelProductCd-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelProductCd-parentBean" parent="ProcurementCardLevel3Fuel-fuelProductCd" abstract="true">
+  	<property name="name" value="procurementCardLevel3Fuel.fuelProductCd" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.productTypeCd" parent="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.productTypeCd-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.productTypeCd-parentBean" parent="ProcurementCardLevel3Fuel-productTypeCd" abstract="true">
+  	<property name="name" value="procurementCardLevel3Fuel.productTypeCd" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelQuantity" parent="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelQuantity-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelQuantity-parentBean" parent="ProcurementCardLevel3Fuel-fuelQuantity" abstract="true">
+  	<property name="name" value="procurementCardLevel3Fuel.fuelQuantity" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelUnitOfMeasure" parent="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelUnitOfMeasure-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelUnitOfMeasure-parentBean" parent="ProcurementCardLevel3Fuel-fuelUnitOfMeasure" abstract="true">
+  	<property name="name" value="procurementCardLevel3Fuel.fuelUnitOfMeasure" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelUnitPrice" parent="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelUnitPrice-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelUnitPrice-parentBean" parent="ProcurementCardLevel3Fuel-fuelUnitPrice" abstract="true">
+  	<property name="name" value="procurementCardLevel3Fuel.fuelUnitPrice" />
+  </bean>
+
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelSaleAmount" parent="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelSaleAmount-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelSaleAmount-parentBean" parent="ProcurementCardLevel3Fuel-fuelSaleAmount" abstract="true">
+  	<property name="name" value="procurementCardLevel3Fuel.fuelSaleAmount" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelDiscountAmount" parent="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelDiscountAmount-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.fuelDiscountAmount-parentBean" parent="ProcurementCardLevel3Fuel-fuelDiscountAmount" abstract="true">
+  	<property name="name" value="procurementCardLevel3Fuel.fuelDiscountAmount" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.taxAmount1" parent="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.taxAmount1-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.taxAmount1-parentBean" parent="ProcurementCardLevel3Fuel-taxAmount1" abstract="true">
+  	<property name="name" value="procurementCardLevel3Fuel.taxAmount1" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.taxAmount2" parent="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.taxAmount2-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.taxAmount2-parentBean" parent="ProcurementCardLevel3Fuel-taxAmount2" abstract="true">
+  	<property name="name" value="procurementCardLevel3Fuel.taxAmount2" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.totalAmount" parent="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.totalAmount-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Fuel.totalAmount-parentBean" parent="ProcurementCardLevel3Fuel-totalAmount" abstract="true">
+  	<property name="name" value="procurementCardLevel3Fuel.totalAmount" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Generic.genericEffectiveDate" parent="ProcurementCardTransactionDetail-procurementCardLevel3Generic.genericEffectiveDate-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Generic.genericEffectiveDate-parentBean" parent="ProcurementCardLevel3Generic-genericEffectiveDate" abstract="true">
+  	<property name="name" value="procurementCardLevel3Generic.genericEffectiveDate" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Generic.genericData" parent="ProcurementCardTransactionDetail-procurementCardLevel3Generic.genericData-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Generic.genericData-parentBean" parent="ProcurementCardLevel3Generic-genericData" abstract="true">
+  	<property name="name" value="procurementCardLevel3Generic.genericData" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.arriveDate" parent="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.arriveDate-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.arriveDate-parentBean" parent="ProcurementCardLevel3Lodging-arriveDate" abstract="true">
+  	<property name="name" value="procurementCardLevel3Lodging.arriveDate" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.departureDate" parent="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.departureDate-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.departureDate-parentBean" parent="ProcurementCardLevel3Lodging-departureDate" abstract="true">
+  	<property name="name" value="procurementCardLevel3Lodging.departureDate" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.folioNum" parent="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.folioNum-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.folioNum-parentBean" parent="ProcurementCardLevel3Lodging-folioNum" abstract="true">
+  	<property name="name" value="procurementCardLevel3Lodging.folioNum" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.propertyPhoneNum" parent="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.propertyPhoneNum-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.propertyPhoneNum-parentBean" parent="ProcurementCardLevel3Lodging-propertyPhoneNum" abstract="true">
+  	<property name="name" value="procurementCardLevel3Lodging.propertyPhoneNum" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.customerServiceNum" parent="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.customerServiceNum-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.customerServiceNum-parentBean" parent="ProcurementCardLevel3Lodging-customerServiceNum" abstract="true">
+  	<property name="name" value="procurementCardLevel3Lodging.customerServiceNum" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.prePaidAmt" parent="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.prePaidAmt-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.prePaidAmt-parentBean" parent="ProcurementCardLevel3Lodging-prePaidAmt" abstract="true">
+  	<property name="name" value="procurementCardLevel3Lodging.prePaidAmt" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.roomRate" parent="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.roomRate-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.roomRate-parentBean" parent="ProcurementCardLevel3Lodging-roomRate" abstract="true">
+  	<property name="name" value="procurementCardLevel3Lodging.roomRate" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.roomTax" parent="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.roomTax-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.roomTax-parentBean" parent="ProcurementCardLevel3Lodging-programCode" abstract="true">
+  	<property name="name" value="procurementCardLevel3Lodging.roomTax" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.programCode" parent="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.programCode-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.programCode-parentBean" parent="ProcurementCardLevel3Lodging-programCode" abstract="true">
+  	<property name="name" value="procurementCardLevel3Lodging.programCode" />
+  </bean>
+
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.callCharges" parent="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.callCharges-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.callCharges-parentBean" parent="ProcurementCardLevel3Lodging-callCharges" abstract="true">
+  	<property name="name" value="procurementCardLevel3Lodging.callCharges" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.foodSvcCharges" parent="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.foodSvcCharges-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.foodSvcCharges-parentBean" parent="ProcurementCardLevel3Lodging-foodSvcCharges" abstract="true">
+  	<property name="name" value="procurementCardLevel3Lodging.foodSvcCharges" />
+  </bean>
+
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.miniBarCharges" parent="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.miniBarCharges-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.miniBarCharges-parentBean" parent="ProcurementCardLevel3Lodging-miniBarCharges" abstract="true">
+  	<property name="name" value="procurementCardLevel3Lodging.miniBarCharges" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.giftShopCharges" parent="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.giftShopCharges-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.giftShopCharges-parentBean" parent="ProcurementCardLevel3Lodging-giftShopCharges" abstract="true">
+  	<property name="name" value="procurementCardLevel3Lodging.giftShopCharges" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.laundryCharges" parent="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.laundryCharges-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.laundryCharges-parentBean" parent="ProcurementCardLevel3Lodging-laundryCharges" abstract="true">
+  	<property name="name" value="procurementCardLevel3Lodging.laundryCharges" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.healthClubCharges" parent="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.healthClubCharges-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.healthClubCharges-parentBean" parent="ProcurementCardLevel3Lodging-healthClubCharges" abstract="true">
+  	<property name="name" value="procurementCardLevel3Lodging.healthClubCharges" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.movieCharges" parent="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.movieCharges-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.movieCharges-parentBean" parent="ProcurementCardLevel3Lodging-movieCharges" abstract="true">
+  	<property name="name" value="procurementCardLevel3Lodging.movieCharges" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.busCtrCharges" parent="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.busCtrCharges-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.busCtrCharges-parentBean" parent="ProcurementCardLevel3Lodging-busCtrCharges" abstract="true">
+  	<property name="name" value="procurementCardLevel3Lodging.busCtrCharges" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.parkingCharges" parent="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.parkingCharges-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.parkingCharges-parentBean" parent="ProcurementCardLevel3Lodging-parkingCharges" abstract="true">
+  	<property name="name" value="procurementCardLevel3Lodging.parkingCharges" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.otherCode" parent="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.otherCode-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.otherCode-parentBean" parent="ProcurementCardLevel3Lodging-otherCode" abstract="true">
+  	<property name="name" value="procurementCardLevel3Lodging.otherCode" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.otherCharges" parent="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.otherCharges-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.otherCharges-parentBean" parent="ProcurementCardLevel3Lodging-otherCharges" abstract="true">
+  	<property name="name" value="procurementCardLevel3Lodging.otherCharges" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.adjustmentAmount" parent="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.adjustmentAmount-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Lodging.adjustmentAmount-parentBean" parent="ProcurementCardLevel3Lodging-adjustmentAmount" abstract="true">
+  	<property name="name" value="procurementCardLevel3Lodging.adjustmentAmount" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.checkOutDate" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.checkOutDate-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.checkOutDate-parentBean" parent="ProcurementCardLevel3Rental-checkOutDate" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.checkOutDate" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.rentalAgreementNum" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.rentalAgreementNum-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.rentalAgreementNum-parentBean" parent="ProcurementCardLevel3Rental-rentalAgreementNum" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.rentalAgreementNum" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.renterName" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.renterName-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.renterName-parentBean" parent="ProcurementCardLevel3Rental-renterName" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.renterName" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.returnCity" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.returnCity-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.returnCity-parentBean" parent="ProcurementCardLevel3Rental-returnCity" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.returnCity" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.returnState" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.returnState-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.returnState-parentBean" parent="ProcurementCardLevel3Rental-returnState" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.returnState" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.returnCountry" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.returnCountry-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.returnCountry-parentBean" parent="ProcurementCardLevel3Rental-returnCountry" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.returnCountry" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.returnDate" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.returnDate-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.returnDate-parentBean" parent="ProcurementCardLevel3Rental-returnDate" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.returnDate" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.returnLocation" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.returnLocation-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.returnLocation-parentBean" parent="ProcurementCardLevel3Rental-returnLocation" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.returnLocation" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.customerSvcNum" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.customerSvcNum-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.customerSvcNum-parentBean" parent="ProcurementCardLevel3Rental-customerSvcNum" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.customerSvcNum" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.rentalClass" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.rentalClass-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.rentalClass-parentBean" parent="ProcurementCardLevel3Rental-rentalClass" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.rentalClass" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.dailyRate" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.dailyRate-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.dailyRate-parentBean" parent="ProcurementCardLevel3Rental-dailyRate" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.dailyRate" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.weeklyRate" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.weeklyRate-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.weeklyRate-parentBean" parent="ProcurementCardLevel3Rental-weeklyRate" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.weeklyRate" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.ratePerMile" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.ratePerMile-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.ratePerMile-parentBean" parent="ProcurementCardLevel3Rental-ratePerMile" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.ratePerMile" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.maxFreeMiles" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.maxFreeMiles-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.maxFreeMiles-parentBean" parent="ProcurementCardLevel3Rental-maxFreeMiles" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.maxFreeMiles" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.totalMiles" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.totalMiles-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.totalMiles-parentBean" parent="ProcurementCardLevel3Rental-totalMiles" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.totalMiles" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.oneWayCharges" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.oneWayCharges-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.oneWayCharges-parentBean" parent="ProcurementCardLevel3Rental-oneWayCharges" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.oneWayCharges" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.insuranceCharges" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.insuranceCharges-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.insuranceCharges-parentBean" parent="ProcurementCardLevel3Rental-insuranceCharges" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.insuranceCharges" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.regularCharges" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.regularCharges-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.regularCharges-parentBean" parent="ProcurementCardLevel3Rental-regularCharges" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.regularCharges" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.towingCharges" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.towingCharges-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.towingCharges-parentBean" parent="ProcurementCardLevel3Rental-towingCharges" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.towingCharges" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.extraCharges" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.extraCharges-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.extraCharges-parentBean" parent="ProcurementCardLevel3Rental-extraCharges" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.extraCharges" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.lateReturnFee" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.lateReturnFee-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.lateReturnFee-parentBean" parent="ProcurementCardLevel3Rental-lateReturnFee" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.lateReturnFee" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.adjustCode" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.adjustCode-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.adjustCode-parentBean" parent="ProcurementCardLevel3Rental-adjustCode" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.adjustCode" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.adjustAmount" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.adjustAmount-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.adjustAmount-parentBean" parent="ProcurementCardLevel3Rental-adjustAmount" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.adjustAmount" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.progCode" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.progCode-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.progCode-parentBean" parent="ProcurementCardLevel3Rental-progCode" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.progCode" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.phoneCharges" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.phoneCharges-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.phoneCharges-parentBean" parent="ProcurementCardLevel3Rental-phoneCharges" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.phoneCharges" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.othrCharges" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.othrCharges-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.othrCharges-parentBean" parent="ProcurementCardLevel3Rental-othrCharges" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.othrCharges" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.totalTaxAmount" parent="ProcurementCardTransactionDetail-procurementCardLevel3Rental.totalTaxAmount-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Rental.totalTaxAmount-parentBean" parent="ProcurementCardLevel3Rental-totalTaxAmount" abstract="true">
+  	<property name="name" value="procurementCardLevel3Rental.totalTaxAmount" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.passengerName" parent="ProcurementCardTransactionDetail-procurementCardLevel3Transport.passengerName-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.passengerName-parentBean" parent="ProcurementCardLevel3Transport-passengerName" abstract="true">
+  	<property name="name" value="procurementCardLevel3Transport.passengerName" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.departDate" parent="ProcurementCardTransactionDetail-procurementCardLevel3Transport.departDate-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.departDate-parentBean" parent="ProcurementCardLevel3Transport-departDate" abstract="true">
+  	<property name="name" value="procurementCardLevel3Transport.departDate" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.departureCity" parent="ProcurementCardTransactionDetail-procurementCardLevel3Transport.departureCity-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.departureCity-parentBean" parent="ProcurementCardLevel3Transport-departureCity" abstract="true">
+  	<property name="name" value="procurementCardLevel3Transport.departureCity" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.agencyCode" parent="ProcurementCardTransactionDetail-procurementCardLevel3Transport.agencyCode-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.agencyCode-parentBean" parent="ProcurementCardLevel3Transport-agencyCode" abstract="true">
+  	<property name="name" value="procurementCardLevel3Transport.agencyCode" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.agencyName" parent="ProcurementCardTransactionDetail-procurementCardLevel3Transport.agencyName-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.agencyName-parentBean" parent="ProcurementCardLevel3Transport-agencyName" abstract="true">
+  	<property name="name" value="procurementCardLevel3Transport.agencyName" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.ticketNumber" parent="ProcurementCardTransactionDetail-procurementCardLevel3Transport.ticketNumber-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.ticketNumber-parentBean" parent="ProcurementCardLevel3Transport-ticketNumber" abstract="true">
+  	<property name="name" value="procurementCardLevel3Transport.ticketNumber" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.customerCode" parent="ProcurementCardTransactionDetail-procurementCardLevel3Transport.customerCode-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.customerCode-parentBean" parent="ProcurementCardLevel3Transport-customerCode" abstract="true">
+  	<property name="name" value="procurementCardLevel3Transport.customerCode" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.issueDate" parent="ProcurementCardTransactionDetail-procurementCardLevel3Transport.issueDate-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.issueDate-parentBean" parent="ProcurementCardLevel3Transport-issueDate" abstract="true">
+  	<property name="name" value="procurementCardLevel3Transport.issueDate" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.issuingCarrier" parent="ProcurementCardTransactionDetail-procurementCardLevel3Transport.issuingCarrier-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.issuingCarrier-parentBean" parent="ProcurementCardLevel3Transport-issuingCarrier" abstract="true">
+  	<property name="name" value="procurementCardLevel3Transport.issuingCarrier" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.totalFare" parent="ProcurementCardTransactionDetail-procurementCardLevel3Transport.totalFare-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.totalFare-parentBean" parent="ProcurementCardLevel3Transport-totalFare" abstract="true">
+  	<property name="name" value="procurementCardLevel3Transport.totalFare" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.totalFees" parent="ProcurementCardTransactionDetail-procurementCardLevel3Transport.totalFees-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.totalFees-parentBean" parent="ProcurementCardLevel3Transport-totalFees" abstract="true">
+  	<property name="name" value="procurementCardLevel3Transport.totalFees" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.totalTaxes" parent="ProcurementCardTransactionDetail-procurementCardLevel3Transport.totalTaxes-parentBean" />
+  <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Transport.totalTaxes-parentBean" parent="ProcurementCardLevel3Transport-totalTaxes" abstract="true">
+  	<property name="name" value="procurementCardLevel3Transport.totalTaxes" />
+  </bean>
+  
+  <bean id="ProcurementCardTransactionDetail-transactionTaxExemptIndicator" parent="ProcurementCardTransactionDetail-transactionTaxExemptIndicator-parentBean">
+  	<property name="label" value="Tax Exempt Indicator"/>
+  </bean>
+  
+<!-- Business Object Inquiry Definition -->
+
+  <bean id="ProcurementCardTransactionDetail-inquiryDefinition" parent="ProcurementCardTransactionDetail-inquiryDefinition-parentBean">
+  	<property name="inquirySections">
+  		<list merge="true">
+  			<bean parent="InquirySectionDefinition">
+  				<property name="title" value="Procurement Card Shipping Information" />
+  				<property name="defaultOpen" value="false" />
+  				<property name="numberOfColumns" value="2" />
+  				<property name="inquiryFields">
+  					<list>
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Add.invoiceNumber" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Add.orderDate" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Add.purchaseTime" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Add.shipPostal" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Add.destinationPostal" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Add.destinationCountryCode" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Add.taxAmount" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Add.discountAmount" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Add.freightAmount" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Add.dutyAmount" />
+  					</list>
+  				</property>
+  			</bean>
+  			<bean parent="InquirySectionDefinition" p:title="Procurement Card Items">
+  				<property name="defaultOpen" value="false" />
+  				<property name="numberOfColumns" value="1" />
+  				<property name="inquiryFields">
+  					<list>
+  						<bean parent="InquiryCollectionDefinition" p:attributeName="procurementCardLevel3AddItems" p:businessObjectClass="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3AddItem">
+  							<property name="numberOfColumns" value="4" />
+  							<property name="inquiryFields">
+  								<list>
+  									<bean parent="FieldDefinition" p:attributeName="sequenceNumber" />
+  									<bean parent="FieldDefinition" p:attributeName="itemCommodityCode" />
+  									<bean parent="FieldDefinition" p:attributeName="itemProductCode" />
+  									<bean parent="FieldDefinition" p:attributeName="itemDescription" />
+  									<bean parent="FieldDefinition" p:attributeName="itemQuantity" />
+  									<bean parent="FieldDefinition" p:attributeName="itemUnitCode" />
+  									<bean parent="FieldDefinition" p:attributeName="itemAmount" />
+  									<bean parent="FieldDefinition" p:attributeName="itemTaxRate" />
+  									<bean parent="FieldDefinition" p:attributeName="itemTaxAmount" />
+  									<bean parent="FieldDefinition" p:attributeName="itemDiscountAmount" />
+  									<bean parent="FieldDefinition" p:attributeName="itemExtendedAmount" />
+  								</list>
+  							</property>
+  						</bean>
+  					</list>
+  				</property>
+  			</bean>
+  			<bean parent="InquirySectionDefinition">
+  				<property name="title" value="Procurement Card User Amounts" />
+  				<property name="defaultOpen" value="false" />
+  				<property name="numberOfColumns" value="2" />
+  				<property name="inquiryFields">
+  					<list>
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3AddUser.userEffectiveDate" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3AddUser.userAmount" />
+  					</list>
+  				</property>
+  			</bean>
+  			<bean parent="InquirySectionDefinition">
+  				<property name="title" value="Procurement Card Fuel Information" />
+  				<property name="defaultOpen" value="false" />
+  				<property name="numberOfColumns" value="2" />
+  				<property name="inquiryFields">
+  					<list>
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Fuel.oilBrandName" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Fuel.odometerReading" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Fuel.fleetId" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Fuel.messageId" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Fuel.usage" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Fuel.fuelServiceType" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Fuel.fuelProductCd" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Fuel.productTypeCd" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Fuel.fuelQuantity" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Fuel.fuelUnitOfMeasure" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Fuel.fuelUnitPrice" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Fuel.fuelSaleAmount" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Fuel.fuelDiscountAmount" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Fuel.taxAmount1" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Fuel.taxAmount2" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Fuel.totalAmount" />
+  					</list>
+  				</property>
+  			</bean>
+  			<bean parent="InquirySectionDefinition">
+  				<property name="title" value="Procurement Card Generic Information" />
+  				<property name="defaultOpen" value="false" />
+  				<property name="numberOfColumns" value="2" />
+  				<property name="inquiryFields">
+  					<list>
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Generic.genericEffectiveDate" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Generic.genericData" />
+  					</list>
+  				</property>
+  			</bean>
+  			<bean parent="InquirySectionDefinition">
+  				<property name="title" value="Procurement Card Lodging Information" />
+  				<property name="defaultOpen" value="false" />
+  				<property name="numberOfColumns" value="2" />
+  				<property name="inquiryFields">
+  					<list>
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Lodging.arriveDate" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Lodging.departureDate" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Lodging.folioNum" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Lodging.propertyPhoneNum" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Lodging.customerServiceNum" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Lodging.prePaidAmt" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Lodging.roomRate" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Lodging.roomTax" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Lodging.programCode" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Lodging.callCharges" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Lodging.foodSvcCharges" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Lodging.miniBarCharges" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Lodging.giftShopCharges" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Lodging.laundryCharges" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Lodging.healthClubCharges" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Lodging.movieCharges" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Lodging.busCtrCharges" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Lodging.parkingCharges" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Lodging.otherCode" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Lodging.otherCharges" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Lodging.adjustmentAmount" />
+  					</list>
+  				</property>
+  			</bean>
+  			<bean parent="InquirySectionDefinition" p:title="Procurement Card Non Fuel">
+  				<property name="defaultOpen" value="false" />
+  				<property name="numberOfColumns" value="1" />
+  				<property name="inquiryFields">
+  					<list>
+  						<bean parent="InquiryCollectionDefinition" p:attributeName="procurementCardLevel3NonFuels" p:businessObjectClass="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3NonFuel">
+  							<property name="numberOfColumns" value="4" />
+  							<property name="inquiryFields">
+  								<list>
+  									<bean parent="FieldDefinition" p:attributeName="sequenceNumber" />
+  									<bean parent="FieldDefinition" p:attributeName="nonFuelProductCode" />
+  									<bean parent="FieldDefinition" p:attributeName="itemDesc" />
+  									<bean parent="FieldDefinition" p:attributeName="itemQuant" />
+  									<bean parent="FieldDefinition" p:attributeName="itemUnitOfMeasure" />
+  									<bean parent="FieldDefinition" p:attributeName="taxRateApplied" />
+  									<bean parent="FieldDefinition" p:attributeName="itemTaxAmt" />
+  									<bean parent="FieldDefinition" p:attributeName="alternateTaxId" />
+  									<bean parent="FieldDefinition" p:attributeName="itemDiscountAmt" />
+  									<bean parent="FieldDefinition" p:attributeName="itemTotal" />
+  								</list>
+  							</property>
+  						</bean>
+  					</list>
+  				</property>
+  			</bean>
+  			<bean parent="InquirySectionDefinition">
+  				<property name="title" value="Procurement Card Rental Information" />
+  				<property name="defaultOpen" value="false" />
+  				<property name="numberOfColumns" value="2" />
+  				<property name="inquiryFields">
+  					<list>
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.checkOutDate" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.rentalAgreementNum" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.renterName" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.returnCity" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.returnState" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.returnCountry" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.returnDate" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.returnLocation" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.customerSvcNum" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.rentalClass" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.dailyRate" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.weeklyRate" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.ratePerMile" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.maxFreeMiles" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.totalMiles" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.oneWayCharges" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.insuranceCharges" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.regularCharges" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.towingCharges" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.extraCharges" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.lateReturnFee" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.adjustCode" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.adjustAmount" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.progCode" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.phoneCharges" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.othrCharges" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Rental.totalTaxAmount" />
+  					</list>
+  				</property>
+  			</bean>
+  			<bean parent="InquirySectionDefinition" p:title="Procurement Card Ship Services">
+  				<property name="defaultOpen" value="false" />
+  				<property name="numberOfColumns" value="1" />
+  				<property name="inquiryFields">
+  					<list>
+  						<bean parent="InquiryCollectionDefinition" p:attributeName="procurementCardLevel3ShipSvcs" p:businessObjectClass="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3ShipSvc">
+  							<property name="numberOfColumns" value="4" />
+  							<property name="inquiryFields">
+  								<list>
+  									<bean parent="FieldDefinition" p:attributeName="sequenceNumber" />
+  									<bean parent="FieldDefinition" p:attributeName="courierName" />
+  									<bean parent="FieldDefinition" p:attributeName="trackingNumber" />
+  									<bean parent="FieldDefinition" p:attributeName="serviceDescription" />
+  									<bean parent="FieldDefinition" p:attributeName="pickupDate" />
+  									<bean parent="FieldDefinition" p:attributeName="originZip" />
+  									<bean parent="FieldDefinition" p:attributeName="originCountryCd" />
+  									<bean parent="FieldDefinition" p:attributeName="destinationZip" />
+  									<bean parent="FieldDefinition" p:attributeName="destinationCountryCd" />
+  									<bean parent="FieldDefinition" p:attributeName="netAmount" />
+  									<bean parent="FieldDefinition" p:attributeName="taxAmt" />
+  									<bean parent="FieldDefinition" p:attributeName="discAmt" />
+  									<bean parent="FieldDefinition" p:attributeName="numberOfPackages" />
+  									<bean parent="FieldDefinition" p:attributeName="weight" />
+  									<bean parent="FieldDefinition" p:attributeName="unitsOfMeasure" />
+  									<bean parent="FieldDefinition" p:attributeName="senderName" />
+  									<bean parent="FieldDefinition" p:attributeName="senderAddress" />
+  									<bean parent="FieldDefinition" p:attributeName="receiverName" />
+  									<bean parent="FieldDefinition" p:attributeName="receiverAddress" />
+  									<bean parent="FieldDefinition" p:attributeName="customerRefNumber" />
+  								</list>
+  							</property>
+  						</bean>
+  					</list>
+  				</property>
+  			</bean>
+  			<bean parent="InquirySectionDefinition" p:title="Procurement Card Temporary Services">
+  				<property name="defaultOpen" value="false" />
+  				<property name="numberOfColumns" value="1" />
+  				<property name="inquiryFields">
+  					<list>
+  						<bean parent="InquiryCollectionDefinition" p:attributeName="procurementCardLevel3TempSvcs" p:businessObjectClass="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3TempSvc">
+  							<property name="numberOfColumns" value="4" />
+  							<property name="inquiryFields">
+  								<list>
+  									<bean parent="FieldDefinition" p:attributeName="sequenceNumber" />
+  									<bean parent="FieldDefinition" p:attributeName="weekEndingDate" />
+  									<bean parent="FieldDefinition" p:attributeName="serviceDesc" />
+  									<bean parent="FieldDefinition" p:attributeName="employeeName" />
+  									<bean parent="FieldDefinition" p:attributeName="regularRate" />
+  									<bean parent="FieldDefinition" p:attributeName="regularHours" />
+  									<bean parent="FieldDefinition" p:attributeName="overtimeRate" />
+  									<bean parent="FieldDefinition" p:attributeName="overtimeHours" />
+  									<bean parent="FieldDefinition" p:attributeName="miscExpenseAmt" />
+  									<bean parent="FieldDefinition" p:attributeName="subTotalAmt" />
+  									<bean parent="FieldDefinition" p:attributeName="salesTaxAmt" />
+  									<bean parent="FieldDefinition" p:attributeName="discountAmt" />
+  									<bean parent="FieldDefinition" p:attributeName="startDate" />
+  									<bean parent="FieldDefinition" p:attributeName="supervisor" />
+  									<bean parent="FieldDefinition" p:attributeName="timeSheetNumber" />
+  									<bean parent="FieldDefinition" p:attributeName="commodityCode" />
+  									<bean parent="FieldDefinition" p:attributeName="jobCode" />
+  								</list>
+  							</property>
+  						</bean>
+  					</list>
+  				</property>
+  			</bean>
+  			<bean parent="InquirySectionDefinition">
+  				<property name="title" value="Procurement Card Transport Information" />
+  				<property name="defaultOpen" value="false" />
+  				<property name="numberOfColumns" value="2" />
+  				<property name="inquiryFields">
+  					<list>
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Transport.passengerName" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Transport.departDate" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Transport.departureCity" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Transport.agencyCode" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Transport.agencyName" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Transport.ticketNumber" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Transport.customerCode" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Transport.issueDate" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Transport.issuingCarrier" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Transport.totalFare" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Transport.totalFees" />
+  						<bean parent="FieldDefinition" p:attributeName="procurementCardLevel3Transport.totalTaxes" />
+  					</list>
+  				</property>
+  			</bean>
+  			<bean parent="InquirySectionDefinition" p:title="Procurement Card Transport Leg">
+  				<property name="defaultOpen" value="false" />
+  				<property name="numberOfColumns" value="1" />
+  				<property name="inquiryFields">
+  					<list>
+  						<bean parent="InquiryCollectionDefinition" p:attributeName="procurementCardLevel3TransportLegs" p:businessObjectClass="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3TransportLeg">
+  							<property name="numberOfColumns" value="4" />
+  							<property name="inquiryFields">
+  								<list>
+  									<bean parent="FieldDefinition" p:attributeName="sequenceNumber" />
+  									<bean parent="FieldDefinition" p:attributeName="carrierCode" />
+  									<bean parent="FieldDefinition" p:attributeName="serviceClass" />
+  									<bean parent="FieldDefinition" p:attributeName="departCity" />
+  									<bean parent="FieldDefinition" p:attributeName="conjunctionTicket" />
+  									<bean parent="FieldDefinition" p:attributeName="exchangeTicket" />
+  									<bean parent="FieldDefinition" p:attributeName="destinationCity" />
+  									<bean parent="FieldDefinition" p:attributeName="fareBasisCode" />
+  									<bean parent="FieldDefinition" p:attributeName="flightNumber" />
+  									<bean parent="FieldDefinition" p:attributeName="departTime" />
+  									<bean parent="FieldDefinition" p:attributeName="departTimeSegment" />
+  									<bean parent="FieldDefinition" p:attributeName="arriveTime" />
+  									<bean parent="FieldDefinition" p:attributeName="arriveTimeSegment" />
+  									<bean parent="FieldDefinition" p:attributeName="fare" />
+  									<bean parent="FieldDefinition" p:attributeName="fees" />
+  									<bean parent="FieldDefinition" p:attributeName="taxes" />
+  									<bean parent="FieldDefinition" p:attributeName="endorsements" />
+  									<bean parent="FieldDefinition" p:attributeName="controlCode" />
+  								</list>
+  							</property>
+  						</bean>
+  					</list>
+  				</property>
+  			</bean>
+  		</list>
+  	</property>
+  </bean>
+  
+</beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardVendor.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardVendor.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+	
+	<bean id="ProcurementCardVendor-vendorStateCode" parent="ProcurementCardVendor-vendorStateCode-parentBean">	
+		<property name="maxLength" value="3"/>
+		<property name="validationPattern">
+      		<bean parent="AnyCharacterValidationPattern"/>
+    	</property>
+    	<property name="control">
+      		<bean parent="TextControlDefinition" p:size="3"/>
+    	</property>
+	</bean>
+		
+	<bean id="ProcurementCardVendor-vendorZipCode" parent="ProcurementCardVendor-vendorZipCode-parentBean">	
+		<property name="validationPattern">
+      		<bean parent="AnyCharacterValidationPattern"/>
+    	</property>
+	</bean>
+	
+</beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/ojb-fp.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/ojb-fp.xml
@@ -465,4 +465,711 @@
     </collection-descriptor>
 </class-descriptor>
 
+<class-descriptor class="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Add" table="FP_PRCRMNT_LVL3_ADD_T">
+    <field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" />
+    <field-descriptor name="financialDocumentTransactionLineNumber" column="FDOC_TRN_LN_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="invoiceNumber" column="INVOICE_NUM" jdbc-type="VARCHAR" />
+    <field-descriptor name="orderDate" column="ORDER_DT" jdbc-type="DATE" />
+    <field-descriptor name="purchaseTime" column="PURCH_TIME" jdbc-type="VARCHAR" />
+    <field-descriptor name="shipPostal" column="SHIP_POSTAL" jdbc-type="VARCHAR" />
+    <field-descriptor name="destinationPostal" column="DEST_POSTAL" jdbc-type="VARCHAR" />
+    <field-descriptor name="destinationCountryCode" column="DEST_CNTRY_CD" jdbc-type="VARCHAR" />    
+    <field-descriptor name="taxAmount" column="TAX_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="taxRate" column="TAX_RATE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="discountAmount" column="DISCOUNT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="freightAmount" column="FREIGHT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="dutyAmount" column="DUTY_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />    
+</class-descriptor>
+
+<class-descriptor class="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3AddItem" table="FP_PRCRMNT_LVL3_ADD_ITEM_T">
+    <field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" />
+    <field-descriptor name="financialDocumentTransactionLineNumber" column="FDOC_TRN_LN_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="sequenceNumber" column="SEQ_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="itemCommodityCode" column="ITEM_COMMODITY_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="itemProductCode" column="ITEM_PRODUCT_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="itemDescription" column="ITEM_DESC" jdbc-type="VARCHAR" />
+    <field-descriptor name="itemQuantity" column="ITEM_QUANTITY" jdbc-type="DECIMAL" />
+    <field-descriptor name="itemUnitCode" column="ITEM_UNIT_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="itemAmount" column="ITEM_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="itemDebitCreditCode" column="ITEM_DEBIT_CREDIT_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="itemTaxRate" column="ITEM_TAX_RATE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="itemTaxAmount" column="ITEM_TAX_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="itemDiscountAmount" column="ITEM_DISCOUNT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="itemExtendedAmount" column="ITEM_EXTENDED_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />        
+</class-descriptor>
+
+<class-descriptor class="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3AddUser" table="FP_PRCRMNT_LVL3_ADD_USER_T">
+    <field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" />
+    <field-descriptor name="financialDocumentTransactionLineNumber" column="FDOC_TRN_LN_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="userEffectiveDate" column="USER_EFF_DT" jdbc-type="DATE" />
+    <field-descriptor name="userAmount" column="USER_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />    
+</class-descriptor>
+
+<class-descriptor class="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Fuel" table="FP_PRCRMNT_LVL3_FUEL_T">
+    <field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" />
+    <field-descriptor name="financialDocumentTransactionLineNumber" column="FDOC_TRN_LN_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="oilBrandName" column="OIL_BRAND_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="odometerReading" column="ODOMETER_READING" jdbc-type="VARCHAR" />
+    <field-descriptor name="fleetId" column="FLEET_ID" jdbc-type="VARCHAR" />
+    <field-descriptor name="messageId" column="MESSAGE_ID" jdbc-type="VARCHAR" />
+    <field-descriptor name="usage" column="USAGE" jdbc-type="VARCHAR" />
+    <field-descriptor name="fuelServiceType" column="FUEL_SVC_TYP" jdbc-type="VARCHAR" />
+    <field-descriptor name="fuelProductCd" column="FUEL_PROD_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="productTypeCd" column="PROD_TYP_CD" jdbc-type="VARCHAR" />    
+    <field-descriptor name="fuelQuantity" column="FUEL_QUANTITY" jdbc-type="DECIMAL" />
+    <field-descriptor name="fuelUnitOfMeasure" column="FUEL_UNIT_OF_MSR" jdbc-type="INTEGER" />
+    <field-descriptor name="fuelUnitPrice" column="FUEL_UNIT_PRICE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="fuelSaleAmount" column="FUEL_SALE_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" /> 
+    <field-descriptor name="fuelDiscountAmount" column="FUEL_DISCOUNT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="taxAmount1" column="TAX_AMT_1" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />       
+	<field-descriptor name="taxAmount2" column="TAX_AMT_2" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />       
+    <field-descriptor name="totalAmount" column="TOTAL_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />       
+</class-descriptor>
+
+<class-descriptor class="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Generic" table="FP_PRCRMNT_LVL3_GENERIC_T">
+    <field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" />
+    <field-descriptor name="financialDocumentTransactionLineNumber" column="FDOC_TRN_LN_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="genericEffectiveDate" column="GENERIC_EFF_DT" jdbc-type="DATE" />
+    <field-descriptor name="genericData" column="GENERIC_DATA" jdbc-type="VARCHAR" />
+</class-descriptor>
+
+<class-descriptor class="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Lodging" table="FP_PRCRMNT_LVL3_LODGNG_T">
+    <field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" />
+    <field-descriptor name="financialDocumentTransactionLineNumber" column="FDOC_TRN_LN_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="arriveDate" column="ARRIVE_DT" jdbc-type="DATE" /> 
+    <field-descriptor name="departureDate" column="DEPARTURE_DT" jdbc-type="DATE" /> 
+    <field-descriptor name="folioNum" column="FOLIO_NUM" jdbc-type="VARCHAR" />
+    <field-descriptor name="propertyPhoneNum" column="PROP_PHONE_NUM" jdbc-type="VARCHAR" />
+    <field-descriptor name="customerServiceNum" column="CUST_SERVICE_NUM" jdbc-type="VARCHAR" />
+    <field-descriptor name="prePaidAmt" column="PRE_PAID_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="roomRate" column="ROOM_RATE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="roomTax" column="ROOM_TAX" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="programCode" column="PROGRAM_CD" jdbc-type="VARCHAR" />  
+    <field-descriptor name="callCharges" column="CALL_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="foodSvcCharges" column="FOOD_SVC_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="miniBarCharges" column="MINI_BAR_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" /> 
+    <field-descriptor name="giftShopCharges" column="GIFT_SHOP_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="laundryCharges" column="LAUNDRY_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="healthClubCharges" column="HEALTH_CLUB_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" /> 
+    <field-descriptor name="movieCharges" column="MOVIE_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="busCtrCharges" column="BUS_CTR_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="parkingCharges" column="PARKING_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />             
+    <field-descriptor name="otherCode" column="OTHER_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="otherCharges" column="OTHER_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="adjustmentAmount" column="ADJUSTMENT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />    
+</class-descriptor>
+
+<class-descriptor class="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3NonFuel" table="FP_PRCRMNT_LVL3_NON_FUEL_T">
+    <field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" />
+    <field-descriptor name="financialDocumentTransactionLineNumber" column="FDOC_TRN_LN_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="sequenceNumber" column="SEQ_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="nonFuelProductCode" column="NON_FUEL_PROD_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="itemDesc" column="ITEM_DESC" jdbc-type="VARCHAR" />
+    <field-descriptor name="itemQuant" column="ITEM_QUANTITY" jdbc-type="VARCHAR" />
+    <field-descriptor name="itemUnitOfMeasure" column="ITEM_UNIT_OF_MSR" jdbc-type="VARCHAR" />
+    <field-descriptor name="taxRateApplied" column="TAX_RATE_APPLIED" jdbc-type="VARCHAR" />   
+    <field-descriptor name="itemTaxAmt" column="TAX_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="alternateTaxId" column="ALTERNATE_TAX_ID" jdbc-type="VARCHAR" />   
+    <field-descriptor name="itemDiscountAmt" column="DISCOUNT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="itemTotal" column="ITEM_TOTAL" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />        
+</class-descriptor>
+
+<class-descriptor class="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Rental" table="FP_PRCRMNT_LVL3_CAR_RENT_T">
+    <field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" />
+    <field-descriptor name="financialDocumentTransactionLineNumber" column="FDOC_TRN_LN_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="checkOutDate" column="CHK_OUT_DT" jdbc-type="DATE" /> 
+    <field-descriptor name="rentalAgreementNum" column="RENTAL_AGREEMENT_NUM" jdbc-type="VARCHAR" />
+    <field-descriptor name="renterName" column="RENTER_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="returnCity" column="RETURN_CITY" jdbc-type="VARCHAR" />
+    <field-descriptor name="returnState" column="RETURN_STATE" jdbc-type="VARCHAR" />
+    <field-descriptor name="returnCountry" column="RETURN_COUNTRY" jdbc-type="VARCHAR" />
+    <field-descriptor name="returnDate" column="RETURN_DT" jdbc-type="DATE" /> 
+    <field-descriptor name="returnLocation" column="RETURN_LOC_CD" jdbc-type="VARCHAR" />   
+    <field-descriptor name="customerSvcNum" column="CUST_SERV_NUM" jdbc-type="VARCHAR" />
+    <field-descriptor name="rentalClass" column="RENTAL_CLASS" jdbc-type="VARCHAR" />
+    <field-descriptor name="dailyRate" column="DAILY_RATE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="weeklyRate" column="WEEKLY_RATE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="ratePerMile" column="RATE_PER_MILE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="maxFreeMiles" column="MAX_FREE_MILES" jdbc-type="INTEGER" />
+    <field-descriptor name="totalMiles" column="TOTAL_MILES" jdbc-type="INTEGER" />
+    <field-descriptor name="oneWayCharges" column="ONE_WAY_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="insuranceCharges" column="INSURANCE_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="regularCharges" column="REG_MILE_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" /> 
+    <field-descriptor name="towingCharges" column="TOWING_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="extraCharges" column="EXTRA_MILE_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="lateReturnFee" column="LATE_RETURN_FEE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" /> 
+    <field-descriptor name="adjustCode" column="ADJUST_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="adjustAmount" column="ADJUST_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />    
+    <field-descriptor name="progCode" column="PROG_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="phoneCharges" column="PHONE_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="othrCharges" column="OTHR_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="totalTaxAmount" column="TOTAL_TAX_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />    
+</class-descriptor>
+
+<class-descriptor class="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3ShipSvc" table="FP_PRCRMNT_LVL3_SHIP_T">
+    <field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" />
+    <field-descriptor name="financialDocumentTransactionLineNumber" column="FDOC_TRN_LN_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="sequenceNumber" column="SEQ_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="courierName" column="COURIER_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="trackingNumber" column="TRACKING_NUM" jdbc-type="VARCHAR" />
+    <field-descriptor name="serviceDescription" column="SVC_DESC" jdbc-type="VARCHAR" />
+    <field-descriptor name="pickupDate" column="PICK_UP_DT" jdbc-type="DATE" />
+    <field-descriptor name="originZip" column="ORIGIN_ZIP" jdbc-type="VARCHAR" />
+    <field-descriptor name="originCountryCd" column="ORIGIN_CNTRY_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="destinationZip" column="DEST_ZIP" jdbc-type="VARCHAR" />
+    <field-descriptor name="destinationCountryCd" column="DEST_CNTRY_CD" jdbc-type="VARCHAR" />    
+    <field-descriptor name="netAmount" column="NET_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="taxAmt" column="TAX_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="discAmt" column="DISCOUNT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />    
+	<field-descriptor name="numberOfPackages" column="NBR_OF_PKGS" jdbc-type="INTEGER" />
+    <field-descriptor name="weight" column="WEIGHT" jdbc-type="VARCHAR" />
+	<field-descriptor name="unitsOfMeasure" column="UNITS_OF_MSR" jdbc-type="VARCHAR" />
+	<field-descriptor name="senderName" column="SENDER_NM" jdbc-type="VARCHAR" />
+	<field-descriptor name="senderAddress" column="SENDER_ADDR" jdbc-type="VARCHAR" />
+	<field-descriptor name="receiverName" column="RECEIVER_NM" jdbc-type="VARCHAR" />
+	<field-descriptor name="receiverAddress" column="RECEIVER_ADDR" jdbc-type="VARCHAR" />
+	<field-descriptor name="customerRefNumber" column="CUST_REF_NUM" jdbc-type="VARCHAR" />
+</class-descriptor>
+
+<class-descriptor class="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3TempSvc" table="FP_PRCRMNT_LVL3_TEMP_T">
+    <field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" />
+    <field-descriptor name="financialDocumentTransactionLineNumber" column="FDOC_TRN_LN_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="sequenceNumber" column="SEQ_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="weekEndingDate" column="WEEK_END_DT" jdbc-type="DATE" />
+    <field-descriptor name="serviceDesc" column="SVC_DESC" jdbc-type="VARCHAR" />
+    <field-descriptor name="employeeName" column="EMPLOYEE_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="regularRate" column="REG_RATE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="regularHours" column="REG_HOURS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="overtimeRate" column="OVERTIME_RATE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="overtimeHours" column="OVERTIME_HOURS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="miscExpenseAmt" column="MISC_EXPENSE_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="subTotalAmt" column="SUB_TOTAL_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="salesTaxAmt" column="SALES_TAX_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="discountAmt" column="DISCOUNT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="startDate" column="START_DT" jdbc-type="DATE" />      
+    <field-descriptor name="supervisor" column="SUPERVISOR" jdbc-type="VARCHAR" />      
+    <field-descriptor name="timeSheetNumber" column="TIME_SHEET_NUM" jdbc-type="VARCHAR" />
+    <field-descriptor name="commodityCode" column="COMMODITY_CD" jdbc-type="VARCHAR" /> 
+    <field-descriptor name="jobCode" column="JOB_CD" jdbc-type="VARCHAR" />    
+</class-descriptor>
+
+<class-descriptor class="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Transport" table="FP_PRCRMNT_LVL3_TRNSPT_T">
+    <field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" />
+    <field-descriptor name="financialDocumentTransactionLineNumber" column="FDOC_TRN_LN_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="passengerName" column="PASSENGER_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="departDate" column="DEPART_DT" jdbc-type="DATE" />
+    <field-descriptor name="departureCity" column="DEPART_CITY" jdbc-type="VARCHAR" />
+    <field-descriptor name="agencyCode" column="AGENCY_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="agencyName" column="AGENCY_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="ticketNumber" column="TICKET_NUM" jdbc-type="BIGINT" />
+    <field-descriptor name="customerCode" column="CUSTOMER_CD" jdbc-type="VARCHAR" />  
+    <field-descriptor name="issueDate" column="ISSUE_DT" jdbc-type="DATE" />  
+    <field-descriptor name="issuingCarrier" column="ISSUING_CARRIER" jdbc-type="VARCHAR" />
+    <field-descriptor name="totalFare" column="TOTAL_FARE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="totalFees" column="TOTAL_FEES" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="totalTaxes" column="TOTAL_TAXES" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />    
+</class-descriptor>
+
+<class-descriptor class="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3TransportLeg" table="FP_PRCRMNT_LVL3_TRNSPT_LEG_T">
+    <field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" />
+    <field-descriptor name="financialDocumentTransactionLineNumber" column="FDOC_TRN_LN_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="sequenceNumber" column="SEQ_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="carrierCode" column="CARRIER_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="serviceClass" column="SERVICE_CLASS" jdbc-type="VARCHAR" />
+    <field-descriptor name="departCity" column="DEPART_CITY" jdbc-type="VARCHAR" />
+    <field-descriptor name="conjunctionTicket" column="CONJUNCTION_TICKET" jdbc-type="VARCHAR" />
+    <field-descriptor name="exchangeTicket" column="EXCHANGE_TICKET" jdbc-type="VARCHAR" />
+    <field-descriptor name="destinationCity" column="DESTINATION_CITY" jdbc-type="VARCHAR" />
+    <field-descriptor name="fareBasisCode" column="FARE_BASIS_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="flightNumber" column="FLIGHT_NUM" jdbc-type="VARCHAR" />  
+    <field-descriptor name="departTime" column="DEPART_TIME" jdbc-type="VARCHAR" />
+    <field-descriptor name="departTimeSegment" column="DEPART_TIME_SEG" jdbc-type="VARCHAR" />
+    <field-descriptor name="arriveTime" column="ARRIVE_TIME" jdbc-type="VARCHAR" />
+    <field-descriptor name="arriveTimeSegment" column="ARRIVE_TIME_SEG" jdbc-type="VARCHAR" />
+    <field-descriptor name="fare" column="FARE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="fees" column="FEES" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="taxes" column="TAXES" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />    
+	<field-descriptor name="endorsements" column="ENDORSEMENTS" jdbc-type="VARCHAR" />
+    <field-descriptor name="controlCode" column="CONTROL_CD" jdbc-type="VARCHAR" />
+</class-descriptor>
+
+<class-descriptor class="edu.arizona.kfs.fp.businessobject.ProcurementCardTranAddItem" table="FP_PRCRMNT_TRN_ADD_ITEM_T">
+	<field-descriptor name="transactionSequenceRowNumber" column="TRN_SEQ_ROW_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="sequenceRowNumber" column="SEQ_ROW_NBR" jdbc-type="INTEGER" primarykey="true" index="true" autoincrement="true" sequence-name="FP_PRCRMNT_TRN_ADD_ITEM_SEQ" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="itemCommodityCode" column="ITEM_COMMODITY_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="itemProductCode" column="ITEM_PRODUCT_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="itemDescription" column="ITEM_DESC" jdbc-type="VARCHAR" />
+    <field-descriptor name="itemQuantity" column="ITEM_QUANTITY" jdbc-type="DECIMAL" />
+    <field-descriptor name="itemUnitCode" column="ITEM_UNIT_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="itemAmount" column="ITEM_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="itemDebitCreditCode" column="ITEM_DEBIT_CREDIT_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="itemTaxRate" column="ITEM_TAX_RATE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="itemTaxAmount" column="ITEM_TAX_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="itemDiscountAmount" column="ITEM_DISCOUNT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="itemExtendedAmount" column="ITEM_EXTENDED_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />        
+</class-descriptor>
+
+<class-descriptor class="edu.arizona.kfs.fp.businessobject.ProcurementCardTranNonFuel" table="FP_PRCRMNT_TRN_NON_FUEL_T">
+    <field-descriptor name="transactionSequenceRowNumber" column="TRN_SEQ_ROW_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="sequenceRowNumber" column="SEQ_ROW_NBR" jdbc-type="INTEGER" primarykey="true" index="true" autoincrement="true" sequence-name="FP_PRCRMNT_TRN_NON_FUEL_SEQ" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="nonFuelProductCode" column="NON_FUEL_PROD_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="itemDesc" column="ITEM_DESC" jdbc-type="VARCHAR" />
+    <field-descriptor name="itemQuant" column="ITEM_QUANTITY" jdbc-type="VARCHAR" />
+    <field-descriptor name="itemUnitOfMeasure" column="ITEM_UNIT_OF_MSR" jdbc-type="VARCHAR" />
+    <field-descriptor name="taxRateApplied" column="TAX_RATE_APPLIED" jdbc-type="VARCHAR" />   
+    <field-descriptor name="itemTaxAmt" column="TAX_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="alternateTaxId" column="ALTERNATE_TAX_ID" jdbc-type="VARCHAR" />   
+    <field-descriptor name="itemDiscountAmt" column="DISCOUNT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="itemTotal" column="ITEM_TOTAL" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />        
+</class-descriptor>
+
+<class-descriptor class="edu.arizona.kfs.fp.businessobject.ProcurementCardTranShipSvc" table="FP_PRCRMNT_TRN_SHIP_T">
+    <field-descriptor name="transactionSequenceRowNumber" column="TRN_SEQ_ROW_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="sequenceRowNumber" column="SEQ_ROW_NBR" jdbc-type="INTEGER" primarykey="true" index="true" autoincrement="true" sequence-name="FP_PRCRMNT_TRN_SHIP_SEQ" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="courierName" column="COURIER_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="trackingNumber" column="TRACKING_NUM" jdbc-type="VARCHAR" />
+    <field-descriptor name="serviceDescription" column="SVC_DESC" jdbc-type="VARCHAR" />
+    <field-descriptor name="pickupDate" column="PICK_UP_DT" jdbc-type="DATE" />
+    <field-descriptor name="originZip" column="ORIGIN_ZIP" jdbc-type="VARCHAR" />
+    <field-descriptor name="originCountryCd" column="ORIGIN_CNTRY_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="destinationZip" column="DEST_ZIP" jdbc-type="VARCHAR" />
+    <field-descriptor name="destinationCountryCd" column="DEST_CNTRY_CD" jdbc-type="VARCHAR" />    
+    <field-descriptor name="netAmount" column="NET_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="taxAmt" column="TAX_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="discAmt" column="DISCOUNT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />    
+	<field-descriptor name="numberOfPackages" column="NBR_OF_PKGS" jdbc-type="INTEGER" />
+    <field-descriptor name="weight" column="WEIGHT" jdbc-type="VARCHAR" />
+	<field-descriptor name="unitsOfMeasure" column="UNITS_OF_MSR" jdbc-type="VARCHAR" />
+	<field-descriptor name="senderName" column="SENDER_NM" jdbc-type="VARCHAR" />
+	<field-descriptor name="senderAddress" column="SENDER_ADDR" jdbc-type="VARCHAR" />
+	<field-descriptor name="receiverName" column="RECEIVER_NM" jdbc-type="VARCHAR" />
+	<field-descriptor name="receiverAddress" column="RECEIVER_ADDR" jdbc-type="VARCHAR" />
+	<field-descriptor name="customerRefNumber" column="CUST_REF_NUM" jdbc-type="VARCHAR" />
+</class-descriptor>
+
+<class-descriptor class="edu.arizona.kfs.fp.businessobject.ProcurementCardTranTempSvc" table="FP_PRCRMNT_TRN_TEMP_T">
+    <field-descriptor name="transactionSequenceRowNumber" column="TRN_SEQ_ROW_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="sequenceRowNumber" column="SEQ_ROW_NBR" jdbc-type="INTEGER" primarykey="true" index="true" autoincrement="true" sequence-name="FP_PRCRMNT_TRN_TEMP_SEQ" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="weekEndingDate" column="WEEK_END_DT" jdbc-type="DATE" />
+    <field-descriptor name="serviceDesc" column="SVC_DESC" jdbc-type="VARCHAR" />
+    <field-descriptor name="employeeName" column="EMPLOYEE_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="regularRate" column="REG_RATE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="regularHours" column="REG_HOURS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="overtimeRate" column="OVERTIME_RATE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="overtimeHours" column="OVERTIME_HOURS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="miscExpenseAmt" column="MISC_EXPENSE_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="subTotalAmt" column="SUB_TOTAL_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="salesTaxAmt" column="SALES_TAX_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="discountAmt" column="DISCOUNT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="startDate" column="START_DT" jdbc-type="DATE" />      
+    <field-descriptor name="supervisor" column="SUPERVISOR" jdbc-type="VARCHAR" />      
+    <field-descriptor name="timeSheetNumber" column="TIME_SHEET_NUM" jdbc-type="VARCHAR" />
+    <field-descriptor name="commodityCode" column="COMMODITY_CD" jdbc-type="VARCHAR" /> 
+    <field-descriptor name="jobCode" column="JOB_CD" jdbc-type="VARCHAR" />    
+</class-descriptor>
+
+<class-descriptor class="edu.arizona.kfs.fp.businessobject.ProcurementCardTranTransportLeg" table="FP_PRCRMNT_TRN_TRNSPT_LEG_T">
+    <field-descriptor name="transactionSequenceRowNumber" column="TRN_SEQ_ROW_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="sequenceRowNumber" column="SEQ_ROW_NBR" jdbc-type="INTEGER" primarykey="true" index="true" autoincrement="true" sequence-name="FP_PRCRMNT_TRN_TRNSPT_LEG_SEQ" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="carrierCode" column="CARRIER_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="serviceClass" column="SERVICE_CLASS" jdbc-type="VARCHAR" />
+    <field-descriptor name="departCity" column="DEPART_CITY" jdbc-type="VARCHAR" />
+    <field-descriptor name="conjunctionTicket" column="CONJUNCTION_TICKET" jdbc-type="VARCHAR" />
+    <field-descriptor name="exchangeTicket" column="EXCHANGE_TICKET" jdbc-type="VARCHAR" />
+    <field-descriptor name="destinationCity" column="DESTINATION_CITY" jdbc-type="VARCHAR" />
+    <field-descriptor name="fareBasisCode" column="FARE_BASIS_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="flightNumber" column="FLIGHT_NUM" jdbc-type="VARCHAR" />  
+    <field-descriptor name="departTime" column="DEPART_TIME" jdbc-type="VARCHAR" />
+    <field-descriptor name="departTimeSegment" column="DEPART_TIME_SEG" jdbc-type="VARCHAR" />
+    <field-descriptor name="arriveTime" column="ARRIVE_TIME" jdbc-type="VARCHAR" />
+    <field-descriptor name="arriveTimeSegment" column="ARRIVE_TIME_SEG" jdbc-type="VARCHAR" />
+    <field-descriptor name="fare" column="FARE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="fees" column="FEES" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="taxes" column="TAXES" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />    
+	<field-descriptor name="endorsements" column="ENDORSEMENTS" jdbc-type="VARCHAR" />
+    <field-descriptor name="controlCode" column="CONTROL_CD" jdbc-type="VARCHAR" />
+</class-descriptor>
+
+<!-- UAF-2499 BO class properties transactionEditableSalesTaxAmount and transactionNoReceiptIndicator will be added in another mod -->
+<class-descriptor class="edu.arizona.kfs.fp.businessobject.ProcurementCardTransactionDetail" table="FP_PRCRMNT_TRN_DTL_T">
+    <field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" index="true" />
+    <field-descriptor name="financialDocumentTransactionLineNumber" column="FDOC_TRN_LN_NBR" jdbc-type="INTEGER" primarykey="true" index="true" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="transactionDate" column="TRANSACTION_DT" jdbc-type="DATE" />
+    <field-descriptor name="transactionReferenceNumber" column="TRN_REF_NBR" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionPostingDate" column="TRN_POST_DT" jdbc-type="DATE" />
+    <field-descriptor name="transactionOriginalCurrencyCode" column="TRN_ORIG_CRNCY_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionBillingCurrencyCode" column="TRN_BILL_CRNCY_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionOriginalCurrencyAmount" column="TRN_ORIG_CRNCY_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="transactionCurrencyExchangeRate" column="TRN_CRNCY_EXCH_RT" jdbc-type="DECIMAL" />
+    <field-descriptor name="transactionSettlementAmount" column="TRN_STLMNT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="transactionSalesTaxAmount" column="TRN_SALES_TAX_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="transactionTaxExemptIndicator" column="TRN_TAX_EXMPT_IND" jdbc-type="VARCHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
+    <field-descriptor name="transactionPurchaseIdentifierIndicator" column="TRN_PURCH_ID_IND" jdbc-type="VARCHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
+    <field-descriptor name="transactionPurchaseIdentifierDescription" column="TRN_PURCH_ID_DESC" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionUnitContactName" column="TRN_UNIT_CNTCT_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionTravelAuthorizationCode" column="TRN_TRVL_AUTH_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionPointOfSaleCode" column="TRN_PT_OF_SALE_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionCycleStartDate" column="TRN_CYCLE_STRT_DT" jdbc-type="DATE" />
+    <field-descriptor name="transactionCycleEndDate" column="TRN_CYCLE_END_DT" jdbc-type="DATE" />
+    <field-descriptor name="transactionTotalAmount" column="TRN_TOT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    
+    <reference-descriptor name="procurementCardVendor" class-ref="org.kuali.kfs.fp.businessobject.ProcurementCardVendor" auto-retrieve="true" auto-update="object" auto-delete="object" proxy="true" >
+        <foreignkey field-ref="documentNumber" />
+        <foreignkey field-ref="financialDocumentTransactionLineNumber" />
+    </reference-descriptor>
+    
+    <reference-descriptor name="procurementCardLevel3Add" class-ref="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Add" auto-retrieve="true" auto-update="object" auto-delete="object" proxy="true" >
+        <foreignkey field-ref="documentNumber" />
+        <foreignkey field-ref="financialDocumentTransactionLineNumber" />       
+    </reference-descriptor>
+    
+    <reference-descriptor name="procurementCardLevel3AddUser" class-ref="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3AddUser" auto-retrieve="true" auto-update="object" auto-delete="object" proxy="true" >
+        <foreignkey field-ref="documentNumber" />
+        <foreignkey field-ref="financialDocumentTransactionLineNumber" />         
+    </reference-descriptor>
+    
+    <reference-descriptor name="procurementCardLevel3Fuel" class-ref="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Fuel" auto-retrieve="true" auto-update="object" auto-delete="object" proxy="true" >
+        <foreignkey field-ref="documentNumber" />
+        <foreignkey field-ref="financialDocumentTransactionLineNumber" />
+    </reference-descriptor>
+    
+    <reference-descriptor name="procurementCardLevel3Generic" class-ref="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Generic" auto-retrieve="true" auto-update="object" auto-delete="object" proxy="true" >
+        <foreignkey field-ref="documentNumber" />
+        <foreignkey field-ref="financialDocumentTransactionLineNumber" />
+    </reference-descriptor>
+    
+    <reference-descriptor name="procurementCardLevel3Lodging" class-ref="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Lodging" auto-retrieve="true" auto-update="object" auto-delete="object" proxy="true" >
+        <foreignkey field-ref="documentNumber" />
+        <foreignkey field-ref="financialDocumentTransactionLineNumber" />    
+    </reference-descriptor>
+    
+    <reference-descriptor name="procurementCardLevel3Rental" class-ref="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Rental" auto-retrieve="true" auto-update="object" auto-delete="object" proxy="true" >
+        <foreignkey field-ref="documentNumber" />
+        <foreignkey field-ref="financialDocumentTransactionLineNumber" />
+    </reference-descriptor>
+    
+    <reference-descriptor name="procurementCardLevel3Transport" class-ref="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3Transport" auto-retrieve="true" auto-update="object" auto-delete="object" proxy="true" >
+        <foreignkey field-ref="documentNumber" />
+        <foreignkey field-ref="financialDocumentTransactionLineNumber" />            
+    </reference-descriptor>
+
+    <collection-descriptor name="sourceAccountingLines" proxy="true" element-class-ref="org.kuali.kfs.fp.businessobject.ProcurementCardSourceAccountingLine" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+        <orderby name="sequenceNumber" sort="ASC" />
+        <inverse-foreignkey field-ref="documentNumber" />
+        <inverse-foreignkey field-ref="financialDocumentTransactionLineNumber" />
+				<query-customizer class="org.kuali.kfs.sys.dataaccess.impl.OjbQueryCustomizer">
+						<attribute attribute-name="financialDocumentLineTypeCode" attribute-value="F" />
+				</query-customizer>
+    </collection-descriptor>
+
+    <collection-descriptor name="targetAccountingLines" proxy="true" element-class-ref="org.kuali.kfs.fp.businessobject.ProcurementCardTargetAccountingLine" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+        <orderby name="sequenceNumber" sort="ASC" />
+        <inverse-foreignkey field-ref="documentNumber" />
+        <inverse-foreignkey field-ref="financialDocumentTransactionLineNumber" />
+				<query-customizer class="org.kuali.kfs.sys.dataaccess.impl.OjbQueryCustomizer">
+						<attribute attribute-name="financialDocumentLineTypeCode" attribute-value="T" />
+				</query-customizer>
+    </collection-descriptor>
+    
+    <collection-descriptor name="procurementCardLevel3AddItems" element-class-ref="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3AddItem" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+        <orderby name="sequenceNumber" sort="ASC" />
+        <inverse-foreignkey field-ref="documentNumber" />
+        <inverse-foreignkey field-ref="financialDocumentTransactionLineNumber" />
+    </collection-descriptor>    
+    
+    <collection-descriptor name="procurementCardLevel3NonFuels" element-class-ref="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3NonFuel" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+        <orderby name="sequenceNumber" sort="ASC" />
+        <inverse-foreignkey field-ref="documentNumber" />
+        <inverse-foreignkey field-ref="financialDocumentTransactionLineNumber" />        
+    </collection-descriptor>
+    
+    <collection-descriptor name="procurementCardLevel3ShipSvcs" element-class-ref="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3ShipSvc" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+        <orderby name="sequenceNumber" sort="ASC" />
+        <inverse-foreignkey field-ref="documentNumber" />
+        <inverse-foreignkey field-ref="financialDocumentTransactionLineNumber" />
+    </collection-descriptor>
+    
+    <collection-descriptor name="procurementCardLevel3TempSvcs" element-class-ref="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3TempSvc" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+        <orderby name="sequenceNumber" sort="ASC" />
+        <inverse-foreignkey field-ref="documentNumber" />
+        <inverse-foreignkey field-ref="financialDocumentTransactionLineNumber" />        
+    </collection-descriptor>
+    
+    <collection-descriptor name="procurementCardLevel3TransportLegs" element-class-ref="edu.arizona.kfs.fp.businessobject.ProcurementCardLevel3TransportLeg" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+        <orderby name="sequenceNumber" sort="ASC" />
+        <inverse-foreignkey field-ref="documentNumber" />
+        <inverse-foreignkey field-ref="financialDocumentTransactionLineNumber" />
+    </collection-descriptor>  
+</class-descriptor>
+
+<!-- pcdo batch load table -->
+<class-descriptor class="edu.arizona.kfs.fp.businessobject.ProcurementCardTransaction" table="FP_PRCRMNT_CARD_TRN_MT">
+    <field-descriptor name="transactionSequenceRowNumber" column="TRN_SEQ_ROW_NBR" jdbc-type="INTEGER" primarykey="true" index="true" autoincrement="true" sequence-name="FP_PRCRMNT_CARD_TRN_MT_SEQ" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="transactionCreditCardNumber" column="TRN_CC_NBR" jdbc-type="VARCHAR" />
+    <field-descriptor name="financialDocumentTotalAmount" column="FDOC_TOTAL_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="transactionDebitCreditCode" column="TRN_DEBIT_CRDT_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="chartOfAccountsCode" column="FIN_COA_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="accountNumber" column="ACCOUNT_NBR" jdbc-type="VARCHAR" />
+    <field-descriptor name="subAccountNumber" column="SUB_ACCT_NBR" jdbc-type="VARCHAR" />
+    <field-descriptor name="financialObjectCode" column="FIN_OBJECT_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="financialSubObjectCode" column="FIN_SUB_OBJ_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="projectCode" column="PROJECT_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionCycleStartDate" column="TRN_CYCLE_STRT_DT" jdbc-type="DATE" />
+    <field-descriptor name="transactionCycleEndDate" column="TRN_CYCLE_END_DT" jdbc-type="DATE" />
+    <field-descriptor name="cardHolderName" column="FDOC_CARD_HLDR_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionDate" column="TRANSACTION_DT" jdbc-type="DATE" />
+    <field-descriptor name="transactionReferenceNumber" column="TRN_REF_NBR" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionMerchantCategoryCode" column="TRN_MCC_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionPostingDate" column="TRN_POST_DT" jdbc-type="DATE" />
+    <field-descriptor name="transactionOriginalCurrencyCode" column="TRN_ORIG_CRNCY_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionBillingCurrencyCode" column="TRN_BILL_CRNCY_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionOriginalCurrencyAmount" column="TRN_ORIG_CRNCY_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="transactionCurrencyExchangeRate" column="TRN_CRNCY_EXCH_RT" jdbc-type="DECIMAL" />
+    <field-descriptor name="transactionSettlementAmount" column="TRN_STLMNT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="transactionSalesTaxAmount" column="TRN_SALES_TAX_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="transactionTaxExemptIndicator" column="TRN_TAX_EXMPT_IND" jdbc-type="VARCHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
+    <field-descriptor name="transactionPurchaseIdentifierIndicator" column="TRN_PURCH_ID_IND" jdbc-type="VARCHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
+    <field-descriptor name="transactionPurchaseIdentifierDescription" column="TRN_PURCH_ID_DESC" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionUnitContactName" column="TRN_UNIT_CNTCT_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionTravelAuthorizationCode" column="TRN_TRVL_AUTH_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="transactionPointOfSaleCode" column="TRN_PT_OF_SALE_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="vendorName" column="VNDR_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="vendorLine1Address" column="VNDR_LN1_ADDR" jdbc-type="VARCHAR" />
+    <field-descriptor name="vendorLine2Address" column="VNDR_LN2_ADDR" jdbc-type="VARCHAR" />
+    <field-descriptor name="vendorCityName" column="VNDR_CTY_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="vendorStateCode" column="VNDR_ST_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="vendorZipCode" column="VNDR_ZIP_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="vendorOrderNumber" column="VNDR_ORD_NBR" jdbc-type="VARCHAR" />
+    <field-descriptor name="visaVendorIdentifier" column="VISA_VNDR_ID" jdbc-type="VARCHAR" />
+    <field-descriptor name="cardHolderAlternateName" column="FDOC_CARD_HLDR_ALTRNT_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="cardHolderLine1Address" column="FDOC_CARD_HLDR_LN1_ADDR" jdbc-type="VARCHAR" />
+    <field-descriptor name="cardHolderLine2Address" column="FDOC_CARD_HLDR_LN2_ADDR" jdbc-type="VARCHAR" />
+    <field-descriptor name="cardHolderCityName" column="FDOC_CARD_HLDR_CTY_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="cardHolderStateCode" column="FDOC_CARD_HLDR_ST_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="cardHolderZipCode" column="FDOC_CARD_HLDR_ZIP_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="cardHolderWorkPhoneNumber" column="FDOC_CARD_HLDR_WRK_PHN_NBR" jdbc-type="VARCHAR" />
+    <field-descriptor name="cardLimit" column="FDOC_CARD_LMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="cardCycleAmountLimit" column="FDOC_CARD_CYCLE_AMT_LMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="cardCycleVolumeLimit" column="FDOC_CARD_CYCLE_VOL_LMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="cardStatusCode" column="FDOC_CARD_STAT_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="cardNoteText" column="FDOC_CARD_NTE_TXT" jdbc-type="VARCHAR" />
+     <!-- Addendum Header Data -->
+    <field-descriptor name="invoiceNumber" column="INVOICE_NUM" jdbc-type="VARCHAR" />
+    <field-descriptor name="orderDate" column="ORDER_DT" jdbc-type="DATE" />
+    <field-descriptor name="purchaseTime" column="PURCH_TIME" jdbc-type="VARCHAR" />
+    <field-descriptor name="shipPostal" column="SHIP_POSTAL" jdbc-type="VARCHAR" />
+    <field-descriptor name="destinationPostal" column="DEST_POSTAL" jdbc-type="VARCHAR" />
+    <field-descriptor name="destinationCountryCode" column="DEST_CNTRY_CD" jdbc-type="VARCHAR" />    
+    <field-descriptor name="taxAmount" column="TAX_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="taxRate" column="TAX_RATE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="discountAmount" column="DISCOUNT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="freightAmount" column="FREIGHT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="dutyAmount" column="DUTY_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />    
+	<!-- User Amount Data -->
+	<field-descriptor name="userEffectiveDate" column="USER_EFF_DT" jdbc-type="DATE" />
+    <field-descriptor name="userAmount" column="USER_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />    
+	<!-- Fuel Data -->
+	<field-descriptor name="oilBrandName" column="OIL_BRAND_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="odometerReading" column="ODOMETER_READING" jdbc-type="VARCHAR" />
+    <field-descriptor name="fleetId" column="FLEET_ID" jdbc-type="VARCHAR" />
+    <field-descriptor name="messageId" column="MESSAGE_ID" jdbc-type="VARCHAR" />
+    <field-descriptor name="usage" column="USAGE" jdbc-type="VARCHAR" />
+    <field-descriptor name="fuelServiceType" column="FUEL_SVC_TYP" jdbc-type="VARCHAR" />
+    <field-descriptor name="fuelProductCd" column="FUEL_PROD_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="productTypeCd" column="PROD_TYP_CD" jdbc-type="VARCHAR" />    
+    <field-descriptor name="fuelQuantity" column="FUEL_QUANTITY" jdbc-type="DECIMAL" />
+    <field-descriptor name="fuelUnitOfMeasure" column="FUEL_UNIT_OF_MSR" jdbc-type="INTEGER" />
+    <field-descriptor name="fuelUnitPrice" column="FUEL_UNIT_PRICE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="fuelSaleAmount" column="FUEL_SALE_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" /> 
+    <field-descriptor name="fuelDiscountAmount" column="FUEL_DISCOUNT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="taxAmount1" column="TAX_AMT_1" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />       
+	<field-descriptor name="taxAmount2" column="TAX_AMT_2" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />       
+    <field-descriptor name="totalAmount" column="TOTAL_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />       
+	<!-- Generic Data -->
+	<field-descriptor name="genericEffectiveDate" column="GENERIC_EFF_DT" jdbc-type="DATE" />
+    <field-descriptor name="genericData" column="GENERIC_DATA" jdbc-type="VARCHAR" />
+	<!-- Lodging Data -->
+	<field-descriptor name="arriveDate" column="ARRIVE_DT" jdbc-type="DATE" /> 
+    <field-descriptor name="departureDate" column="DEPARTURE_DT" jdbc-type="DATE" /> 
+    <field-descriptor name="folioNum" column="FOLIO_NUM" jdbc-type="VARCHAR" />
+    <field-descriptor name="propertyPhoneNum" column="PROP_PHONE_NUM" jdbc-type="VARCHAR" />
+    <field-descriptor name="customerServiceNum" column="CUST_SERVICE_NUM" jdbc-type="VARCHAR" />
+    <field-descriptor name="prePaidAmt" column="PRE_PAID_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="roomRate" column="ROOM_RATE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="roomTax" column="ROOM_TAX" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="programCode" column="PROGRAM_CD" jdbc-type="VARCHAR" />  
+    <field-descriptor name="callCharges" column="CALL_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="foodSvcCharges" column="FOOD_SVC_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="miniBarCharges" column="MINI_BAR_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" /> 
+    <field-descriptor name="giftShopCharges" column="GIFT_SHOP_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="laundryCharges" column="LAUNDRY_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="healthClubCharges" column="HEALTH_CLUB_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" /> 
+    <field-descriptor name="movieCharges" column="MOVIE_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="busCtrCharges" column="BUS_CTR_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="parkingCharges" column="PARKING_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />             
+    <field-descriptor name="otherCode" column="OTHER_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="otherCharges" column="OTHER_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="adjustmentAmount" column="ADJUSTMENT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />    
+	<!-- Rental Data -->
+	<field-descriptor name="checkOutDate" column="CHK_OUT_DT" jdbc-type="DATE" /> 
+    <field-descriptor name="rentalAgreementNum" column="RENTAL_AGREEMENT_NUM" jdbc-type="VARCHAR" />
+    <field-descriptor name="renterName" column="RENTER_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="returnCity" column="RETURN_CITY" jdbc-type="VARCHAR" />
+    <field-descriptor name="returnState" column="RETURN_STATE" jdbc-type="VARCHAR" />
+    <field-descriptor name="returnCountry" column="RETURN_COUNTRY" jdbc-type="VARCHAR" />
+    <field-descriptor name="returnDate" column="RETURN_DT" jdbc-type="DATE" /> 
+    <field-descriptor name="returnLocation" column="RETURN_LOC_CD" jdbc-type="VARCHAR" />   
+    <field-descriptor name="customerSvcNum" column="CUST_SERV_NUM" jdbc-type="VARCHAR" />
+    <field-descriptor name="rentalClass" column="RENTAL_CLASS" jdbc-type="VARCHAR" />
+    <field-descriptor name="dailyRate" column="DAILY_RATE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="weeklyRate" column="WEEKLY_RATE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="ratePerMile" column="RATE_PER_MILE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="maxFreeMiles" column="MAX_FREE_MILES" jdbc-type="INTEGER" />
+    <field-descriptor name="totalMiles" column="TOTAL_MILES" jdbc-type="INTEGER" />
+    <field-descriptor name="oneWayCharges" column="ONE_WAY_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="insuranceCharges" column="INSURANCE_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="regularCharges" column="REG_MILE_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" /> 
+    <field-descriptor name="towingCharges" column="TOWING_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="extraCharges" column="EXTRA_MILE_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="lateReturnFee" column="LATE_RETURN_FEE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" /> 
+    <field-descriptor name="adjustCode" column="ADJUST_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="adjustAmount" column="ADJUST_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />    
+    <field-descriptor name="progCode" column="PROG_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="phoneCharges" column="PHONE_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="othrCharges" column="OTHR_CHGS" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="totalTaxAmount" column="TOTAL_TAX_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />    
+	<!-- Transport Data -->
+	<field-descriptor name="passengerName" column="PASSENGER_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="departDate" column="DEPART_DT" jdbc-type="DATE" />
+    <field-descriptor name="departureCity" column="DEPART_CITY" jdbc-type="VARCHAR" />
+    <field-descriptor name="agencyCode" column="AGENCY_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="agencyName" column="AGENCY_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="ticketNumber" column="TICKET_NUM" jdbc-type="BIGINT" />
+    <field-descriptor name="customerCode" column="CUSTOMER_CD" jdbc-type="VARCHAR" />  
+    <field-descriptor name="issueDate" column="ISSUE_DT" jdbc-type="DATE" />  
+    <field-descriptor name="issuingCarrier" column="ISSUING_CARRIER" jdbc-type="VARCHAR" />
+    <field-descriptor name="totalFare" column="TOTAL_FARE" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="totalFees" column="TOTAL_FEES" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="totalTaxes" column="TOTAL_TAXES" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />    
+	
+	<collection-descriptor name="procurementCardTranAddItems" element-class-ref="edu.arizona.kfs.fp.businessobject.ProcurementCardTranAddItem" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+        <orderby name="sequenceRowNumber" sort="ASC" />
+        <inverse-foreignkey field-ref="transactionSequenceRowNumber" />
+    </collection-descriptor>
+    
+    <collection-descriptor name="procurementCardTranNonFuels" element-class-ref="edu.arizona.kfs.fp.businessobject.ProcurementCardTranNonFuel" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+        <orderby name="sequenceRowNumber" sort="ASC" />
+        <inverse-foreignkey field-ref="transactionSequenceRowNumber" />
+    </collection-descriptor>
+    
+    <collection-descriptor name="procurementCardTranShipSvcs" element-class-ref="edu.arizona.kfs.fp.businessobject.ProcurementCardTranShipSvc" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+        <orderby name="sequenceRowNumber" sort="ASC" />
+        <inverse-foreignkey field-ref="transactionSequenceRowNumber" />
+    </collection-descriptor>
+    
+     <collection-descriptor name="procurementCardTranTempSvcs" element-class-ref="edu.arizona.kfs.fp.businessobject.ProcurementCardTranTempSvc" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+        <orderby name="sequenceRowNumber" sort="ASC" />
+        <inverse-foreignkey field-ref="transactionSequenceRowNumber" />
+    </collection-descriptor>
+   
+    <collection-descriptor name="procurementCardTranTransportLegs" element-class-ref="edu.arizona.kfs.fp.businessobject.ProcurementCardTranTransportLeg" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+        <orderby name="sequenceRowNumber" sort="ASC" />
+        <inverse-foreignkey field-ref="transactionSequenceRowNumber" />
+    </collection-descriptor>
+</class-descriptor>
+
+<class-descriptor class="org.kuali.kfs.fp.document.ProcurementCardDocument" table="FP_PRCRMNT_DOC_T">
+    <field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="nextTargetLineNumber" column="FDOC_NXT_LINE_NBR" jdbc-type="INTEGER" />
+    <field-descriptor name="autoApprovedIndicator" column="AUTO_APPROVED_IND" jdbc-type="VARCHAR" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbCharBooleanConversion" />
+
+    <reference-descriptor name="documentHeader" class-ref="org.kuali.kfs.sys.businessobject.FinancialSystemDocumentHeader" auto-retrieve="true" auto-update="object" auto-delete="object" proxy="true" >
+        <foreignkey field-ref="documentNumber" />
+    </reference-descriptor>
+
+    <reference-descriptor name="procurementCardHolder" class-ref="org.kuali.kfs.fp.businessobject.ProcurementCardHolder" auto-retrieve="true" auto-update="object" auto-delete="object" proxy="true">
+        <foreignkey field-ref="documentNumber" />
+    </reference-descriptor>
+
+    <collection-descriptor name="generalLedgerPendingEntries" proxy="true" element-class-ref="org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntry" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+        <orderby name="transactionLedgerEntrySequenceNumber" sort="ASC" />
+        <inverse-foreignkey field-ref="documentNumber" />
+    </collection-descriptor>
+
+    <collection-descriptor name="transactionEntries" proxy="true" element-class-ref="edu.arizona.kfs.fp.businessobject.ProcurementCardTransactionDetail" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+        <orderby name="transactionReferenceNumber" sort="ASC" />
+        <inverse-foreignkey field-ref="documentNumber" />
+    </collection-descriptor>
+    
+    <!-- capital asset specific collections -->
+    <collection-descriptor name="capitalAssetInformation" proxy="true" element-class-ref="org.kuali.kfs.fp.businessobject.CapitalAssetInformation" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+		<orderby name="capitalAssetLineNumber" sort="ASC" />
+        <inverse-foreignkey field-ref="documentNumber" />
+    </collection-descriptor>
+</class-descriptor>
+
+<class-descriptor class="org.kuali.kfs.fp.businessobject.ProcurementCardHolder" table="FP_PRCRMNT_CARD_HLDR_T">
+    <field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" index="true" />
+    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+    <field-descriptor name="transactionCreditCardNumber" column="TRN_CC_NBR" jdbc-type="VARCHAR" />
+    <field-descriptor name="cardHolderName" column="FDOC_CARD_HLDR_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="cardHolderAlternateName" column="FDOC_CARD_HLDR_ALTRNT_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="cardHolderLine1Address" column="FDOC_CARD_HLDR_LN1_ADDR" jdbc-type="VARCHAR" />
+    <field-descriptor name="cardHolderLine2Address" column="FDOC_CARD_HLDR_LN2_ADDR" jdbc-type="VARCHAR" />
+    <field-descriptor name="cardHolderCityName" column="FDOC_CARD_HLDR_CTY_NM" jdbc-type="VARCHAR" />
+    <field-descriptor name="cardHolderStateCode" column="FDOC_CARD_HLDR_ST_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="cardHolderZipCode" column="FDOC_CARD_HLDR_ZIP_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="cardHolderWorkPhoneNumber" column="FDOC_CARD_HLDR_WRK_PHN_NBR" jdbc-type="VARCHAR" />
+    <field-descriptor name="cardLimit" column="FDOC_CARD_LMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="cardCycleAmountLimit" column="FDOC_CARD_CYCLE_AMT_LMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="cardCycleVolumeLimit" column="FDOC_CARD_CYCLE_VOL_LMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+    <field-descriptor name="cardStatusCode" column="FDOC_CARD_STAT_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="cardNoteText" column="FDOC_CARD_NTE_TXT" jdbc-type="VARCHAR" />
+    <field-descriptor name="chartOfAccountsCode" column="FIN_COA_CD" jdbc-type="VARCHAR" />
+    <field-descriptor name="accountNumber" column="ACCOUNT_NBR" jdbc-type="VARCHAR" />
+    <field-descriptor name="subAccountNumber" column="SUB_ACCT_NBR" jdbc-type="VARCHAR" />
+    <!-- the chart, account, and subaccount fields in this table are potientally invalid and when references are setup and not found OJB seems to be settting the primitive field to blank-->
+</class-descriptor>
+
 </descriptor-repository>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/spring-fp.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/spring-fp.xml
@@ -64,5 +64,35 @@
             </list>
         </property>
     </bean>
+    
+    <bean id="procurementCardInputFileType" class="org.kuali.kfs.fp.batch.ProcurementCardInputFileType"> 
+	    <property name="directoryPath">
+	       <value>${staging.directory}/fp/procurementCard</value>
+	    </property>
+	    <property name="fileExtension">
+	       <value>xml</value>
+	    </property>
+	    <property name="digestorRulesFileName">
+	       <value>edu/arizona/kfs/fp/batch/pcdoLevel3DigesterRules.xml</value>
+	    </property>
+	    <property name="schemaLocation">
+	       <value>${externalizable.static.content.url}/xsd/fp/procurementCardLevel3.xsd</value>
+	    </property>
+	    <property name="dateTimeService">
+	       <ref bean="dateTimeService"/>
+	    </property>
+	</bean>
+	
+	<bean id="procurementCardLoadTransactionsService" class="edu.arizona.kfs.fp.batch.service.impl.ProcurementCardLoadTransactionsServiceImpl">
+		<property name="businessObjectService">
+			<ref bean="businessObjectService" />
+		</property>
+		<property name="batchInputFileService">
+			<ref bean="batchInputFileService" />
+		</property>
+		<property name="procurementCardInputFileType">
+			<ref bean="procurementCardInputFileType" />
+		</property>
+	</bean>
 
 </beans>

--- a/kfs-web/src/main/webapp/WEB-INF/tags/fp/procurementCardTransactions.tag
+++ b/kfs-web/src/main/webapp/WEB-INF/tags/fp/procurementCardTransactions.tag
@@ -68,7 +68,7 @@
           <td valign=top><bean:write name="KualiForm" property="document.transactionEntries[${ctr}].transactionDate" /></td>
           <th> <div align="right"><kul:htmlAttributeLabel attributeEntry="${transactionAttributes.transactionReferenceNumber}"/></div></th>
           <td valign=top>
-            <kul:inquiry boClassName="org.kuali.kfs.fp.businessobject.ProcurementCardTransactionDetail" 
+            <kul:inquiry boClassName="edu.arizona.kfs.fp.businessobject.ProcurementCardTransactionDetail" 
                keyValues="documentNumber=${currentTransaction.documentNumber}&financialDocumentTransactionLineNumber=${currentTransaction.financialDocumentTransactionLineNumber}" 
                render="true">
 				<bean:write name="KualiForm" property="document.transactionEntries[${ctr}].transactionReferenceNumber" />

--- a/kfs-web/src/main/webapp/static/xsd/fp/procurementCardLevel3.xsd
+++ b/kfs-web/src/main/webapp/static/xsd/fp/procurementCardLevel3.xsd
@@ -1,0 +1,542 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema elementFormDefault="qualified"
+    targetNamespace="http://www.kuali.org/kfs/fp/procurementCardLevel3"
+    xmlns:kfs="http://www.kuali.org/kfs/sys/types"
+    xmlns:dd="http://www.kuali.org/kfs/sys/ddTypes"
+    xmlns="http://www.kuali.org/kfs/fp/procurementCardLevel3" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+	<xsd:import namespace="http://www.kuali.org/kfs/sys/types" schemaLocation="http://www.kuali.org/kfs/sys/types @externalizable.static.content.url@/xsd/sys/types.xsd" />
+    <xsd:import namespace="http://www.kuali.org/kfs/sys/ddTypes" schemaLocation="http://www.kuali.org/kfs/sys/ddTypes @externalizable.static.content.url@/xsd/sys/ddTypes.xsd" />
+    
+    <xsd:element name="transactionCreditCardNumber" type="xsd:normalizedString"/>
+    <xsd:element name="financialDocumentTotalAmount" type="xsd:decimal"/>
+    <xsd:element name="transactionDebitCreditCode" type="xsd:normalizedString"/>
+    <xsd:element name="chartOfAccountsCode" type="xsd:normalizedString"/>
+    <xsd:element name="accountNumber" type="xsd:normalizedString"/>
+    <xsd:element name="subAccountNumber" type="xsd:normalizedString"/>
+    <xsd:element name="financialObjectCode" type="xsd:normalizedString"/>
+    <xsd:element name="financialSubObjectCode" type="xsd:normalizedString"/>
+    <xsd:element name="projectCode" type="xsd:normalizedString"/>
+    <xsd:element name="transactionCycleStartDate" type="xsd:date"/>
+    <xsd:element name="transactionCycleEndDate" type="xsd:date"/>
+    <xsd:element name="cardHolderName" type="xsd:normalizedString"/>
+    <xsd:element name="transactionDate" type="xsd:date"/>
+    <xsd:element name="transactionReferenceNumber" type="xsd:normalizedString"/>
+    <xsd:element name="transactionMerchantCategoryCode" type="xsd:normalizedString"/>
+    <xsd:element name="transactionPostingDate" type="xsd:date"/>
+    <xsd:element name="transactionOriginalCurrencyCode" type="xsd:normalizedString"/>
+    <xsd:element name="transactionBillingCurrencyCode" type="xsd:normalizedString"/>
+    <xsd:element name="transactionOriginalCurrencyAmount" type="xsd:decimal"/>
+    <xsd:element name="transactionCurrencyExchangeRate" type="xsd:decimal"/>
+    <xsd:element name="transactionSettlementAmount" type="xsd:decimal"/>
+    <xsd:element name="transactionSalesTaxAmount" type="xsd:decimal"/>
+    <xsd:element name="transactionTaxExemptIndicator" type="xsd:normalizedString"/>
+    <xsd:element name="transactionPurchaseIdentifierIndicator" type="xsd:normalizedString"/>
+    <xsd:element name="transactionPurchaseIdentifierDescription" type="xsd:normalizedString"/>
+    <xsd:element name="transactionUnitContactName" type="xsd:normalizedString"/>
+    <xsd:element name="transactionTravelAuthorizationCode" type="xsd:normalizedString"/>
+    <xsd:element name="transactionPointOfSaleCode" type="xsd:normalizedString"/>
+    <xsd:element name="vendorName" type="xsd:normalizedString"/>
+    <xsd:element name="vendorLine1Address" type="xsd:normalizedString"/>
+    <xsd:element name="vendorLine2Address" type="xsd:normalizedString"/>
+    <xsd:element name="vendorCityName" type="xsd:normalizedString"/>
+    <xsd:element name="vendorStateCode" type="xsd:normalizedString"/>
+    <xsd:element name="vendorZipCode" type="xsd:normalizedString"/>
+    <xsd:element name="vendorOrderNumber" type="xsd:normalizedString"/>
+    <xsd:element name="visaVendorIdentifier" type="xsd:normalizedString"/>
+    <xsd:element name="cardHolderAlternateName" type="xsd:normalizedString"/>
+    <xsd:element name="cardHolderLine1Address" type="xsd:normalizedString"/>
+    <xsd:element name="cardHolderLine2Address" type="xsd:normalizedString"/>
+    <xsd:element name="cardHolderCityName" type="xsd:normalizedString"/>
+    <xsd:element name="cardHolderStateCode" type="xsd:normalizedString"/>
+    <xsd:element name="cardHolderZipCode" type="xsd:normalizedString"/>
+    <xsd:element name="cardHolderWorkPhoneNumber" type="xsd:normalizedString"/>
+    <xsd:element name="cardLimit" type="xsd:decimal"/>
+    <xsd:element name="cardCycleAmountLimit" type="xsd:decimal"/>
+    <xsd:element name="cardCycleVolumeLimit" type="xsd:decimal"/>
+    <xsd:element name="cardStatusCode" type="xsd:normalizedString"/>
+    <xsd:element name="cardNoteText" type="xsd:normalizedString"/>
+    
+    <!-- Procurement Card Level 3 Addendum Header fields - Record/Addendum Type UA=40 -->   
+    <xsd:element name="invoiceNumber" type="xsd:normalizedString"/>
+    <xsd:element name="orderDate" type="xsd:date"/>
+    <xsd:element name="purchaseTime" type="xsd:normalizedString"/>
+    <xsd:element name="shipPostal" type="xsd:normalizedString"/>
+    <xsd:element name="destinationPostal" type="xsd:normalizedString"/>
+    <xsd:element name="destinationCountryCode" type="xsd:normalizedString"/>
+    <xsd:element name="taxAmount" type="xsd:decimal"/>
+    <xsd:element name="taxRate" type="xsd:decimal"/>
+    <xsd:element name="discountAmount" type="xsd:decimal"/>
+    <xsd:element name="freightAmount" type="xsd:decimal"/>
+    <xsd:element name="dutyAmount" type="xsd:decimal"/>
+    
+    <!-- Procurement Card Level 3 Addendum Item fields - Record/Addendum Type UA=41,CSU=1 -->   
+    <xsd:element name="itemCommodityCode" type="xsd:normalizedString"/>
+    <xsd:element name="itemProductCode" type="xsd:normalizedString"/>
+    <xsd:element name="itemDescription" type="xsd:normalizedString"/>
+    <xsd:element name="itemQuantity" type="xsd:decimal"/>
+    <xsd:element name="itemUnitCode" type="xsd:normalizedString"/>
+    <xsd:element name="itemAmount" type="xsd:decimal"/>
+    <xsd:element name="itemDebitCreditCode" type="xsd:normalizedString"/>
+    <xsd:element name="itemTaxRate" type="xsd:decimal"/>
+    <xsd:element name="itemTaxAmount" type="xsd:decimal"/>
+    <xsd:element name="itemDiscountAmount" type="xsd:decimal"/>
+    <xsd:element name="itemExtendedAmount" type="xsd:decimal"/>
+    
+    <!-- Procurement Card Level 3 User Amounts fields - Record/Addendum Type CSU=11 -->   
+    <xsd:element name="userEffectiveDate" type="xsd:date"/>
+    <xsd:element name="userAmount" type="xsd:decimal"/>
+    
+    <!-- Procurement Card Level 3 Fuel fields - Record Type UA=70 -->   
+    <xsd:element name="oilBrandName" type="xsd:normalizedString"/>
+    <xsd:element name="odometerReading" type="xsd:normalizedString"/>
+    <xsd:element name="fleetId" type="xsd:normalizedString"/>
+    <xsd:element name="messageId" type="xsd:normalizedString"/>
+    <xsd:element name="usage" type="xsd:normalizedString"/>
+    <xsd:element name="fuelServiceType" type="xsd:normalizedString"/>
+    <xsd:element name="fuelProductCd" type="xsd:normalizedString"/>
+    <xsd:element name="productTypeCd" type="xsd:normalizedString"/>
+    <xsd:element name="fuelQuantity" type="xsd:decimal"/>
+    <xsd:element name="fuelUnitOfMeasure" type="xsd:integer"/>
+    <xsd:element name="fuelUnitPrice" type="xsd:decimal"/>
+    <xsd:element name="fuelSaleAmount" type="xsd:decimal"/>
+    <xsd:element name="fuelDiscountAmount" type="xsd:decimal"/>
+    <xsd:element name="taxAmount1" type="xsd:decimal"/>
+    <xsd:element name="taxAmount2" type="xsd:decimal"/>
+    <xsd:element name="totalAmount" type="xsd:decimal"/>
+    
+    <!-- Procurement Card Level 3 Generic fields - Record/Addendum Type CSU=5  --> 
+    <xsd:element name="genericEffectiveDate" type="xsd:date"/>
+    <xsd:element name="genericData" type="xsd:normalizedString"/>
+    
+    <!-- Procurement Card Level 3 Lodging fields - Record/Addendum Type UA=90,CSU=3  --> 
+    <xsd:element name="arriveDate" type="xsd:date"/>
+    <xsd:element name="departureDate" type="xsd:date"/>
+    <xsd:element name="folioNum" type="xsd:normalizedString"/>
+    <xsd:element name="propertyPhoneNum" type="xsd:normalizedString"/>
+    <xsd:element name="customerServiceNum" type="xsd:normalizedString"/>
+    <xsd:element name="prePaidAmt" type="xsd:decimal"/>
+    <xsd:element name="roomRate" type="xsd:decimal"/>
+    <xsd:element name="roomTax" type="xsd:decimal"/>
+    <xsd:element name="programCode" type="xsd:normalizedString"/>
+    <xsd:element name="callCharges" type="xsd:decimal"/>
+    <xsd:element name="foodSvcCharges" type="xsd:decimal"/>
+    <xsd:element name="miniBarCharges" type="xsd:decimal"/>
+    <xsd:element name="giftShopCharges" type="xsd:decimal"/>
+    <xsd:element name="laundryCharges" type="xsd:decimal"/>
+    <xsd:element name="healthClubCharges" type="xsd:decimal"/>
+    <xsd:element name="movieCharges" type="xsd:decimal"/>
+    <xsd:element name="busCtrCharges" type="xsd:decimal"/>
+    <xsd:element name="parkingCharges" type="xsd:decimal"/>
+    <xsd:element name="otherCode" type="xsd:normalizedString"/>
+    <xsd:element name="otherCharges" type="xsd:decimal"/>
+    <xsd:element name="adjustmentAmount" type="xsd:decimal"/>
+    
+     <!-- Procurement Card Level 3 Non Fuel fields - Record/Addendum Type UA=71  -->     
+    <xsd:element name="nonFuelProductCode" type="xsd:normalizedString"/>
+    <xsd:element name="itemDesc" type="xsd:normalizedString"/>
+    <xsd:element name="itemQuant" type="xsd:normalizedString"/>
+    <xsd:element name="itemUnitOfMeasure" type="xsd:normalizedString"/>
+    <xsd:element name="taxRateApplied" type="xsd:normalizedString"/>
+    <xsd:element name="itemTaxAmt" type="xsd:decimal"/>
+    <xsd:element name="alternateTaxId" type="xsd:normalizedString"/>
+    <xsd:element name="itemDiscountAmt" type="xsd:decimal"/>
+    <xsd:element name="itemTotal" type="xsd:decimal"/>   
+    
+    <!-- Procurement Card Level 3 Rental fields - Record/Addendum Type UA=100,CSU=4  --> 
+    <xsd:element name="checkOutDate" type="xsd:date"/>
+    <xsd:element name="rentalAgreementNum" type="xsd:normalizedString"/>
+    <xsd:element name="renterName" type="xsd:normalizedString"/>
+    <xsd:element name="returnCity" type="xsd:normalizedString"/>
+    <xsd:element name="returnState" type="xsd:normalizedString"/>
+    <xsd:element name="returnCountry" type="xsd:normalizedString"/>
+    <xsd:element name="returnDate" type="xsd:date"/>
+    <xsd:element name="returnLocation" type="xsd:normalizedString"/>
+    <xsd:element name="customerSvcNum" type="xsd:normalizedString"/>
+    <xsd:element name="rentalClass" type="xsd:normalizedString"/>
+    <xsd:element name="dailyRate" type="xsd:decimal"/>
+    <xsd:element name="weeklyRate" type="xsd:decimal"/>
+    <xsd:element name="ratePerMile" type="xsd:decimal"/>
+    <xsd:element name="maxFreeMiles" type="xsd:normalizedString"/>
+    <xsd:element name="totalMiles" type="xsd:normalizedString"/>
+    <xsd:element name="oneWayCharges" type="xsd:decimal"/>
+    <xsd:element name="insuranceCharges" type="xsd:decimal"/>
+    <xsd:element name="regularCharges" type="xsd:decimal"/>
+    <xsd:element name="towingCharges" type="xsd:decimal"/>
+    <xsd:element name="extraCharges" type="xsd:decimal"/>
+    <xsd:element name="lateReturnFee" type="xsd:decimal"/>
+    <xsd:element name="adjustCode" type="xsd:normalizedString"/>
+    <xsd:element name="adjustAmount" type="xsd:decimal"/>
+    <xsd:element name="progCode" type="xsd:normalizedString"/>
+    <xsd:element name="phoneCharges" type="xsd:decimal"/>
+    <xsd:element name="othrCharges" type="xsd:decimal"/>
+    <xsd:element name="totalTaxAmount" type="xsd:decimal"/>
+    
+     <!-- Procurement Card Level 3 Ship Services fields - Record/Addendum Type UA=60 -->   
+    <xsd:element name="courierName" type="xsd:normalizedString"/>
+    <xsd:element name="trackingNumber" type="xsd:normalizedString"/>
+    <xsd:element name="serviceDescription" type="xsd:normalizedString"/>
+    <xsd:element name="pickupDate" type="xsd:date"/>
+    <xsd:element name="originZip" type="xsd:normalizedString"/>
+    <xsd:element name="originCountryCd" type="xsd:normalizedString"/>
+    <xsd:element name="destinationZip" type="xsd:normalizedString"/>
+    <xsd:element name="destinationCountryCd" type="xsd:normalizedString"/>
+    <xsd:element name="netAmount" type="xsd:decimal"/>
+    <xsd:element name="taxAmt" type="xsd:decimal"/>
+    <xsd:element name="discAmt" type="xsd:decimal"/>
+    <xsd:element name="numberOfPackages" type="xsd:integer"/>
+    <xsd:element name="weight" type="xsd:normalizedString"/>  
+    <xsd:element name="unitsOfMeasure" type="xsd:normalizedString"/>
+    <xsd:element name="senderName" type="xsd:normalizedString"/>
+    <xsd:element name="senderAddress" type="xsd:normalizedString"/>
+    <xsd:element name="receiverName" type="xsd:normalizedString"/>
+    <xsd:element name="receiverAddress" type="xsd:normalizedString"/>
+    <xsd:element name="customerRefNumber" type="xsd:normalizedString"/> 
+    
+     <!-- Procurement Card Level 3 Temp Services fields - Record/Addendum Type UA=50 --> 
+    <xsd:element name="weekEndingDate" type="xsd:date"/>    
+    <xsd:element name="serviceDesc" type="xsd:normalizedString"/>    
+    <xsd:element name="employeeName" type="xsd:normalizedString"/>    
+    <xsd:element name="regularRate" type="xsd:decimal"/>
+    <xsd:element name="regularHours" type="xsd:decimal"/>
+    <xsd:element name="overtimeRate" type="xsd:decimal"/>
+    <xsd:element name="overtimeHours" type="xsd:decimal"/>
+    <xsd:element name="miscExpenseAmt" type="xsd:decimal"/>
+    <xsd:element name="subTotalAmt" type="xsd:decimal"/>
+    <xsd:element name="salesTaxAmt" type="xsd:decimal"/>
+    <xsd:element name="discountAmt" type="xsd:decimal"/>
+    <xsd:element name="startDate" type="xsd:date"/>    
+    <xsd:element name="supervisor" type="xsd:normalizedString"/>
+    <xsd:element name="timeSheetNumber" type="xsd:normalizedString"/>
+    <xsd:element name="commodityCode" type="xsd:normalizedString"/>
+    <xsd:element name="jobCode" type="xsd:normalizedString"/>
+    
+    <!-- Procurement Card Level 3 Transport fields - Record/Addendum Type UA=80,CSU=2  --> 
+    <xsd:element name="passengerName" type="xsd:normalizedString"/>
+    <xsd:element name="departDate" type="xsd:date"/>
+    <xsd:element name="departureCity" type="xsd:normalizedString"/>
+    <xsd:element name="agencyCode" type="xsd:normalizedString"/>
+    <xsd:element name="agencyName" type="xsd:normalizedString"/>    
+    <xsd:element name="ticketNumber" type="xsd:normalizedString"/>
+    <xsd:element name="customerCode" type="xsd:normalizedString"/>
+    <xsd:element name="issueDate" type="xsd:date"/>
+    <xsd:element name="issuingCarrier" type="xsd:normalizedString"/>
+    <xsd:element name="totalFare" type="xsd:decimal"/>
+    <xsd:element name="totalFees" type="xsd:decimal"/>
+    <xsd:element name="totalTaxes" type="xsd:decimal"/>
+    
+     <!-- Procurement Card Level 3 Transport Leg fields - Record/Addendum Type UA=81,CSU=21 -->   
+    <xsd:element name="carrierCode" type="xsd:normalizedString"/>
+    <xsd:element name="serviceClass" type="xsd:normalizedString"/>
+    <xsd:element name="departCity" type="xsd:normalizedString"/>
+    <xsd:element name="conjunctionTicket" type="xsd:normalizedString"/>
+    <xsd:element name="exchangeTicket" type="xsd:normalizedString"/>
+    <xsd:element name="destinationCity" type="xsd:normalizedString"/>
+    <xsd:element name="fareBasisCode" type="xsd:normalizedString"/>
+    <xsd:element name="flightNumber" type="xsd:normalizedString"/>
+    <xsd:element name="departTime" type="xsd:normalizedString"/>
+    <xsd:element name="departTimeSegment" type="xsd:normalizedString"/>
+    <xsd:element name="arriveTime" type="xsd:normalizedString"/>
+    <xsd:element name="arriveTimeSegment" type="xsd:normalizedString"/>
+    <xsd:element name="fare" type="xsd:decimal"/>
+    <xsd:element name="fees" type="xsd:decimal"/>
+    <xsd:element name="taxes" type="xsd:decimal"/>
+    <xsd:element name="endorsements" type="xsd:normalizedString"/>
+    <xsd:element name="controlCode" type="xsd:normalizedString"/>
+    
+    <!-- definition of complex type elements -->
+    
+    <xsd:element name="transactions">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element maxOccurs="unbounded" minOccurs="1" ref="transaction"/>
+            </xsd:sequence>
+        </xsd:complexType>
+    </xsd:element>
+    
+    <xsd:element name="addItem">
+	    <xsd:complexType>
+	   		<xsd:sequence>
+	   			<xsd:element maxOccurs="1" minOccurs="0" ref="itemCommodityCode" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="itemProductCode" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="itemDescription" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="itemQuantity" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="itemUnitCode" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="itemAmount" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="itemDebitCreditCode" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="itemTaxRate" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="itemTaxAmount" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="itemDiscountAmount" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="itemExtendedAmount" />
+	    	</xsd:sequence>
+	    </xsd:complexType>
+    </xsd:element>
+    
+    <xsd:element name="nonFuel">
+	    <xsd:complexType>
+	   		<xsd:sequence>
+	   			<xsd:element maxOccurs="1" minOccurs="0" ref="nonFuelProductCode" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="itemDesc" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="itemQuant" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="itemUnitOfMeasure" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="taxRateApplied" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="itemTaxAmt" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="alternateTaxId" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="itemDiscountAmt" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="itemTotal" />				
+	    	</xsd:sequence>
+	    </xsd:complexType>
+    </xsd:element> 
+    
+    <xsd:element name="shipService">
+	    <xsd:complexType>
+	   		<xsd:sequence>
+	   			<xsd:element maxOccurs="1" minOccurs="0" ref="courierName" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="trackingNumber" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="serviceDescription" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="pickupDate" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="originZip" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="originCountryCd" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="destinationZip" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="destinationCountryCd" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="netAmount" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="taxAmt" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="discAmt" />				
+				<xsd:element maxOccurs="1" minOccurs="0" ref="numberOfPackages" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="weight" />				
+				<xsd:element maxOccurs="1" minOccurs="0" ref="unitsOfMeasure" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="senderName" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="senderAddress" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="receiverName" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="receiverAddress" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="customerRefNumber" />
+	    	</xsd:sequence>
+	    </xsd:complexType>
+    </xsd:element>  
+    
+     <xsd:element name="tempService">
+	    <xsd:complexType>
+	   		<xsd:sequence>
+	   			<xsd:element maxOccurs="1" minOccurs="0" ref="weekEndingDate" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="serviceDesc" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="employeeName" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="regularRate" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="regularHours" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="overtimeRate" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="overtimeHours" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="miscExpenseAmt" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="subTotalAmt" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="salesTaxAmt" />				
+				<xsd:element maxOccurs="1" minOccurs="0" ref="discountAmt" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="startDate" />				
+				<xsd:element maxOccurs="1" minOccurs="0" ref="supervisor" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="timeSheetNumber" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="commodityCode" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="jobCode" />
+	    	</xsd:sequence>
+	    </xsd:complexType>
+    </xsd:element>        
+         
+    <xsd:element name="transportLeg">
+	    <xsd:complexType>
+	   		<xsd:sequence>
+	   			<xsd:element maxOccurs="1" minOccurs="0" ref="carrierCode" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="serviceClass" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="departCity" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="conjunctionTicket" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="exchangeTicket" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="destinationCity" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="fareBasisCode" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="flightNumber" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="departTime" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="departTimeSegment" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="arriveTime" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="arriveTimeSegment" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="fare" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="fees" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="taxes" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="endorsements" />
+				<xsd:element maxOccurs="1" minOccurs="0" ref="controlCode" />
+	    	</xsd:sequence>
+	    </xsd:complexType>
+    </xsd:element>      
+         
+    <xsd:element name="transaction">
+        <xsd:complexType>
+            <xsd:sequence>
+                <!-- Procurement Card basic transaction fields - Record/Addendum Type UA=30,CSU=0 -->  
+               <xsd:element maxOccurs="1" minOccurs="1" ref="transactionCreditCardNumber" />
+               <xsd:element maxOccurs="1" minOccurs="1" ref="financialDocumentTotalAmount" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="transactionDebitCreditCode" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="chartOfAccountsCode" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="accountNumber" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="subAccountNumber" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="financialObjectCode" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="financialSubObjectCode" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="projectCode" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="transactionCycleStartDate" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="transactionCycleEndDate" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="cardHolderName" />
+               <xsd:element maxOccurs="1" minOccurs="1" ref="transactionDate" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="transactionReferenceNumber" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="transactionMerchantCategoryCode" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="transactionPostingDate" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="transactionOriginalCurrencyCode" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="transactionBillingCurrencyCode" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="transactionOriginalCurrencyAmount" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="transactionCurrencyExchangeRate" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="transactionSettlementAmount" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="transactionSalesTaxAmount" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="transactionTaxExemptIndicator" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="transactionPurchaseIdentifierIndicator" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="transactionPurchaseIdentifierDescription" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="transactionUnitContactName" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="transactionTravelAuthorizationCode" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="transactionPointOfSaleCode" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="vendorName" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="vendorLine1Address" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="vendorLine2Address" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="vendorCityName" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="vendorStateCode" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="vendorZipCode" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="vendorOrderNumber" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="visaVendorIdentifier" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="cardHolderAlternateName" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="cardHolderLine1Address" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="cardHolderLine2Address" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="cardHolderCityName" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="cardHolderStateCode" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="cardHolderZipCode" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="cardHolderWorkPhoneNumber" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="cardLimit" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="cardCycleAmountLimit" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="cardCycleVolumeLimit" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="cardStatusCode" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="cardNoteText" />
+               
+                <!-- Procurement Card Level 3 Addendum Header fields - Record/Addendum Type UA=40 -->   
+               <xsd:element maxOccurs="1" minOccurs="0" ref="invoiceNumber" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="orderDate" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="purchaseTime" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="shipPostal" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="destinationPostal" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="destinationCountryCode" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="taxAmount" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="taxRate" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="discountAmount" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="freightAmount" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="dutyAmount" />
+               
+                <!-- Procurement Card Level 3 Addendum Items - Record/Addendum Type UA=41,CSU=1 -->   
+               <xsd:element maxOccurs="unbounded" minOccurs="0" ref="addItem"/>      		   
+               
+                <!-- Procurement Card Level 3 User Amounts fields - Record/Addendum Type CSU=11 -->   
+               <xsd:element maxOccurs="1" minOccurs="0" ref="userEffectiveDate" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="userAmount" />
+               
+               <!-- Procurement Card Level 3 Fuel fields - Record Type UA=70 -->                  
+               <xsd:element maxOccurs="1" minOccurs="0" ref="oilBrandName" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="odometerReading" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="fleetId" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="messageId" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="usage" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="fuelServiceType" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="fuelProductCd" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="productTypeCd" />             
+   			   <xsd:element maxOccurs="1" minOccurs="0" ref="fuelQuantity" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="fuelUnitOfMeasure" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="fuelUnitPrice" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="fuelSaleAmount" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="fuelDiscountAmount" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="taxAmount1" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="taxAmount2" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="totalAmount" />
+     		   
+     		   <!-- Procurement Card Level 3 Generic fields - Record/Addendum Type CSU=5  -->     
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="genericEffectiveDate" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="genericData" />
+     		   
+     		    <!-- Procurement Card Level 3 Lodging fields - Record/Addendum Type UA=90,CSU=3  --> 
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="arriveDate" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="departureDate" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="folioNum" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="propertyPhoneNum" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="customerServiceNum" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="prePaidAmt" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="roomRate" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="roomTax" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="programCode" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="callCharges" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="foodSvcCharges" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="miniBarCharges" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="giftShopCharges" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="laundryCharges" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="healthClubCharges" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="movieCharges" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="busCtrCharges" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="parkingCharges" />
+               <xsd:element maxOccurs="1" minOccurs="0" ref="otherCode" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="otherCharges" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="adjustmentAmount" />
+     		   
+     		    <!-- Procurement Card Level 3 Non Fuel Items - Record/Addendum Type UA=71  -->   
+               <xsd:element maxOccurs="unbounded" minOccurs="0" ref="nonFuel"/>      		   
+                    		   
+     		   <!-- Procurement Card Level 3 Rental fields - Record/Addendum Type UA=100,CSU=4  -->   
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="checkOutDate" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="rentalAgreementNum" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="renterName" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="returnCity" /> 
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="returnState" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="returnCountry" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="returnDate" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="returnLocation" />  
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="customerSvcNum" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="rentalClass" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="dailyRate" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="weeklyRate" /> 
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="ratePerMile" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="maxFreeMiles" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="totalMiles" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="oneWayCharges" /> 
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="insuranceCharges" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="regularCharges" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="towingCharges" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="extraCharges" />  
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="lateReturnFee" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="adjustCode" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="adjustAmount" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="progCode" />      
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="phoneCharges" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="othrCharges" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="totalTaxAmount" />
+     		   
+     		    <!-- Procurement Card Level 3 Ship Service Items - Record/Addendum Type UA=60 --> 
+			   <xsd:element maxOccurs="unbounded" minOccurs="0" ref="shipService"/>     
+     		   
+     		   <!-- Procurement Card Level 3 Temp Service Items - Record/Addendum Type UA=50 --> 
+			   <xsd:element maxOccurs="unbounded" minOccurs="0" ref="tempService"/>     
+     		   
+     		    <!-- Procurement Card Level 3 Transport fields - Record/Addendum Type UA=80,CSU=2 -->      		   
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="passengerName" /> 
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="departDate" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="departureCity" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="agencyCode" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="agencyName" />  
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="ticketNumber" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="customerCode" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="issueDate" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="issuingCarrier" />      
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="totalFare" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="totalFees" />
+     		   <xsd:element maxOccurs="1" minOccurs="0" ref="totalTaxes" />    		        		   
+
+			    <!-- Procurement Card Level 3 Transport Legs - Record/Addendum Type UA=81,CSU=21 --> 
+			   <xsd:element maxOccurs="unbounded" minOccurs="0" ref="transportLeg"/>      		   
+    		   	
+             </xsd:sequence>  
+        </xsd:complexType>
+    </xsd:element>    
+
+</xsd:schema>
+


### PR DESCRIPTION
Added Level 3 tables to ojb-fp.xml, added one bean to spring-fp.xml and ported over the Procurement Card Level xsd and digester rules files form KFS 3.0.  Created Business Objects and data dictionary files for the Level 3 Data.  Added the the inquiry to the Procurement Card Transaction Details. Created ProcurementCardTransaction.xml to hold the new Level 3 Data fields that were added to the BO.  Updated the JSP inquiry bo class name to point to the new edu/arizona verion of ProcurementCardTransactionDetail.java  Changes to service impl class and Spring for handling Level 3 data in the first step of the batch job, the load. Plus some odds-and-ends level 3 changes previously overlooked.  

This was worked on by Leaha and Julie.
