### PR TITLE
UAF-3611

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/tax/document/web/struts/PayeeSearchForm.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/tax/document/web/struts/PayeeSearchForm.java
@@ -1,8 +1,8 @@
 package edu.arizona.kfs.tax.document.web.struts;
 
-import org.kuali.kfs.sys.web.struts.KualiAccountingDocumentFormBase;
+import org.kuali.rice.kns.web.struts.form.KualiForm;
 
-public class PayeeSearchForm extends KualiAccountingDocumentFormBase {
+public class PayeeSearchForm extends KualiForm {
 
 	private Integer taxYear;
 	private String headerTaxNumber;

--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/web/struts/PayeeSearchAction.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/web/struts/PayeeSearchAction.java
@@ -1,0 +1,92 @@
+package edu.arizona.kfs.module.purap.document.web.struts;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.log4j.Logger;
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.rice.kim.api.role.Role;
+import org.kuali.rice.kim.api.role.RoleService;
+import org.kuali.rice.krad.util.GlobalVariables;
+import org.kuali.rice.kns.web.struts.action.KualiAction;
+import org.kuali.rice.kim.api.services.KimApiServiceLocator;
+import org.kuali.rice.krad.exception.AuthorizationException;
+import org.kuali.rice.krad.util.KRADConstants;
+import org.kuali.rice.kim.api.KimConstants;
+
+import edu.arizona.kfs.tax.TaxConstants;
+import edu.arizona.kfs.tax.TaxPropertyConstants;
+import edu.arizona.kfs.tax.businessobject.Payee;
+import edu.arizona.kfs.tax.businessobject.Payer;
+import edu.arizona.kfs.tax.document.web.struts.PayeeSearchForm;
+import edu.arizona.kfs.sys.KFSConstants;
+import edu.arizona.kfs.sys.KFSKeyConstants;
+import edu.arizona.kfs.module.purap.service.TaxReporting1099Service;
+
+public class PayeeSearchAction extends KualiAction {
+    private static final Logger LOG = Logger.getLogger(PayeeSearchAction.class);
+    
+    public ActionForward searchPayees(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+    	RoleService roleService = KimApiServiceLocator.getRoleService();
+        
+        Role role = roleService.getRoleByNamespaceCodeAndName(TaxConstants.NMSPC_CD, TaxConstants.TAX_USER_ROLE);
+        // Protective guard for null condition which should never happen
+        if (role == null) {
+            LOG.error("System expected to find a role named " + TaxConstants.TAX_USER_ROLE + " under the " + TaxConstants.NMSPC_CD + " namespace, but it was not found.");
+            throw new IllegalStateException("System expected to find a role named " + TaxConstants.TAX_USER_ROLE + " under the " + TaxConstants.NMSPC_CD + " namespace, but it was not found.");
+        } 
+
+        boolean hasRole  = roleService.principalHasRole(GlobalVariables.getUserSession().getPerson().getPrincipalId(), Collections.singletonList(role.getId()), null);
+        
+        if(hasRole) {
+            PayeeSearchForm pform = (PayeeSearchForm)form;
+            
+            TaxReporting1099Service payeeServ = SpringContext.getBean(TaxReporting1099Service.class);
+    
+            Payer p = payeeServ.getDefaultPayer();
+            
+            if( p == null ) {
+                GlobalVariables.getMessageMap().putError(TaxPropertyConstants.TAX_YEAR, KFSKeyConstants.ERROR_CUSTOM, "No 1099 Payer Record Found");
+            } else {
+                List <Payee> payees  = payeeServ.searchPayees(pform);
+                
+                if ((payees != null) && !payees.isEmpty()) {
+                    request.setAttribute(KFSConstants.REQUEST_SEARCH_RESULTS, payees);
+                    request.setAttribute(KFSConstants.REQUEST_SEARCH_RESULTS_SIZE, payees.size());
+                } else {
+                    GlobalVariables.getMessageMap().putError(TaxPropertyConstants.TAX_YEAR, KFSKeyConstants.ERROR_CUSTOM, "No 1099 Payees Found");
+                }
+            }
+        } else {
+            GlobalVariables.getMessageMap().putError(TaxPropertyConstants.TAX_YEAR, KFSKeyConstants.ERROR_CUSTOM, "User Not Authorized");
+        }
+        
+        return mapping.findForward(KFSConstants.MAPPING_BASIC);
+    }
+    
+    public ActionForward returnToIndex(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        return mapping.findForward(KFSConstants.MAPPING_CLOSE);
+    }
+    
+    @Override
+    protected void checkAuthorization( ActionForm form, String methodToCall) throws AuthorizationException {
+        String principalId = GlobalVariables.getUserSession().getPrincipalId();
+        Map<String, String> roleQualifier = new HashMap<String, String>(getRoleQualification(form, methodToCall));
+        Map<String, String> permissionDetails = new HashMap<String, String>();
+        permissionDetails.put(KRADConstants.NAMESPACE_CODE, TaxConstants.NMSPC_CD);
+        permissionDetails.put(KRADConstants.ACTION_CLASS, this.getClass().getName());
+        
+        if (!KimApiServiceLocator.getPermissionService().isAuthorizedByTemplate(principalId,
+                KRADConstants.KNS_NAMESPACE, KimConstants.PermissionTemplateNames.USE_SCREEN, permissionDetails, roleQualifier)) {
+            throw new AuthorizationException(GlobalVariables.getUserSession().getPerson().getPrincipalName(), methodToCall, this.getClass().getSimpleName());
+        }
+    }
+}

--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/web/struts/TaxFormAction.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/web/struts/TaxFormAction.java
@@ -1,0 +1,42 @@
+package edu.arizona.kfs.module.purap.document.web.struts;
+
+import java.io.ByteArrayOutputStream;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.KFSConstants.ReportGeneration;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.rice.kns.util.WebUtils;
+import org.kuali.rice.kns.web.struts.action.KualiAction;
+
+import edu.arizona.kfs.module.purap.service.TaxReporting1099Service;
+
+
+public class TaxFormAction extends KualiAction {
+
+    public ActionForward downloadTaxForm(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        Integer id = Integer.valueOf(request.getParameter("id"));
+        String year = request.getParameter("year");
+        
+        TaxReporting1099Service taxReportingService = SpringContext.getBean(TaxReporting1099Service.class);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        
+        byte[] pdf = taxReportingService.getPayee1099Form(id, year);
+        
+        if ((pdf != null) && (pdf.length > 0)) {
+            baos.write(pdf);
+            WebUtils.saveMimeOutputStreamAsFile(response, ReportGeneration.PDF_MIME_TYPE, baos, "f1099msc" + ReportGeneration.PDF_FILE_EXTENSION);
+        }
+        
+        return null;
+    }
+    
+    public ActionForward returnToIndex(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        return mapping.findForward(KFSConstants.MAPPING_CLOSE);
+    }
+}

--- a/kfs-purap/src/main/resources/edu/arizona/kfs/module/purap/spring-purap.xml
+++ b/kfs-purap/src/main/resources/edu/arizona/kfs/module/purap/spring-purap.xml
@@ -182,6 +182,7 @@
 		<property name="businessObjectService" ref="businessObjectService" />
 		<property name="parameterService" ref="parameterService" />
 		<property name="taxReporting1099Dao" ref="taxReporting1099Dao" />
+		<property name="pdfDirectory" value="${staging.directory}/tax/pdf"/>
 		<property name="documentIncomeTypeSet">
 			<set>
 				<value>CM</value>

--- a/kfs-web/src/main/webapp/WEB-INF/struts-config.xml
+++ b/kfs-web/src/main/webapp/WEB-INF/struts-config.xml
@@ -342,7 +342,11 @@
 
         <!-- VND Module Bean Definitions -->
 	    <form-bean name="VendorExclusionForm"
-			type="org.kuali.kfs.vnd.web.struts.VendorExclusionForm" />     			
+			type="org.kuali.kfs.vnd.web.struts.VendorExclusionForm" />     
+			
+		<!--  Tax Form -->
+        <form-bean name="PayeeSearchForm"
+            type="edu.arizona.kfs.tax.document.web.struts.PayeeSearchForm" />
 	</form-beans>
 
 	<global-exceptions>
@@ -1057,6 +1061,21 @@
 			type="org.kuali.rice.kns.web.struts.action.KualiSimpleAction">
 			<forward name="basic" path="/jsp/sys/SessionExpiration.jsp" />
 		</action>
+		
+		<action path="/tax*" name="{1}Form"
+            input="/jsp/tax/{1}.jsp"
+            type="edu.arizona.kfs.module.purap.document.web.struts.{1}Action"
+            scope="request" parameter="methodToCall" validate="true"
+            attribute="KualiForm">
+            <set-property property="cancellable" value="true" />
+            <forward name="basic" path="/jsp/tax/{1}.jsp" />
+        </action>
+        
+        <action path="/downloadTaxForm" name="KualiForm"
+			type="edu.arizona.kfs.module.purap.document.web.struts.TaxFormAction"
+			scope="request" parameter="methodToCall" validate="false" attribute="KualiForm">
+		</action>
+        
 
 	</action-mappings>
 

--- a/kfs-web/src/main/webapp/WEB-INF/tags/portal/channel/centralAdmin/administrativeTransactions.tag
+++ b/kfs-web/src/main/webapp/WEB-INF/tags/portal/channel/centralAdmin/administrativeTransactions.tag
@@ -40,6 +40,7 @@
 		<li><portal:portalLink displayTitle="true" title="Payee"   url="${ConfigProperties.application.url}/kr/lookup.do?methodToCall=start&businessObjectClassName=edu.arizona.kfs.tax.businessobject.Payee&docFormKey=88888888&returnLocation=${ConfigProperties.application.url}/portal.do&hideReturnLink=true" /></li>
 		<li><portal:portalLink displayTitle="true" title="Payment" url="${ConfigProperties.application.url}/kr/lookup.do?methodToCall=start&businessObjectClassName=edu.arizona.kfs.tax.businessobject.Payment&docFormKey=88888888&returnLocation=${ConfigProperties.application.url}/portal.do&hideReturnLink=true" /></li>
 		<li><portal:portalLink displayTitle="true" title="Extract History" url="${ConfigProperties.application.url}/kr/lookup.do?methodToCall=start&businessObjectClassName=edu.arizona.kfs.tax.businessobject.ExtractHistory&docFormKey=88888888&returnLocation=${ConfigProperties.application.url}/portal.do&hideReturnLink=true" /></li>
+		<li><portal:portalLink displayTitle="true" title="Payee 1099 Forms" url="${ConfigProperties.application.url}/taxPayeeSearch.do" /></li>
 	</ul>
 </div>
 <channel:portalChannelBottom />

--- a/kfs-web/src/main/webapp/jsp/tax/PayeeSearch.jsp
+++ b/kfs-web/src/main/webapp/jsp/tax/PayeeSearch.jsp
@@ -1,0 +1,98 @@
+<%@ include file="/jsp/sys/kfsTldHeader.jsp"%>
+
+<kul:page showDocumentInfo="false"
+	headerTitle="Payee 1099 Forms" docTitle="Payee 1099 Forms" renderMultipart="false"
+	transactionalDocument="false" htmlFormAction="taxPayeeSearch" errorKey="foo" showTabButtons="true">
+	
+	<html-el:hidden property="methodToCall" />
+
+	<table width="100%" border="0">
+	<tr><td>	
+		<kul:errors keyMatch="*" errorTitle="Errors Found On Page:"/>
+	</td></tr>
+	</table>  
+	
+	</br>
+
+	<kul:tabTop tabTitle="Run Search" defaultOpen="true" tabErrorKey="">
+
+	    <div class="tab-container" align="center">
+			<h3>Payee Search Parameters</h3>
+
+	      	<table width="100%" cellpadding="0" cellspacing="0" class="datatable">
+			<tr>
+				<th class="grid" width="50%" align="right">Tax Year:</th>
+		      	<td class="grid" width="50%">
+					<html:text property="taxYear" size="4" />
+				</td>
+			</tr>
+			<tr>
+				<th class="grid" width="50%" align="right">Tax Number:</th>
+		      	<td class="grid" width="50%">
+					<html:text property="headerTaxNumber" size="9" />
+				</td>
+			</tr>
+			<tr>
+				<th class="grid" width="50%" align="right">Vendor Number:</th>
+		      	<td class="grid" width="50%">
+					<html:text property="vendorNumber" size="20" />
+				</td>
+			</tr>
+			<tr>
+				<th class="grid" width="50%" align="right">Vendor Name:</th>
+		      	<td class="grid" width="50%">
+					<html:text property="vendorName" size="40" />
+				</td>
+			</tr>
+			</table>
+		</div>
+
+	</kul:tabTop>
+
+	<kul:panelFooter />
+
+    <div id="globalbuttons" class="globalbuttons">
+		<html:image src="${ConfigProperties.kr.externalizable.images.url}buttonsmall_submit.gif" styleClass="globalbuttons" property="methodToCall.searchPayees" title="submit" alt="submit" onclick="excludeSubmitRestriction=true"/>
+        <html:image src="${ConfigProperties.kr.externalizable.images.url}buttonsmall_close.gif"  styleClass="globalbuttons" property="methodToCall.returnToIndex" title="close"  alt="close"/>
+    </div>
+
+	<c:if test="${!empty reqSearchResults }">
+		<c:set var="offset" value="0" />
+
+		<display:table class="datatable-100" cellspacing="0" cellpadding="0" name="${reqSearchResults}" id="row" export="false" pagesize="100" offset="${offset}" requestURI="taxPayeeSearch.do">
+
+		<display:column class="infocell" title="Actions" sortable="false">					
+			<a href="downloadTaxForm.do?methodToCall=downloadTaxForm&id=${row.id}&year=${row.taxYear}">download</a>
+		</display:column>
+
+		<display:column class="infocell" title="Vendor Name" sortable="true">					
+			<c:out value="${row.vendorName}" />
+		</display:column>
+
+		<display:column class="infocell" title="Vendor Number" sortable="true">					
+			<c:out value="${row.vendorNumber}" />
+		</display:column>
+
+		<display:column class="infocell" title="Vendor Type" sortable="true">					
+			<c:out value="${row.headerTypeCode}" />
+		</display:column>
+
+		<display:column class="infocell" title="Ownership Code" sortable="true">					
+			<c:out value="${row.headerOwnershipCode}" />
+		</display:column>
+
+		<display:column class="infocell" title="Ownership Category Code" sortable="true">					
+			<c:out value="${row.headerOwnershipCategoryCode}" />
+		</display:column>
+
+		<display:column class="infocell" title="Tax Year" sortable="true">					
+			<c:out value="${row.taxYear}" />
+		</display:column>
+
+		<display:column class="numbercell" title="Amount" sortable="true">					
+			<c:out value="${row.taxAmount}" />
+		</display:column>
+
+		</display:table>
+	</c:if>
+</kul:page>


### PR DESCRIPTION
Modified PayeeSearchForm.java to extend KualiForm instead of KualiAccountingDocumentFormBase. This is how it is done in KFS 3.0 and I was getting this error: user 'kruser' is not authorized to take action 'null' on targets of type 'PayeeSearchAction'.
Added new file PayeeSearchAction.java. I removed private methods getIdentityManagementService, getParameterService, readTotalTaxAmount, and returnToIndex because they are never used. Overrode the checkAuthorization method so the permissionDetails uses the correct namespace code of KFS-TAX instead of KFS-PURAP. Throw an exception in searchPayees method if the role is null, otherwise there will be a null pointer exception when calculating principalHasRole.
Added new file TaxFormAction.java which is used for downloading the tax form on Payee 1099 Forms search.
Modified spring-purap.xml to add the pdfDirectory. This is where the templates are stored for downloading the tax form on Payee 1099 Forms search.
Modified struts-config.xml to use the files PayeeSearchForm.java, PayeeSearch.jsp, PayeeSearchAction.java, and TaxFormAction.java
Modified administrativeTransactions.tag to add the Payee 1099 Forms portal link
Added new file PayeeSearch.jsp, the GUI for the Payee 1099 Forms page.