### PR TITLE
UAF-2877 / UAF-3260 BUG - Batch Format Checks/ACH Will Not Complete

### DIFF
--- a/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/changesets/db.changelog-UAF-2877.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/changesets/db.changelog-UAF-2877.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="UAF-2877" author="Adam Kost">
+        <preConditions onError="MARK_RAN" onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM KRCR_PARM_T
+                    WHERE NMSPC_CD='KFS-PDP'
+                        AND CMPNT_CD='Batch'
+                        AND PARM_NM='FROM_EMAIL_ADDRESS'
+                        AND VAL='kfsbsateam@list.arizona.edu'
+            </sqlCheck>
+        </preConditions>
+        <comment>
+            UAF-2877 Batch Format Checks/ACH Will Not Complete
+        </comment>
+        <update tableName="KRCR_PARM_T">
+            <column name="VAL" value="kfsbsateam@list.arizona.edu" />
+            <where>NMSPC_CD='KFS-PDP' AND CMPNT_CD='Batch' AND PARM_NM='FROM_EMAIL_ADDRESS'</where>
+        </update>
+        <rollback>
+            <update tableName="KRCR_PARM_T">
+                <column name="VAL" value="" />
+                <where>NMSPC_CD='KFS-PDP' AND CMPNT_CD='Batch' AND PARM_NM='FROM_EMAIL_ADDRESS'</where>
+            </update>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/db.changelog-master.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/db.changelog-master.xml
@@ -22,4 +22,5 @@
   <include file="changesets/db.changelog-UAF-2450.xml" />
   <include file="changesets/db.changelog-UAF-1790.xml" />
   <include file="changesets/db.changelog-UAF-2791.xml" />
+  <include file="changesets/db.changelog-UAF-2877.xml" />
 </databaseChangeLog>

--- a/kfs-core/src/main/resources/institutional-config.properties
+++ b/kfs-core/src/main/resources/institutional-config.properties
@@ -1,3 +1,10 @@
+#SMTP Mail server settings
+mail.transport.protocol=smtp
+mail.smtp.host=smtpgate.email.arizona.edu
+mail.smtp.port=587
+mail.smtp.starttls.enable=true
+mail.smtp.auth=true
+
 batchinvoker.directory.towatch=${work.directory}/control
 batchinvoker.directory.history=${work.directory}/control/history
 


### PR DESCRIPTION
This problem is being caused by 3 issues:
1) The SMTP settings are not configured to allow KFS to send email notifications,
2) The From address for email notifications is null,
3) The email address in the user ID's profile is null.

This pull request resolves the first 2 issues. The final cause for this can only be resolved by UA.
Project UAF Liquibase - Test Changelog 34 shows a successful run of the Liquibase that is part of this pull request.

Note: There are 2 additional properties (mail.smtp.username and mail.smtp.password) that must be configured in the uaf-security-config.properties or uaf-security-config.properties.erb, depending on the environment, and are not set here due to security issues. This will be handled as a separate ticket per Heather Lo in the Jira ticket for this branch.
