### PR TITLE
UAF-3617 Bug: Stack Trace Error when returning order to create Requisition, PO, and Electronic Invoice.

### DIFF
--- a/kfs-core/src/main/resources/institutional-config.properties
+++ b/kfs-core/src/main/resources/institutional-config.properties
@@ -14,7 +14,8 @@ b2b.environment=test
 b2b.purchase.order.url=https://usertest.sciquest.com/apps/Router/POXMLImport
 b2b.punch.back.url=${application.url}/b2b.do?methodToCall=returnFromShopping
 b2b.punch.out.url=https://usertest.sciquest.com/apps/Router/ExternalAuth/cXML/Arizona
-#b2b.punch.back.action.forwarding.url=/portal.do?channelTitle=Requisition&channelUrl=purapRequisition.do?methodToCall=displayB2BRequisition
+b2b.punch.back.action.forwarding.url=/portal.do?channelTitle=Requisition&channelUrl=${application.url}/purapRequisition.do?methodToCall=displayB2BRequisition
+b2b.purchase.order.dtd=http://usertest.sciquest.com/app_docs/dtd/po/
 
 # ECustoms properties
 ecustoms.output.directory=${staging.directory}/vnd/ecustoms

--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/service/impl/B2BPurchaseOrderSciquestServiceImpl.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/service/impl/B2BPurchaseOrderSciquestServiceImpl.java
@@ -1,0 +1,231 @@
+package edu.arizona.kfs.module.purap.document.service.impl;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.module.purap.businessobject.PurchaseOrderItem;
+import org.kuali.kfs.module.purap.document.PurchaseOrderDocument;
+import org.kuali.kfs.module.purap.util.PurApDateFormatUtils;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.kfs.vnd.businessobject.ContractManager;
+import org.kuali.rice.core.api.datetime.DateTimeService;
+import org.kuali.rice.krad.util.ObjectUtils;
+
+import edu.arizona.kfs.module.purap.PurapConstants;
+
+@SuppressWarnings("rawtypes")
+public class B2BPurchaseOrderSciquestServiceImpl extends org.kuali.kfs.module.purap.document.service.impl.B2BPurchaseOrderSciquestServiceImpl {
+    private static org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(B2BPurchaseOrderSciquestServiceImpl.class);
+
+    private String b2bPurchaseOrderDtd;
+
+    public String getB2bPurchaseOrderDtd() {
+        return b2bPurchaseOrderDtd;
+    }
+
+    public void setB2bPurchaseOrderDtd(String b2bPurchaseOrderDtd) {
+        this.b2bPurchaseOrderDtd = b2bPurchaseOrderDtd;
+    }
+
+    @Override
+    public String getCxml(PurchaseOrderDocument purchaseOrder, String requisitionInitiatorPrincipalId, String password, ContractManager contractManager, String contractManagerEmail, String vendorDuns) {
+
+        StringBuffer cxml = new StringBuffer();
+
+        cxml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        // ** UAF-3617
+        if (StringUtils.isNotBlank(b2bPurchaseOrderDtd)) {
+            cxml.append("<!DOCTYPE PurchaseOrderMessage SYSTEM \"" + b2bPurchaseOrderDtd.trim() + "PO.dtd\">\n");
+        } else {
+            cxml.append("<!DOCTYPE PurchaseOrderMessage SYSTEM \"PO.dtd\">\n");
+        }
+        // ** UAF-3617
+        cxml.append("<PurchaseOrderMessage version=\"2.0\">\n");
+        cxml.append("  <Header>\n");
+
+        // MessageId - can be whatever you would like it to be. Just make it unique.
+        cxml.append("    <MessageId>KFS_cXML_PO</MessageId>\n");
+
+        // Timestamp - it doesn't matter what's in the timezone, just that it's there (need "T" space between date/time)
+        Date d = SpringContext.getBean(DateTimeService.class).getCurrentDate();
+        SimpleDateFormat date = PurApDateFormatUtils.getSimpleDateFormat(PurapConstants.NamedDateFormats.CXML_SIMPLE_DATE_FORMAT);
+        SimpleDateFormat time = PurApDateFormatUtils.getSimpleDateFormat(PurapConstants.NamedDateFormats.CXML_SIMPLE_TIME_FORMAT);
+        cxml.append("    <Timestamp>").append(date.format(d)).append("T").append(time.format(d)).append("+05:30").append("</Timestamp>\n");
+
+        cxml.append("    <Authentication>\n");
+        // ** UAF-3617
+        cxml.append("      <Identity>").append(getB2bPurchaseOrderIdentity()).append("</Identity>\n");
+        // ** UAF-3617
+        cxml.append("      <SharedSecret>").append(password).append("</SharedSecret>\n");
+        cxml.append("    </Authentication>\n");
+        cxml.append("  </Header>\n");
+        cxml.append("  <PurchaseOrder>\n");
+        cxml.append("    <POHeader>\n");
+        cxml.append("      <PONumber>").append(purchaseOrder.getPurapDocumentIdentifier()).append("</PONumber>\n");
+        cxml.append("      <Requestor>\n");
+        cxml.append("        <UserProfile username=\"").append(requisitionInitiatorPrincipalId.toUpperCase()).append("\">\n");
+        cxml.append("        </UserProfile>\n");
+        cxml.append("      </Requestor>\n");
+        cxml.append("      <Priority>High</Priority>\n");
+        cxml.append("      <AccountingDate>").append(purchaseOrder.getPurchaseOrderCreateTimestamp()).append("</AccountingDate>\n");
+
+        /** *** SUPPLIER SECTION **** */
+        cxml.append("      <Supplier id=\"").append(purchaseOrder.getExternalOrganizationB2bSupplierIdentifier()).append("\">\n");
+        cxml.append("        <DUNS>").append(vendorDuns).append("</DUNS>\n");
+        cxml.append("        <SupplierNumber>").append(purchaseOrder.getVendorNumber()).append("</SupplierNumber>\n");
+
+        // Type attribute is required. Valid values: main and technical. Only main will be considered for POImport.
+        cxml.append("        <ContactInfo type=\"main\">\n");
+        // TelephoneNumber is required. With all fields, only numeric digits will be stored. Non-numeric characters are allowed, but
+        // will be stripped before storing.
+        cxml.append("          <Phone>\n");
+        cxml.append("            <TelephoneNumber>\n");
+        cxml.append("              <CountryCode>1</CountryCode>\n");
+        if (contractManager.getContractManagerPhoneNumber().length() > 4) {
+            cxml.append("              <AreaCode>").append(contractManager.getContractManagerPhoneNumber().substring(0, 3)).append("</AreaCode>\n");
+            cxml.append("              <Number>").append(contractManager.getContractManagerPhoneNumber().substring(3)).append("</Number>\n");
+        } else {
+            LOG.error("getCxml() The phone number is invalid for this contract manager: " + contractManager.getContractManagerUserIdentifier() + " " + contractManager.getContractManagerName());
+            cxml.append("              <AreaCode>555</AreaCode>\n");
+            cxml.append("              <Number>").append(contractManager.getContractManagerPhoneNumber()).append("</Number>\n");
+        }
+        cxml.append("            </TelephoneNumber>\n");
+        cxml.append("          </Phone>\n");
+        cxml.append("        </ContactInfo>\n");
+        cxml.append("      </Supplier>\n");
+
+        /** *** BILL TO SECTION **** */
+        cxml.append("      <BillTo>\n");
+        cxml.append("        <Address>\n");
+        cxml.append("          <TemplateName>Bill To</TemplateName>\n");
+        cxml.append("          <AddressCode>").append(purchaseOrder.getDeliveryCampusCode()).append("</AddressCode>\n");
+        // Contact - There can be 0-5 Contact elements. The label attribute is optional.
+        cxml.append("          <Contact label=\"FirstName\" linenumber=\"1\"><![CDATA[Accounts]]></Contact>\n");
+        cxml.append("          <Contact label=\"LastName\" linenumber=\"2\"><![CDATA[Payable]]></Contact>\n");
+        cxml.append("          <Contact label=\"Company\" linenumber=\"3\"><![CDATA[").append(purchaseOrder.getBillingName().trim()).append("]]></Contact>\n");
+        // since email address is not required, we need to check whether its empty; if yes, don't add it
+        if (!StringUtils.isEmpty(purchaseOrder.getBillingEmailAddress())) {
+            cxml.append("          <Contact label=\"Email\" linenumber=\"4\"><![CDATA[").append(purchaseOrder.getBillingEmailAddress().trim()).append("]]></Contact>\n");
+        }
+        // since phone number is not required, we need to check whether its empty; if yes, don't add it
+        if (!StringUtils.isEmpty(purchaseOrder.getBillingPhoneNumber())) {
+            cxml.append("          <Contact label=\"Phone\" linenumber=\"5\"><![CDATA[").append(purchaseOrder.getBillingPhoneNumber().trim()).append("]]></Contact>\n");
+        }
+        // There must be 1-5 AddressLine elements. The label attribute is optional.
+        cxml.append("          <AddressLine label=\"Street1\" linenumber=\"1\"><![CDATA[").append(purchaseOrder.getBillingLine1Address()).append("]]></AddressLine>\n");
+        cxml.append("          <AddressLine label=\"Street2\" linenumber=\"2\"><![CDATA[").append(purchaseOrder.getBillingLine2Address()).append("]]></AddressLine>\n");
+        cxml.append("          <City><![CDATA[").append(purchaseOrder.getBillingCityName()).append("]]></City>\n"); // Required.
+        cxml.append("          <State>").append(purchaseOrder.getBillingStateCode()).append("</State>\n");
+        cxml.append("          <PostalCode>").append(purchaseOrder.getBillingPostalCode()).append("</PostalCode>\n"); // Required.
+        cxml.append("          <Country isocountrycode=\"").append(purchaseOrder.getBillingCountryCode()).append("\">").append(purchaseOrder.getBillingCountryCode()).append("</Country>\n");
+        cxml.append("        </Address>\n");
+        cxml.append("      </BillTo>\n");
+
+        /** *** SHIP TO SECTION **** */
+        cxml.append("      <ShipTo>\n");
+        cxml.append("        <Address>\n");
+        cxml.append("          <TemplateName>Ship To</TemplateName>\n");
+        // AddressCode. A code to identify the address, that is sent to the supplier.
+        cxml.append("          <AddressCode>").append(purchaseOrder.getDeliveryCampusCode()).append(purchaseOrder.getOrganizationCode()).append("</AddressCode>\n");
+        cxml.append("          <Contact label=\"Name\" linenumber=\"1\"><![CDATA[").append(purchaseOrder.getDeliveryToName().trim()).append("]]></Contact>\n");
+        cxml.append("          <Contact label=\"PurchasingEmail\" linenumber=\"2\"><![CDATA[").append(contractManagerEmail).append("]]></Contact>\n");
+        if (ObjectUtils.isNotNull(purchaseOrder.getInstitutionContactEmailAddress())) {
+            cxml.append("          <Contact label=\"ContactEmail\" linenumber=\"3\"><![CDATA[").append(purchaseOrder.getInstitutionContactEmailAddress()).append("]]></Contact>\n");
+        } else {
+            cxml.append("          <Contact label=\"ContactEmail\" linenumber=\"3\"><![CDATA[").append(purchaseOrder.getRequestorPersonEmailAddress()).append("]]></Contact>\n");
+        }
+        if (ObjectUtils.isNotNull(purchaseOrder.getInstitutionContactPhoneNumber())) {
+            cxml.append("          <Contact label=\"Phone\" linenumber=\"4\"><![CDATA[").append(purchaseOrder.getInstitutionContactPhoneNumber().trim()).append("]]></Contact>\n");
+        } else {
+            cxml.append("          <Contact label=\"Phone\" linenumber=\"4\"><![CDATA[").append(purchaseOrder.getRequestorPersonPhoneNumber()).append("]]></Contact>\n");
+        }
+
+        // check indicator to decide if receiving or delivery address should be sent to the vendor
+        if (purchaseOrder.getAddressToVendorIndicator()) { // use receiving address
+            cxml.append("          <AddressLine label=\"Street1\" linenumber=\"1\"><![CDATA[").append(purchaseOrder.getReceivingName().trim()).append("]]></AddressLine>\n");
+            cxml.append("          <AddressLine label=\"Street2\" linenumber=\"2\"><![CDATA[").append(purchaseOrder.getReceivingLine1Address().trim()).append("]]></AddressLine>\n");
+            if (ObjectUtils.isNull(purchaseOrder.getReceivingLine2Address())) {
+                cxml.append("          <AddressLine label=\"Street3\" linenumber=\"3\"><![CDATA[").append(" ").append("]]></AddressLine>\n");
+            } else {
+                cxml.append("          <AddressLine label=\"Street3\" linenumber=\"3\"><![CDATA[").append(purchaseOrder.getReceivingLine2Address()).append("]]></AddressLine>\n");
+            }
+            cxml.append("          <City><![CDATA[").append(purchaseOrder.getReceivingCityName().trim()).append("]]></City>\n");
+            cxml.append("          <State>").append(purchaseOrder.getReceivingStateCode()).append("</State>\n");
+            cxml.append("          <PostalCode>").append(purchaseOrder.getReceivingPostalCode()).append("</PostalCode>\n");
+            cxml.append("          <Country isocountrycode=\"").append(purchaseOrder.getReceivingCountryCode()).append("\">").append(purchaseOrder.getReceivingCountryCode()).append("</Country>\n");
+        } else { // use final delivery address
+            /*
+             * replaced this with getBuildingLine so institutions can customize what info they need on this line
+             * if (StringUtils.isNotEmpty(purchaseOrder.getDeliveryBuildingName())) {
+             * cxml.append("          <Contact label=\"Building\" linenumber=\"5\"><![CDATA[").append(purchaseOrder.getDeliveryBuildingName()).append(" (").append(purchaseOrder.getDeliveryBuildingCode()).append(")]]></Contact>\n");
+             * }
+             */
+            cxml.append(getBuildingLine(purchaseOrder));
+            cxml.append("          <AddressLine label=\"Street1\" linenumber=\"1\"><![CDATA[").append(purchaseOrder.getDeliveryBuildingLine1Address().trim()).append("]]></AddressLine>\n");
+            cxml.append("          <AddressLine label=\"Street2\" linenumber=\"2\"><![CDATA[Room #").append(purchaseOrder.getDeliveryBuildingRoomNumber().trim()).append("]]></AddressLine>\n");
+            cxml.append("          <AddressLine label=\"Company\" linenumber=\"4\"><![CDATA[").append(purchaseOrder.getBillingName().trim()).append("]]></AddressLine>\n");
+            if (ObjectUtils.isNull(purchaseOrder.getDeliveryBuildingLine2Address())) {
+                cxml.append("          <AddressLine label=\"Street3\" linenumber=\"3\"><![CDATA[").append(" ").append("]]></AddressLine>\n");
+            } else {
+                cxml.append("          <AddressLine label=\"Street3\" linenumber=\"3\"><![CDATA[").append(purchaseOrder.getDeliveryBuildingLine2Address()).append("]]></AddressLine>\n");
+            }
+            cxml.append("          <City><![CDATA[").append(purchaseOrder.getDeliveryCityName().trim()).append("]]></City>\n");
+            cxml.append("          <State>").append(purchaseOrder.getDeliveryStateCode()).append("</State>\n");
+            cxml.append("          <PostalCode>").append(purchaseOrder.getDeliveryPostalCode()).append("</PostalCode>\n");
+            cxml.append("          <Country isocountrycode=\"").append(purchaseOrder.getDeliveryCountryCode()).append("\">").append(purchaseOrder.getDeliveryCountryCode()).append("</Country>\n");
+        }
+
+        cxml.append("        </Address>\n");
+        cxml.append("      </ShipTo>\n");
+        cxml.append("    </POHeader>\n");
+
+        /** *** Items Section **** */
+        List detailList = purchaseOrder.getItems();
+        for (Iterator iter = detailList.iterator(); iter.hasNext();) {
+            PurchaseOrderItem poi = (PurchaseOrderItem) iter.next();
+            if ((ObjectUtils.isNotNull(poi.getItemType())) && poi.getItemType().isLineItemIndicator()) {
+                cxml.append("    <POLine linenumber=\"").append(poi.getItemLineNumber()).append("\">\n");
+                cxml.append("      <Item>\n");
+                // CatalogNumber - This is a string that the supplier uses to identify the item (i.e., SKU). Optional.
+                cxml.append("        <CatalogNumber><![CDATA[").append(poi.getItemCatalogNumber()).append("]]></CatalogNumber>\n");
+                if (ObjectUtils.isNotNull(poi.getItemAuxiliaryPartIdentifier())) {
+                    cxml.append("        <AuxiliaryCatalogNumber><![CDATA[").append(poi.getItemAuxiliaryPartIdentifier()).append("]]></AuxiliaryCatalogNumber>\n");
+                }
+                cxml.append("        <Description><![CDATA[").append(poi.getItemDescription()).append("]]></Description>\n"); // Required.
+                cxml.append("        <ProductUnitOfMeasure type=\"supplier\"><Measurement><MeasurementValue><![CDATA[").append(poi.getItemUnitOfMeasureCode()).append("]]></MeasurementValue></Measurement></ProductUnitOfMeasure>\n");
+                cxml.append("        <ProductUnitOfMeasure type=\"system\"><Measurement><MeasurementValue><![CDATA[").append(poi.getItemUnitOfMeasureCode()).append("]]></MeasurementValue></Measurement></ProductUnitOfMeasure>\n");
+                // ProductReferenceNumber - Unique id for hosted products in SelectSite
+                if (poi.getExternalOrganizationB2bProductTypeName().equals("Punchout")) {
+                    cxml.append("        <ProductReferenceNumber>null</ProductReferenceNumber>\n");
+                } else {
+                    cxml.append("        <ProductReferenceNumber>").append(poi.getExternalOrganizationB2bProductReferenceNumber()).append("</ProductReferenceNumber>\n");
+                }
+                // ProductType - Describes the type of the product or service. Valid values: Catalog, Form, Punchout. Mandatory.
+                cxml.append("        <ProductType>").append(poi.getExternalOrganizationB2bProductTypeName()).append("</ProductType>\n");
+                cxml.append("      </Item>\n");
+                cxml.append("      <Quantity>").append(poi.getItemQuantity()).append("</Quantity>\n");
+                // LineCharges - All the monetary charges for this line, including the price, tax, shipping, and handling.
+                // Required.
+                cxml.append("      <LineCharges>\n");
+                cxml.append("        <UnitPrice>\n");
+                cxml.append("          <Money currency=\"USD\">").append(poi.getItemUnitPrice()).append("</Money>\n");
+                cxml.append("        </UnitPrice>\n");
+                cxml.append("      </LineCharges>\n");
+                cxml.append("    </POLine>\n");
+            }
+        }
+
+        cxml.append("  </PurchaseOrder>\n");
+        cxml.append("</PurchaseOrderMessage>");
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("getCxml(): cXML for po number " + purchaseOrder.getPurapDocumentIdentifier() + ":\n" + cxml.toString());
+        }
+
+        return cxml.toString();
+    }
+
+}

--- a/kfs-purap/src/main/resources/edu/arizona/kfs/module/purap/spring-purap.xml
+++ b/kfs-purap/src/main/resources/edu/arizona/kfs/module/purap/spring-purap.xml
@@ -147,4 +147,8 @@
 
     <bean id="paymentRequestDao" parent="platformAwareDao" class="edu.arizona.kfs.module.purap.document.dataaccess.impl.PaymentRequestDaoOjb"/>
     	
+    <bean id="b2bPurchaseOrderService" class="edu.arizona.kfs.module.purap.document.service.impl.B2BPurchaseOrderSciquestServiceImpl" parent="b2bPurchaseOrderService-parentBean">
+        <property name="b2bPurchaseOrderDtd" value="${b2b.purchase.order.dtd}"/>
+    </bean>
+
 </beans>

--- a/kfs-web/src/main/webapp/static/xsd/purap/b2bPOResponse.xsd
+++ b/kfs-web/src/main/webapp/static/xsd/purap/b2bPOResponse.xsd
@@ -21,11 +21,26 @@
 <xsd:schema elementFormDefault="qualified"
 		    targetNamespace="http://www.kuali.org/kfs/purap/b2bPOResponse"
 		    xmlns="http://www.kuali.org/kfs/purap/b2bPOResponse" 
-		    xmlns:purap="http://www.kuali.org/kfs/purap/types"
 		    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 
-	<xsd:import namespace="http://www.kuali.org/kfs/purap/types" schemaLocation="../../xsd/purap/purapTypes.xsd" />
-	
+<xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd" />
+
+<!-- Simple Data Types from purapTypes.xsd -->
+
+    <xsd:simpleType name="statusCodeType">
+        <xsd:restriction base="xsd:token">
+            <xsd:pattern value="[0-9]{3}"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="statusTextType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="200"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+<!-- Original Schema -->
+
 	<xsd:element name="Error">
 	  	<xsd:complexType>
 	  		<xsd:sequence>
@@ -51,8 +66,8 @@
         		      	<xsd:element name="Status">
 	        		      	<xsd:complexType>
 	        		      		<xsd:sequence>
-		        		      		<xsd:element name="StatusCode" type="purap:statusCodeType"/>
-		        		      		<xsd:element name="StatusText" type="purap:statusTextType"/>
+                                    <xsd:element name="StatusCode" type="statusCodeType"/>
+                                    <xsd:element name="StatusText" type="statusTextType"/>
 	        		      			<xsd:element name="Errors" minOccurs="0">
 	        		      				<xsd:complexType>
 									  		<xsd:sequence>

--- a/kfs-web/src/main/webapp/static/xsd/purap/b2bPunchOutOrder.xsd
+++ b/kfs-web/src/main/webapp/static/xsd/purap/b2bPunchOutOrder.xsd
@@ -21,29 +21,122 @@
 <xsd:schema elementFormDefault="qualified"
 		    targetNamespace="http://www.kuali.org/kfs/purap/b2bPunchOutOrder"
 		    xmlns="http://www.kuali.org/kfs/purap/b2bPunchOutOrder" 
-		    xmlns:purap="http://www.kuali.org/kfs/purap/types"
-		    xmlns:kfs="http://www.kuali.org/kfs/sys/types"
 		    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 		    
-<xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="../../xsd/sys/xml.xsd"/>
-<xsd:import namespace="http://www.kuali.org/kfs/purap/types" schemaLocation="../../xsd/purap/purapTypes.xsd" />
-<xsd:import namespace="http://www.kuali.org/kfs/sys/types" schemaLocation="../../xsd/sys/types.xsd" />
+<xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd" />
+
+<!-- Simple Data Types from purapTypes.xsd -->
+
+    <xsd:simpleType name="domainType">
+        <xsd:restriction base="xsd:string">
+            <xsd:pattern value="DUNS|NetworkId|AribaNetworkUserId"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="dunsNumberType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="50"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="amountType">
+        <xsd:restriction base="xsd:decimal">
+            <xsd:fractionDigits value="4"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="currencyType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="3"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="catalogNumberType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="30"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="auxiliaryIDType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="300"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="itemDescriptionType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="4000"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="statusCodeType">
+        <xsd:restriction base="xsd:token">
+            <xsd:pattern value="[0-9]{3}"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="statusTextType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="200"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="uomType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="4"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+<!-- Simple Data Types from types.xsd -->
+
+    <xsd:simpleType name="zeroToThirtyCharType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="30"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="oneToTwentyOneCharType">
+        <xsd:restriction base="xsd:string">
+            <xsd:minLength value="1"/>
+            <xsd:maxLength value="21"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="zeroToFiftyFiveCharType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="55"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="zeroToNinetyCharType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="90"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="zeroToTwentyCharType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="20"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+<!-- Original Schema -->
 
 <xsd:element name="Credential">
 	<xsd:complexType>
 		<xsd:sequence>
-			<xsd:element name="Identity" type="purap:dunsNumberType" />
+			<xsd:element name="Identity" type="dunsNumberType" />
 			<xsd:element name="SharedSecret" minOccurs="0" maxOccurs="1" type="xsd:string" /> <!-- Not used -->
 		</xsd:sequence>
-		<xsd:attribute name="domain" type="purap:domainType" use="required" />
+		<xsd:attribute name="domain" type="domainType" use="required" />
 	</xsd:complexType>
 </xsd:element>
   
 <xsd:element name="Money" default="0">
 	<xsd:complexType>
 		<xsd:simpleContent>
-			<xsd:extension base="purap:amountType">
-				<xsd:attribute name="currency" type="purap:currencyType" use="required" />
+			<xsd:extension base="amountType">
+				<xsd:attribute name="currency" type="currencyType" use="required" />
 			</xsd:extension>
 		</xsd:simpleContent>
 	</xsd:complexType>
@@ -52,8 +145,8 @@
 <xsd:element name="ItemID">
 	<xsd:complexType>
 		<xsd:sequence>
-			<xsd:element name="SupplierPartID" type="purap:catalogNumberType" />
-			<xsd:element name="SupplierPartAuxiliaryID" type="purap:auxiliaryIDType" minOccurs="0"/>
+			<xsd:element name="SupplierPartID" type="catalogNumberType" />
+			<xsd:element name="SupplierPartAuxiliaryID" type="auxiliaryIDType" minOccurs="0"/>
 		</xsd:sequence>
 	</xsd:complexType>
 </xsd:element>
@@ -69,7 +162,7 @@
 <xsd:element name="Description">
  	<xsd:complexType>
  		<xsd:simpleContent>
- 			<xsd:extension base="purap:itemDescriptionType">
+            <xsd:extension base="itemDescriptionType">
  				<xsd:attribute ref="xml:lang" use="required" />
  			</xsd:extension>
  		</xsd:simpleContent>
@@ -79,8 +172,8 @@
 <xsd:element name="Extrinsic">
  	<xsd:complexType>
  		<xsd:simpleContent>
- 			<xsd:extension base="kfs:zeroToThirtyCharType">
- 				<xsd:attribute name="name" type="kfs:oneToTwentyOneCharType" />
+            <xsd:extension base="zeroToThirtyCharType">
+                <xsd:attribute name="name" type="oneToTwentyOneCharType" />
  			</xsd:extension>
  		</xsd:simpleContent>
  	</xsd:complexType>
@@ -124,8 +217,8 @@
 						  <xsd:complexType>
 						  	<xsd:simpleContent>
 						  		<xsd:extension base="xsd:string">
-						  			<xsd:attribute name="code" type="purap:statusCodeType" />
-						  			<xsd:attribute name="text" type="purap:statusTextType" />
+									<xsd:attribute name="code" type="statusCodeType" />
+									<xsd:attribute name="text" type="statusTextType" />
 						  		</xsd:extension>
 						  	</xsd:simpleContent>
 						  </xsd:complexType>
@@ -159,19 +252,19 @@
 									  					<xsd:sequence>
 									  						<xsd:element ref="UnitPrice"/>
 									  						<xsd:element ref="Description"/>
-									  						<xsd:element name="UnitOfMeasure" type="purap:uomType" />
+															<xsd:element name="UnitOfMeasure" type="uomType" />
 									  						
 									  						<xsd:element name="Classification" maxOccurs="unbounded">
 															  	<xsd:complexType>
 															  		<xsd:simpleContent>
-															  			<xsd:extension base="kfs:zeroToThirtyCharType">
-															  				<xsd:attribute name="domain" type="kfs:oneToTwentyOneCharType" />
+																		<xsd:extension base="zeroToThirtyCharType">
+																			<xsd:attribute name="domain" type="oneToTwentyOneCharType" />
 															  			</xsd:extension>
 															  		</xsd:simpleContent>
 															  	</xsd:complexType>
 															</xsd:element> <!-- Classification -->
-															<xsd:element name="ManufacturerPartID" type="kfs:oneToTwentyOneCharType" minOccurs="0"/>
-															<xsd:element name="ManufacturerName" type="kfs:zeroToFiftyFiveCharType" minOccurs="0"/>
+															<xsd:element name="ManufacturerPartID" type="oneToTwentyOneCharType" minOccurs="0"/>
+															<xsd:element name="ManufacturerName" type="zeroToFiftyFiveCharType" minOccurs="0"/>
 															<xsd:element ref="Extrinsic" maxOccurs="unbounded"/>
 									  					</xsd:sequence>
 									  				</xsd:complexType>	
@@ -179,8 +272,8 @@
 									  			<xsd:element name="SupplierID" minOccurs="0" maxOccurs="unbounded"> <!-- Not used -->
 									  				<xsd:complexType>
 												 		<xsd:simpleContent>
-												 			<xsd:extension base="kfs:zeroToNinetyCharType">
-												 				<xsd:attribute name="domain" type="kfs:zeroToTwentyCharType" />
+															<xsd:extension base="zeroToNinetyCharType">
+																<xsd:attribute name="domain" type="zeroToTwentyCharType" />
 												 			</xsd:extension>
 												 		</xsd:simpleContent>
 												 	</xsd:complexType>

--- a/kfs-web/src/main/webapp/static/xsd/purap/electronicInvoice.xsd
+++ b/kfs-web/src/main/webapp/static/xsd/purap/electronicInvoice.xsd
@@ -21,28 +21,174 @@
 <xsd:schema elementFormDefault="qualified"
 		    targetNamespace="http://www.kuali.org/kfs/purap/electronicInvoice"
 		    xmlns="http://www.kuali.org/kfs/purap/electronicInvoice" 
-		    xmlns:purap="http://www.kuali.org/kfs/purap/types"
-		    xmlns:kfs="http://www.kuali.org/kfs/sys/types"
 		    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 
-  <xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="../../xsd/sys/xml.xsd"/>
-  <xsd:import namespace="http://www.kuali.org/kfs/purap/types" schemaLocation="../../xsd/purap/purapTypes.xsd" />
-  <xsd:import namespace="http://www.kuali.org/kfs/sys/types" schemaLocation="../../xsd/sys/types.xsd" />
+<xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd" />
+
+<!-- Simple Data Types from purapTypes.xsd -->
+
+    <xsd:simpleType name="dunsNumberType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="50"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="domainType">
+        <xsd:restriction base="xsd:string">
+            <xsd:pattern value="DUNS|NetworkId|AribaNetworkUserId"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="twoHundredCharsType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="200"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="eInvoiceDescriptionType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="300"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="addressType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="200"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="postalCodeType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="10"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="countryCodeType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="2"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="currencyType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="3"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="idType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="100"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="dateStringType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="100"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="uomType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="4"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="catalogNumberType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="30"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="auxiliaryIDType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="300"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="hundredCharsType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="100"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="emptyType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="0"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+<!-- Simple Data Types from types.xsd -->
+
+    <xsd:simpleType name="emailType">
+        <xsd:restriction base="xsd:string">
+            <xsd:minLength value="1"/>
+            <xsd:maxLength value="40"/>
+        <!-- FIXME: add regex for email address -->
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="oneToFiftyCharType">
+        <xsd:restriction base="xsd:string">
+            <xsd:minLength value="1"/>
+            <xsd:maxLength value="50"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="zeroToFiftyFiveCharType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="55"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="oneToFourCharType">
+        <xsd:restriction base="xsd:string">
+            <xsd:minLength value="1"/>
+            <xsd:maxLength value="4"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="oneToTwentyCharType">
+        <xsd:restriction base="xsd:string">
+            <xsd:minLength value="1"/>
+            <xsd:maxLength value="20"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="zeroToNinetyCharType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="90"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="zeroToTwentyCharType">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="20"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:simpleType name="oneToTenCharType">
+        <xsd:restriction base="xsd:string">
+            <xsd:minLength value="1"/>
+            <xsd:maxLength value="10"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+<!-- Original Schema -->
 
   <xsd:element name="Credential">
   	<xsd:complexType>
   		<xsd:sequence>
-  			<xsd:element name="Identity" type="purap:dunsNumberType" />
+			<xsd:element name="Identity" type="dunsNumberType" />
   			<xsd:element name="SharedSecret" minOccurs="0" maxOccurs="1" type="xsd:string" /> <!-- Not used -->
   		</xsd:sequence>
-  		<xsd:attribute name="domain" type="purap:domainType" use="required" />
+		<xsd:attribute name="domain" type="domainType" use="required" />
   	</xsd:complexType>
   </xsd:element>
 
   <xsd:element name="Name">
   	<xsd:complexType>
   		<xsd:simpleContent>
-  			<xsd:extension base="purap:twoHundredCharsType"> <!--  since barnesandnoble.xml contains empty name in contact, we need minLen=0 insteadof 1 -->
+			<xsd:extension base="twoHundredCharsType"> <!--  since barnesandnoble.xml contains empty name in contact, we need minLen=0 insteadof 1 -->
   				<xsd:attribute ref="xml:lang" use="required" />
   			</xsd:extension>
   		</xsd:simpleContent>
@@ -52,7 +198,7 @@
   <xsd:element name="Description">
   	<xsd:complexType>
   		<xsd:simpleContent>
-  			<xsd:extension base="purap:eInvoiceDescriptionType">
+			<xsd:extension base="eInvoiceDescriptionType">
   				<xsd:attribute ref="xml:lang" use="required" />
   			</xsd:extension>
   		</xsd:simpleContent>
@@ -62,8 +208,8 @@
   <xsd:element name="Email">
   	<xsd:complexType>
   		<xsd:simpleContent>
-  			<xsd:extension base="kfs:emailType">
-  				<xsd:attribute name="name" type="kfs:oneToFiftyCharType" />
+			<xsd:extension base="emailType">
+				<xsd:attribute name="name" type="oneToFiftyCharType" />
   			</xsd:extension>
   		</xsd:simpleContent>
   	</xsd:complexType>
@@ -72,22 +218,22 @@
   <xsd:element name="PostalAddress">
   	<xsd:complexType>
   		<xsd:sequence>
-  			<xsd:element name="DeliverTo" type="kfs:zeroToFiftyFiveCharType" minOccurs="0" maxOccurs="unbounded"/>
-  			<xsd:element name="Street" type="purap:addressType" maxOccurs="unbounded" />
-  			<xsd:element name="City" type="purap:addressType" />
-  			<xsd:element name="State" type="purap:addressType" />
-  			<xsd:element name="PostalCode" type="purap:postalCodeType" />
+			<xsd:element name="DeliverTo" type="zeroToFiftyFiveCharType" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="Street" type="addressType" maxOccurs="unbounded" />
+			<xsd:element name="City" type="addressType" />
+			<xsd:element name="State" type="addressType" />
+			<xsd:element name="PostalCode" type="postalCodeType" />
   			<xsd:element name="Country">
   				<xsd:complexType>
   					<xsd:simpleContent>
-  						<xsd:extension base="purap:addressType">
-  							<xsd:attribute name="isoCountryCode" type="purap:countryCodeType" use="required" />
+						<xsd:extension base="addressType">
+							<xsd:attribute name="isoCountryCode" type="countryCodeType" use="required" />
   						</xsd:extension>
   					</xsd:simpleContent>
   				</xsd:complexType>
   			</xsd:element>
   		</xsd:sequence>
-  		<xsd:attribute name="name" type="kfs:oneToFiftyCharType" use="optional" />
+		<xsd:attribute name="name" type="oneToFiftyCharType" use="optional" />
   	</xsd:complexType>
   </xsd:element>
 
@@ -100,19 +246,19 @@
   						<xsd:element name="CountryCode">
   							<xsd:complexType>
   								<xsd:simpleContent>
-  									<xsd:extension base="purap:addressType">
-  										<xsd:attribute name="isoCountryCode" type="kfs:oneToFourCharType" /> <!-- It's national prefix, not iso Country Code -->
+									<xsd:extension base="addressType">
+										<xsd:attribute name="isoCountryCode" type="oneToFourCharType" /> <!-- It's national prefix, not iso Country Code -->
   									</xsd:extension>
   								</xsd:simpleContent>
   							</xsd:complexType>
   						</xsd:element>
-  						<xsd:element name="AreaOrCityCode" type="kfs:oneToFourCharType" />
-  						<xsd:element name="Number" type="kfs:oneToTwentyCharType" />
+						<xsd:element name="AreaOrCityCode" type="oneToFourCharType" />
+						<xsd:element name="Number" type="oneToTwentyCharType" />
   					</xsd:sequence>
   				</xsd:complexType>
   			</xsd:element>
   		</xsd:sequence>
-  		<xsd:attribute name="name" type="kfs:oneToFiftyCharType" />
+		<xsd:attribute name="name" type="oneToFiftyCharType" />
   	</xsd:complexType>
   </xsd:element>
 
@@ -125,27 +271,27 @@
   						<xsd:element name="CountryCode">
   							<xsd:complexType>
   								<xsd:simpleContent>
-  									<xsd:extension base="purap:addressType">
-  										<xsd:attribute name="isoCountryCode" type="kfs:oneToFourCharType" /> <!-- It's national prefix, not iso Country Code -->
+									<xsd:extension base="addressType">
+										<xsd:attribute name="isoCountryCode" type="oneToFourCharType" /> <!-- It's national prefix, not iso Country Code -->
   									</xsd:extension>
   								</xsd:simpleContent>
   							</xsd:complexType>
   						</xsd:element>
-  						<xsd:element name="AreaOrCityCode" type="kfs:oneToFourCharType" />
-  						<xsd:element name="Number" type="kfs:oneToTwentyCharType" />
+						<xsd:element name="AreaOrCityCode" type="oneToFourCharType" />
+						<xsd:element name="Number" type="oneToTwentyCharType" />
   					</xsd:sequence>
   				</xsd:complexType>
   			</xsd:element>
   		</xsd:sequence>
-  		<xsd:attribute name="name" type="kfs:oneToFiftyCharType" />
+		<xsd:attribute name="name" type="oneToFiftyCharType" />
   	</xsd:complexType>
   </xsd:element>
 
   <xsd:element name="URL">
   	<xsd:complexType>
   		<xsd:simpleContent>
-  			<xsd:extension base="kfs:zeroToNinetyCharType">
-  				<xsd:attribute name="name" type="kfs:oneToFiftyCharType" />
+			<xsd:extension base="zeroToNinetyCharType">
+				<xsd:attribute name="name" type="oneToFiftyCharType" />
   			</xsd:extension>
   		</xsd:simpleContent>
   	</xsd:complexType>
@@ -161,16 +307,16 @@
   			<xsd:element ref="Fax" minOccurs="0" maxOccurs="unbounded" />
   			<xsd:element ref="URL" minOccurs="0" maxOccurs="unbounded" />
   		</xsd:sequence>
-  		<xsd:attribute name="role" type="kfs:oneToTwentyCharType" use="required" />
-  		<xsd:attribute name="addressID" type="kfs:zeroToTwentyCharType" use="optional" />
+		<xsd:attribute name="role" type="oneToTwentyCharType" use="required" />
+		<xsd:attribute name="addressID" type="zeroToTwentyCharType" use="optional" />
   	</xsd:complexType>
   </xsd:element>
 
   <xsd:element name="Extrinsic">
   	<xsd:complexType>
   		<xsd:simpleContent>
-  			<xsd:extension base="kfs:zeroToNinetyCharType"> <!-- It may have CDATA also -->
-  				<xsd:attribute name="name" type="kfs:zeroToFiftyFiveCharType" />
+			<xsd:extension base="zeroToNinetyCharType"> <!-- It may have CDATA also -->
+				<xsd:attribute name="name" type="zeroToFiftyFiveCharType" />
   			</xsd:extension>
   		</xsd:simpleContent>
   	</xsd:complexType>
@@ -189,8 +335,8 @@
   <xsd:element name="Money" default="0">
   	<xsd:complexType>
   		<xsd:simpleContent>
-  			<xsd:extension base="xsd:string"> <!-- since cdw3.xml contains 3703.7400000000002, declaring as string insteadof kfs:amountType -->
-  				<xsd:attribute name="currency" type="purap:currencyType" use="required" />
+			<xsd:extension base="xsd:string"> <!-- since cdw3.xml contains 3703.7400000000002, declaring as string insteadof amountType -->
+				<xsd:attribute name="currency" type="currencyType" use="required" />
   			</xsd:extension>
   		</xsd:simpleContent>
   	</xsd:complexType>
@@ -237,8 +383,8 @@
   						</xsd:element>
   						<xsd:element ref="Description" minOccurs="0" />
   					</xsd:sequence>
-  					<xsd:attribute name="purpose" type="kfs:oneToFiftyCharType" use="optional" />
-  					<xsd:attribute name="category" type="kfs:oneToFiftyCharType" use="required" />
+					<xsd:attribute name="purpose" type="oneToFiftyCharType" use="optional" />
+					<xsd:attribute name="category" type="oneToFiftyCharType" use="required" />
   					<xsd:attribute name="percentageRate" type="xsd:decimal" use="optional" />
   				</xsd:complexType>
   			</xsd:element>
@@ -253,15 +399,15 @@
   			<xsd:element name="DocumentReference" minOccurs="0" maxOccurs="1">
   				<xsd:complexType>
   					<xsd:simpleContent>
-  						<xsd:extension base="purap:idType">
-  							<xsd:attribute name="payloadID" type="purap:idType" />
+						<xsd:extension base="idType">
+							<xsd:attribute name="payloadID" type="idType" />
   						</xsd:extension>
   					</xsd:simpleContent>
   				</xsd:complexType>
   			</xsd:element>
   		</xsd:sequence>
-  		<xsd:attribute name="orderID" type="purap:idType" use="optional" />
-  		<xsd:attribute name="orderDate" type="purap:dateStringType" use="optional" />
+		<xsd:attribute name="orderID" type="idType" use="optional" />
+		<xsd:attribute name="orderDate" type="dateStringType" use="optional" />
   	</xsd:complexType>
   </xsd:element>
 
@@ -269,8 +415,8 @@
   	<xsd:complexType>
   		<xsd:simpleContent>
   			<xsd:extension base="xsd:string">
-  				<xsd:attribute name="agreementID" type="purap:idType" use="optional" />
-  				<xsd:attribute name="agreementDate" type="purap:dateStringType" use="optional" />
+				<xsd:attribute name="agreementID" type="idType" use="optional" />
+				<xsd:attribute name="agreementDate" type="dateStringType" use="optional" />
   			</xsd:extension>
   		</xsd:simpleContent>
   	</xsd:complexType>
@@ -280,8 +426,8 @@
   	<xsd:complexType>
   		<xsd:simpleContent>
   			<xsd:extension base="xsd:string">
-  				<xsd:attribute name="agreementID" type="purap:idType" use="required" />
-  				<xsd:attribute name="agreementDate" type="purap:dateStringType" use="optional" />
+				<xsd:attribute name="agreementID" type="idType" use="required" />
+				<xsd:attribute name="agreementDate" type="dateStringType" use="optional" />
   			</xsd:extension>
   		</xsd:simpleContent>
   	</xsd:complexType>
@@ -291,8 +437,8 @@
   	<xsd:complexType>
   		<xsd:simpleContent>
   			<xsd:extension base="xsd:string">
-  				<xsd:attribute name="orderID" type="purap:idType" use="required" />
-  				<xsd:attribute name="orderDate" type="purap:dateStringType" use="optional" />
+				<xsd:attribute name="orderID" type="idType" use="required" />
+				<xsd:attribute name="orderDate" type="dateStringType" use="optional" />
   			</xsd:extension>
   		</xsd:simpleContent>
   	</xsd:complexType>
@@ -302,7 +448,7 @@
   	<xsd:complexType>
   		<xsd:simpleContent>
   			<xsd:extension base="xsd:string">
-  				<xsd:attribute name="orderID" type="purap:idType" use="required" />
+				<xsd:attribute name="orderID" type="idType" use="required" />
   			</xsd:extension>
   		</xsd:simpleContent>
   	</xsd:complexType>
@@ -331,7 +477,7 @@
        				</xsd:complexType>
        			</xsd:element>
        		</xsd:sequence>
-       		<xsd:attribute name="shippingDate" type="purap:dateStringType" use="optional" />
+            <xsd:attribute name="shippingDate" type="dateStringType" use="optional" />
        	</xsd:complexType>
   </xsd:element>
     
@@ -363,7 +509,7 @@
   <xsd:element name="InvoiceDetailItem">
   	<xsd:complexType>
   		<xsd:sequence>
-  			<xsd:element name="UnitOfMeasure" type="purap:uomType" />
+			<xsd:element name="UnitOfMeasure" type="uomType" />
   			<xsd:element ref="UnitPrice" />
   			
   			<xsd:element name="InvoiceDetailItemReference">
@@ -373,8 +519,8 @@
   						<xsd:element name="ItemID" minOccurs="0">
   							<xsd:complexType>
   								<xsd:sequence>
-  									<xsd:element name="SupplierPartID" type="purap:catalogNumberType" />
-  									<xsd:element name="SupplierPartAuxiliaryID" type="purap:auxiliaryIDType" minOccurs="0"/>
+									<xsd:element name="SupplierPartID" type="catalogNumberType" />
+									<xsd:element name="SupplierPartAuxiliaryID" type="auxiliaryIDType" minOccurs="0"/>
   								</xsd:sequence>
   							</xsd:complexType>
   						</xsd:element>
@@ -383,11 +529,11 @@
   						
   						<xsd:choice minOccurs="0">
   							<xsd:sequence>
-  								<xsd:element name="ManufacturerPartID" type="purap:hundredCharsType" />
+								<xsd:element name="ManufacturerPartID" type="hundredCharsType" />
   								<xsd:element name="ManufacturerName">
   									<xsd:complexType>
   										<xsd:simpleContent>
-  											<xsd:extension base="purap:hundredCharsType">
+											<xsd:extension base="hundredCharsType">
   												<xsd:attribute ref="xml:lang" use="optional" />
   											</xsd:extension>
   										</xsd:simpleContent>
@@ -399,8 +545,8 @@
   						<xsd:element name="Country" minOccurs="0">
   							<xsd:complexType>
   								<xsd:simpleContent>
-  									<xsd:extension base="purap:addressType">
-  										<xsd:attribute name="isoCountryCode" type="kfs:oneToFourCharType" use="required" />
+									<xsd:extension base="addressType">
+										<xsd:attribute name="isoCountryCode" type="oneToFourCharType" use="required" />
   									</xsd:extension>
   								</xsd:simpleContent>
   							</xsd:complexType>
@@ -494,14 +640,14 @@
   					<xsd:sequence>
   						<xsd:element name="Classification" minOccurs="0" maxOccurs="unbounded">
   							<xsd:complexType>
-  								<xsd:attribute name="domain" type="kfs:oneToTenCharType" use="required" />
+								<xsd:attribute name="domain" type="oneToTenCharType" use="required" />
   							</xsd:complexType>
   						</xsd:element>
   						<xsd:element name="ItemID" minOccurs="0" maxOccurs="1">
   							<xsd:complexType>
   								<xsd:sequence>
-  									<xsd:element name="SupplierPartID" type="purap:catalogNumberType" />
-  									<xsd:element name="SupplierPartAuxiliaryID" type="purap:auxiliaryIDType" minOccurs="0" maxOccurs="1" />
+									<xsd:element name="SupplierPartID" type="catalogNumberType" />
+									<xsd:element name="SupplierPartAuxiliaryID" type="auxiliaryIDType" minOccurs="0" maxOccurs="1" />
   								</xsd:sequence>
   							</xsd:complexType>
   						</xsd:element><!-- ItemID -->
@@ -525,11 +671,11 @@
   						<xsd:complexType>
   							<xsd:sequence>
   								<xsd:element ref="Money" />
-  								<xsd:element name="UnitOfMeasure" type="purap:uomType" />
+								<xsd:element name="UnitOfMeasure" type="uomType" />
   								<xsd:element name="TermReference" minOccurs="0">
   									<xsd:complexType>
-  										<xsd:attribute name="termName" type="kfs:oneToTwentyCharType" use="required" />
-  										<xsd:attribute name="term" type="kfs:oneToTenCharType" use="required" />
+										<xsd:attribute name="termName" type="oneToTwentyCharType" use="required" />
+										<xsd:attribute name="term" type="oneToTenCharType" use="required" />
   									</xsd:complexType>
   								</xsd:element>
   							</xsd:sequence>
@@ -537,7 +683,7 @@
   					</xsd:element><!-- UnitRate -->
   				</xsd:sequence>
   				<xsd:sequence>
-  					<xsd:element name="UnitOfMeasure" type="purap:uomType" />
+					<xsd:element name="UnitOfMeasure" type="uomType" />
   					<xsd:element ref="UnitPrice" />
   				</xsd:sequence>
   			</xsd:choice>
@@ -585,7 +731,7 @@
                 <xsd:complexType>
                   <xsd:sequence>
                     <xsd:element ref="Credential"/>
-                    <xsd:element name="UserAgent" type="kfs:zeroToFiftyFiveCharType" />
+                    <xsd:element name="UserAgent" type="zeroToFiftyFiveCharType" />
                   </xsd:sequence>
                 </xsd:complexType>
               </xsd:element>
@@ -604,7 +750,7 @@
                           <xsd:element name="InvoiceDetailHeaderIndicator">
                             <xsd:complexType>
                               <xsd:simpleContent>
-                                <xsd:extension base="purap:emptyType">
+                                <xsd:extension base="emptyType">
                                   <xsd:attribute name="isHeaderInvoice" use="optional">
                                   	<xsd:simpleType>
 										<xsd:restriction base="xsd:string">
@@ -626,7 +772,7 @@
                           <xsd:element name="InvoiceDetailLineIndicator">
                             <xsd:complexType>
                               <xsd:simpleContent>
-                                <xsd:extension base="purap:emptyType">
+                                <xsd:extension base="emptyType">
                                   <xsd:attribute name="isTaxInLine" use="optional">
                                   	<xsd:simpleType>
 										<xsd:restriction base="xsd:string">
@@ -675,11 +821,11 @@
                                 <xsd:element name="IdReference" minOccurs="0">
                                   <xsd:complexType>
                                     <xsd:sequence>
-                                      <xsd:element name="Creator" type="kfs:zeroToTwentyCharType" minOccurs="0" />
+                                      <xsd:element name="Creator" type="zeroToTwentyCharType" minOccurs="0" />
                                       <xsd:element ref="Description" minOccurs="0"/>
                                     </xsd:sequence>
-                                    <xsd:attribute name="domain" type="kfs:zeroToTwentyCharType" use="required" />
-                                    <xsd:attribute name="identifier" type="kfs:zeroToTwentyCharType" use="required" />
+                                    <xsd:attribute name="domain" type="zeroToTwentyCharType" use="required" />
+                                    <xsd:attribute name="identifier" type="zeroToTwentyCharType" use="required" />
                                   </xsd:complexType>
                                 </xsd:element>
                               </xsd:sequence>
@@ -737,9 +883,9 @@
   						In vwr, it's like 2008-07-29 (Not valid)
   						In guybrown, it's 2008-07-29T12:00:00 (valid dateTime)
   						In fisher, it's 2008-07-25T00:00:00-08:00 (valid dateTime) -->
-                        <xsd:attribute name="invoiceDate" type="purap:dateStringType" use="required" />
+                        <xsd:attribute name="invoiceDate" type="dateStringType" use="required" />
                         <!-- Changed to String from unsignedint -->
-                        <xsd:attribute name="invoiceID" type="purap:idType" use="required" />
+                        <xsd:attribute name="invoiceID" type="idType" use="required" />
                         <xsd:attribute name="isInformationOnly" use="optional">
                         	<xsd:simpleType>
 								<xsd:restriction base="xsd:string">


### PR DESCRIPTION
Includes:
modified b2bPOResponse.xsd
modified b2bPunchOutOrder.xsd
modified electronicInvoice.xsd
These modifications were to copy the various simple data types used since ANT is no longer used to build or deploy KFS.

overrode the b2b.punch.back.action.forwarding.url property in the institutional-config.properties file to a working value.
create the b2b.purchase.order.dtd property in the institutional-config.properties file to contain the path for the PO.dtd file.
Copied the B2BPurchaseOrderSciquestServiceImpl#getCxml() as into an edu.arizona B2BPurchaseOrderSciquestServiceImpl and made appropriate spring changes.
Added code to updating the path of the PO.dtd if the value of b2b.purchase.order.dtd is populated. (made a notation where this changes were made)
changed the reference of a private variable in the org.kuali B2BPurchaseOrderSciquestServiceImpl to use its getter. (made a notation where this changes were made)

This pull request is being created because the original pull request (#196) was accidentally removed from the ua-development branch. The XSD files from the previous pull request have not been modified since that PR.