### PR TITLE
UAF-69 / UAF-3858 Fix Inadvertently Removed PURAP Batch Jobs & Batch File Directories

### DIFF
--- a/kfs-purap/src/main/resources/edu/arizona/kfs/module/purap/spring-purap.xml
+++ b/kfs-purap/src/main/resources/edu/arizona/kfs/module/purap/spring-purap.xml
@@ -26,16 +26,16 @@
             </list>
         </property>
         <property name="jobNames">
-        	<list>
-        		<value>payeeMasterExtractJob</value>
-        	</list>
+            <list merge="true">
+                <value>payeeMasterExtractJob</value>
+            </list>
         </property>
         <property name="batchFileDirectories">
-          <list>
-            <value>${staging.directory}/1099</value>
-            <value>${reports.directory}/tax</value>
-            <value>${staging.directory}/tax</value>
-          </list>
+            <list merge="true">
+                <value>${staging.directory}/1099</value>
+                <value>${reports.directory}/tax</value>
+                <value>${staging.directory}/tax</value>
+            </list>
         </property>
 	</bean>
 


### PR DESCRIPTION
This changes the <list> to <list merge="true"> on the "jobNames" and "batchFileDirectories" properties (along with code-style spacing of the affected lines)