### PR TITLE
UAF-46 / UAF-2968 / UAF-3476 MOD-PA1018-01 Procurement Card Reconciliation Step 5

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/web/struts/ProcurementCardForm.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/web/struts/ProcurementCardForm.java
@@ -1,5 +1,8 @@
 package edu.arizona.kfs.fp.document.web.struts;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.kuali.kfs.fp.document.ProcurementCardDocument;
 import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.rice.coreservice.framework.parameter.ParameterService;
@@ -24,5 +27,19 @@ public class ProcurementCardForm extends org.kuali.kfs.fp.document.web.struts.Pr
      */
     public String getDocuwareTableParam() {
         return SpringContext.getBean(ParameterService.class).getParameterValueAsString(ProcurementCardDocument.class, KFSConstants.DOCUWARE_TABLE_PARAMETER);
+    }
+
+    /**
+     * @return an array, parallel to the ProcurementCardDocument#getTransactionEntries, which holds whether the
+     *         current user can see the credit card number or not.
+     *         In this case, the credit card number should be masked at all times.
+     */
+    @Override
+    public List<Boolean> getTransactionCreditCardNumbersViewStatus() {
+        if (this.transactionCreditCardNumbersViewStatus == null) {
+            this.transactionCreditCardNumbersViewStatus = new ArrayList<Boolean>();
+            this.transactionCreditCardNumbersViewStatus.add(Boolean.FALSE);
+        }
+        return transactionCreditCardNumbersViewStatus;
     }
 }

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardHolder.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardHolder.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xmlns:dd="http://rice.kuali.org/dd"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd http://rice.kuali.org/dd http://rice.kuali.org/dd/dd.xsd">
+
+    <bean id="ProcurementCardHolder-cardHolderName" parent="ProcurementCardHolder-cardHolderName-parentBean">
+        <property name="label" value="Cardholder Name" />
+    </bean>
+
+    <bean id="ProcurementCardHolder-cardHolderAlternateName" parent="ProcurementCardHolder-cardHolderAlternateName-parentBean">
+        <property name="label" value="Cardholder Alternate Name" />
+    </bean>
+
+    <bean id="ProcurementCardHolder-cardHolderLine1Address" parent="ProcurementCardHolder-cardHolderLine1Address-parentBean">
+        <property name="label" value="Cardholder Line1 Address" />
+    </bean>
+
+    <bean id="ProcurementCardHolder-cardHolderLine2Address" parent="ProcurementCardHolder-cardHolderLine2Address-parentBean">
+        <property name="label" value="Cardholder Line2 Address" />
+    </bean>
+
+    <bean id="ProcurementCardHolder-cardHolderCityName" parent="ProcurementCardHolder-cardHolderCityName-parentBean" >
+        <property name="label" value="Cardholder City Name" />
+    </bean>
+
+    <bean id="ProcurementCardHolder-cardHolderStateCode" parent="ProcurementCardHolder-cardHolderStateCode-parentBean">
+        <property name="label" value="Cardholder State Code" />
+    </bean>
+
+    <bean id="ProcurementCardHolder-cardHolderZipCode" parent="ProcurementCardHolder-cardHolderZipCode-parentBean">
+        <property name="label" value="Cardholder Postal (ZIP) Code" />
+    </bean>
+
+    <bean id="ProcurementCardHolder-cardHolderWorkPhoneNumber" parent="ProcurementCardHolder-cardHolderWorkPhoneNumber-parentBean">
+        <property name="label" value="Cardholder Work Phone Number" />
+    </bean>
+
+    <bean id="ProcurementCardHolder-cardNoteText" parent="ProcurementCardHolder-cardNoteText-parentBean" >
+        <property name="label" value="Original Vendor Name" />
+    </bean>
+
+    <bean id="ProcurementCardHolder-transactionCreditCardNumber" parent="ProcurementCardHolder-transactionCreditCardNumber-parentBean">
+        <property name="attributeSecurity">
+            <bean parent="AttributeSecurity">
+                <property name="mask" value="true" />
+                <property name="maskFormatter">
+                    <bean parent="MaskFormatterSubString" p:maskCharacter="*" p:maskLength="12" />
+                </property>
+            </bean>
+        </property>
+    </bean>
+
+</beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardTransactionDetail.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardTransactionDetail.xml
@@ -566,6 +566,18 @@ http://rice.kuali.org/dd http://rice.kuali.org/dd/dd.xsd">
   	<property name="label" value="Tax Exempt Indicator"/>
   </bean>
   
+    <bean id="ProcurementCardTransactionDetail-transactionPostingDate" parent="ProcurementCardTransactionDetail-transactionPostingDate-parentBean">
+        <property name="label" value="Post Date" />
+    </bean>
+
+    <bean id="ProcurementCardTransactionDetail-transactionReferenceNumber" parent="ProcurementCardTransactionDetail-transactionReferenceNumber-parentBean">
+        <property name="label" value="Transaction ID Number" />
+    </bean>
+
+    <bean id="ProcurementCardTransactionDetail-transactionSalesTaxAmount" parent="ProcurementCardTransactionDetail-transactionSalesTaxAmount-parentBean">
+        <property name="label" value="Sales Tax Amount" />
+    </bean>
+
 <!-- Business Object Inquiry Definition -->
 
   <bean id="ProcurementCardTransactionDetail-inquiryDefinition" parent="ProcurementCardTransactionDetail-inquiryDefinition-parentBean">

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardVendor.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardVendor.xml
@@ -18,5 +18,9 @@
       		<bean parent="AnyCharacterValidationPattern"/>
     	</property>
 	</bean>
+
+    <bean id="ProcurementCardVendor-visaVendorIdentifier" parent="ProcurementCardVendor-visaVendorIdentifier-parentBean">
+        <property name="label" value="Vendor ID" />
+    </bean>
 	
 </beans>

--- a/kfs-web/src/main/webapp/WEB-INF/tags/fp/procurementCardTransactions.tag
+++ b/kfs-web/src/main/webapp/WEB-INF/tags/fp/procurementCardTransactions.tag
@@ -38,61 +38,80 @@
     <table cellpadding="0" class="datatable" summary="Transaction Details">
                                                                                            
        <fp:subheadingWithDetailToggleRow columnCount="4" subheading="Transaction #${currentTransaction.transactionReferenceNumber}"/>
-	      <tr>
-	        <th scope="row"><div align="right"><kul:htmlAttributeLabel attributeEntry="${cardAttributes.transactionCreditCardNumber}" readOnly="true"/></div></th>
-	        <td>
-	          <kul:inquiry boClassName="org.kuali.kfs.fp.businessobject.ProcurementCardHolder" 
-               keyValues="documentNumber=${currentTransaction.documentNumber}" render="true">
-				<c:choose>
-					<c:when test="${KualiForm.transactionCreditCardNumbersViewStatus[ctr]}">
-						<bean:write name="KualiForm" property="document.procurementCardHolder.transactionCreditCardNumber" />
-					</c:when>
-					<c:otherwise>
-						<kul:htmlControlAttribute attributeEntry="${cardAttributes.transactionCreditCardNumber}" property="document.procurementCardHolder.transactionCreditCardNumber"
-						 readOnly="true" />
-					</c:otherwise>
-				</c:choose>
-	          </kul:inquiry>
-	        </td>
-			<th>&nbsp;</th>
-			<td>&nbsp;</td>
-	      </tr>
-	      <tr>
-	        <th scope="row"><div align="right"><kul:htmlAttributeLabel attributeEntry="${cardAttributes.cardHolderName}" readOnly="true"/></div></th>
-	        <td><kul:htmlControlAttribute attributeEntry="${cardAttributes.cardHolderName}" property="document.procurementCardHolder.cardHolderName" readOnly="true"/></td>
-            <th> <div align="right"><kul:htmlAttributeLabel attributeEntry="${transactionAttributes.transactionTotalAmount}"/></div></th>
-            <td valign=top><kul:htmlControlAttribute attributeEntry="${transactionAttributes.transactionTotalAmount}" property="document.transactionEntries[${ctr}].transactionTotalAmount" readOnly="true"/></td>
-	     </tr>
-       <tr>
-          <th><div align="right"><kul:htmlAttributeLabel attributeEntry="${transactionAttributes.transactionDate}"/></div></th>
-          <td valign=top><bean:write name="KualiForm" property="document.transactionEntries[${ctr}].transactionDate" /></td>
-          <th> <div align="right"><kul:htmlAttributeLabel attributeEntry="${transactionAttributes.transactionReferenceNumber}"/></div></th>
-          <td valign=top>
-            <kul:inquiry boClassName="edu.arizona.kfs.fp.businessobject.ProcurementCardTransactionDetail" 
-               keyValues="documentNumber=${currentTransaction.documentNumber}&financialDocumentTransactionLineNumber=${currentTransaction.financialDocumentTransactionLineNumber}" 
-               render="true">
-				<bean:write name="KualiForm" property="document.transactionEntries[${ctr}].transactionReferenceNumber" />
-            </kul:inquiry>
-          </td>
-       </tr>   
-       <tr>  
-          <th> <div align="right"><kul:htmlAttributeLabel attributeEntry="${vendorAttributes.vendorName}"/></div></th> 
-          <td valign=top>
-            <kul:inquiry boClassName="org.kuali.kfs.fp.businessobject.ProcurementCardVendor" 
-               keyValues="documentNumber=${currentTransaction.documentNumber}&financialDocumentTransactionLineNumber=${currentTransaction.financialDocumentTransactionLineNumber}" 
-               render="true">
-				<bean:write name="KualiForm" property="document.transactionEntries[${ctr}].procurementCardVendor.vendorName" />
-            </kul:inquiry>  
-          </td>
-          <th colspan="2"> <div align="left">
-		  <c:choose>
-			<c:when test="${KualiForm.documentActions[Constants.KUALI_ACTION_CAN_EDIT]}">
-				<a href="${KualiForm.disputeURL}" target="_blank"><img src="${ConfigProperties.externalizable.images.url}buttonsmall_dispute.gif"/></a>
-			</c:when>
-			<c:otherwise>&nbsp;</c:otherwise>
-		  </c:choose>
-          </div></th>
-       </tr>   
+         <tr>
+           <th scope="row"><div align="right"><kul:htmlAttributeLabel attributeEntry="${cardAttributes.transactionCreditCardNumber}" readOnly="true"/></div></th>
+           <td>
+             <kul:inquiry boClassName="org.kuali.kfs.fp.businessobject.ProcurementCardHolder" keyValues="documentNumber=${currentTransaction.documentNumber}" render="true">
+               <c:choose>
+                 <c:when test="${KualiForm.transactionCreditCardNumbersViewStatus[ctr]}">
+                   <bean:write name="KualiForm" property="document.procurementCardHolder.transactionCreditCardNumber" />
+                 </c:when>
+                 <c:otherwise>
+                   <kul:htmlControlAttribute attributeEntry="${cardAttributes.transactionCreditCardNumber}" property="document.procurementCardHolder.transactionCreditCardNumber" readOnly="true" />
+                 </c:otherwise>
+               </c:choose>
+             </kul:inquiry>
+           </td>
+           <th><div align="right"><kul:htmlAttributeLabel attributeEntry="${vendorAttributes.vendorName}" /></div></th>
+           <td valign="top">
+             <kul:inquiry boClassName="org.kuali.kfs.fp.businessobject.ProcurementCardVendor" keyValues="documentNumber=${currentTransaction.documentNumber}&financialDocumentTransactionLineNumber=${currentTransaction.financialDocumentTransactionLineNumber}" render="true">
+               <bean:write name="KualiForm" property="document.transactionEntries[${ctr}].procurementCardVendor.vendorName" />
+             </kul:inquiry>
+           </td>
+         </tr>
+         <tr>
+           <th scope="row"><div align="right"><kul:htmlAttributeLabel attributeEntry="${cardAttributes.cardHolderName}" readOnly="true"/></div></th>
+           <td><kul:htmlControlAttribute attributeEntry="${cardAttributes.cardHolderName}" property="document.procurementCardHolder.cardHolderName" readOnly="true" /></td>
+           <th scope="row"><div align="right"><kul:htmlAttributeLabel attributeEntry="${cardAttributes.cardNoteText}" readOnly="true"/></div></th>
+           <td><kul:htmlControlAttribute attributeEntry="${cardAttributes.cardNoteText}" property="document.procurementCardHolder.cardNoteText" readOnly="true" /></td>
+         </tr>
+         <tr>
+           <th scope="row"><div align="right"><kul:htmlAttributeLabel attributeEntry="${cardAttributes.cardHolderAlternateName}" readOnly="true" /></div></th>
+           <td><kul:htmlControlAttribute attributeEntry="${cardAttributes.cardHolderAlternateName}" property="document.procurementCardHolder.cardHolderAlternateName" readOnly="true" /></td>
+           <th><div align="right"><kul:htmlAttributeLabel attributeEntry="${transactionAttributes.transactionTotalAmount}" /></div></th>
+           <td valign="top"><kul:htmlControlAttribute attributeEntry="${transactionAttributes.transactionTotalAmount}" property="document.transactionEntries[${ctr}].transactionTotalAmount" readOnly="true" /></td>
+         </tr>
+         <tr>
+           <th><div align="right"><kul:htmlAttributeLabel attributeEntry="${transactionAttributes.transactionDate}" /></div></th>
+           <td valign="top"><bean:write name="KualiForm" property="document.transactionEntries[${ctr}].transactionDate" /></td>
+           <th><div align="right"><kul:htmlAttributeLabel attributeEntry="${transactionAttributes.transactionSalesTaxAmount}" /></div></th>
+           <td valign="top"><kul:htmlControlAttribute attributeEntry="${transactionAttributes.transactionSalesTaxAmount}" property="document.transactionEntries[${ctr}].transactionSalesTaxAmount" readOnly="true"/></td>
+         </tr>
+         <tr>
+           <th><div align="right"><kul:htmlAttributeLabel attributeEntry="${transactionAttributes.transactionPostingDate}" /></div></th>
+           <td valign="top"><bean:write name="KualiForm" property="document.transactionEntries[${ctr}].transactionPostingDate" /></td>
+           <th><div align="right">Editable Sales Tax Amount Placeholder</div></th>
+           <td valign="top"><div align="left">see UAF-2972</div></th>
+<%--            <th><div align="right"><kul:htmlAttributeLabel attributeEntry="${transactionAttributes.transactionEditableSalesTaxAmount}"/></div></th> --%>
+<%--            <td valign="top"><kul:htmlControlAttribute attributeEntry="${transactionAttributes.transactionEditableSalesTaxAmount}" property="document.transactionEntries[${ctr}].transactionEditableSalesTaxAmount" readOnly="${!canEdit}"/></td> --%>
+         </tr>
+         <tr>
+           <th><div align="right"><kul:htmlAttributeLabel attributeEntry="${transactionAttributes.transactionReferenceNumber}"/></div></th>
+           <td valign="top">
+             <kul:inquiry boClassName="edu.arizona.kfs.fp.businessobject.ProcurementCardTransactionDetail" keyValues="documentNumber=${currentTransaction.documentNumber}&financialDocumentTransactionLineNumber=${currentTransaction.financialDocumentTransactionLineNumber}" render="true">
+               <bean:write name="KualiForm" property="document.transactionEntries[${ctr}].transactionReferenceNumber" />
+             </kul:inquiry>
+           </td>
+           <th><div align="right"><kul:htmlAttributeLabel attributeEntry="${transactionAttributes.transactionTaxExemptIndicator}"/></div></th>
+           <td valign="top"><kul:htmlControlAttribute attributeEntry="${transactionAttributes.transactionTaxExemptIndicator}" property="document.transactionEntries[${ctr}].transactionTaxExemptIndicator" readOnly="${!canEdit}" /></td>
+         </tr>
+         <tr>
+           <th><div align="right">No Reciept Indicator Placeholder:</div></th>
+           <td valign="top"><div align="left">see UAF-2972</div></th>
+<%--            <th><div align="right"><kul:htmlAttributeLabel attributeEntry="${transactionAttributes.transactionNoReceiptIndicator}"/></div></th> --%>
+<%--            <td valign="top"><kul:htmlControlAttribute attributeEntry="${transactionAttributes.transactionNoReceiptIndicator}" property="document.transactionEntries[${ctr}].transactionNoReceiptIndicator" readOnly="${!canEdit}" /></td> --%>
+           <th colspan="2"><div align="left"></div></th>
+         </tr>
+         <tr>
+           <th colspan="2"><div align="left">
+             <c:choose>
+               <c:when test="${KualiForm.documentActions[Constants.KUALI_ACTION_CAN_EDIT]}">
+                 <a href="${KualiForm.disputeURL}" target="_blank"><img src="${ConfigProperties.externalizable.images.url}buttonsmall_dispute.gif"/></a>
+               </c:when>
+               <c:otherwise>&nbsp;</c:otherwise>
+             </c:choose>
+             </div></th>
+         </tr>
     </table>   
 	
 	<%-- For accounting lines to tab through the fields correctly, the sys-java:accountingLineGroup needs to be in a TAB tag, and in 


### PR DESCRIPTION
included in this pull request:
1) User Story 9 - As a Campus User I want the PCard credit card number to be masked with stars for the first 12-digits, but display the last 4-digits so that the credit card number is secure within the KFS software.
2) User Story 13 - As a PCard Administrator I want to update field names on PCDO document so that it is consistent with UA naming conventions.
3) User Story 14 - As a PCard Administrator I want to change the field order on PCDO document so that locating pertinent mandatory fields easier to find for users.

Note 1, 2 fields for User Story 14 are part of UAF-2972. Hardcoded placeholders have been placed in the location that the spec requires these fields in procurementCardTransactions.tag, with the code from KFS3 to display these fields commented out. The developer that takes on that task can remove the placeholders and uncomment those lines (with some possible modifications) to enable these fields.

Note 2: Full testing of the acceptance criteria on this ticket cannot be completed until UAF-2972, UAF-2973, and UAF-2965 are completed.
