### PR TITLE
UAF-3209 Update Asset Status Code for Retired Assets

### DIFF
--- a/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/businessobject/AssetRetirementGlobal.java
+++ b/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/businessobject/AssetRetirementGlobal.java
@@ -1,0 +1,46 @@
+package edu.arizona.kfs.module.cam.businessobject;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+
+import org.kuali.kfs.module.cam.businessobject.Asset;
+import org.kuali.kfs.module.cam.document.service.AssetRetirementService;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.rice.krad.bo.PersistableBusinessObject;
+import org.kuali.rice.coreservice.framework.parameter.ParameterService;
+
+public class AssetRetirementGlobal extends org.kuali.kfs.module.cam.businessobject.AssetRetirementGlobal {
+    private static final String VALID_ASSET_RETIREMENT_STATUSES_BY_ASSET_STATUS = "VALID_ASSET_RETIREMENT_STATUSES_BY_ASSET_STATUS";
+    
+    @Override
+    protected void setAssetForPersist(Asset asset, List<PersistableBusinessObject> persistables, AssetRetirementService retirementService) {
+        String invStatusCode = asset.getInventoryStatusCode();
+        super.setAssetForPersist(asset, persistables, retirementService);
+        ParameterService parameterService = SpringContext.getBean(ParameterService.class);
+
+        //Look up parameter to see the new status to use
+        Map<String, String> inventoryStatusMap = new HashMap<String, String>();
+        Collection<String> wholeValues = parameterService.getParameterValuesAsString(AssetRetirementGlobal.class, VALID_ASSET_RETIREMENT_STATUSES_BY_ASSET_STATUS);
+
+        for (String wholeValue : wholeValues) {
+            String[] tokens = wholeValue.split("=");
+            String valueStr = tokens[0];
+
+            String values = tokens[1];
+            String[] valueTokens = values.split(",");
+            for (String str : valueTokens) {
+                String keyValue = str;
+                inventoryStatusMap.put(keyValue, valueStr);
+            }
+        }
+        
+        String newInvStatusCode = inventoryStatusMap.get(invStatusCode);
+        if(StringUtils.isNotBlank(newInvStatusCode)) {
+            asset.setInventoryStatusCode(newInvStatusCode);
+        }
+    }
+}

--- a/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/businessobject/lookup/AssetRetirementReasonLookupableHelperServiceImpl.java
+++ b/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/businessobject/lookup/AssetRetirementReasonLookupableHelperServiceImpl.java
@@ -1,0 +1,19 @@
+package edu.arizona.kfs.module.cam.businessobject.lookup;
+
+import java.util.List;
+import java.util.Properties;
+
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.rice.kns.document.authorization.BusinessObjectRestrictions;
+import org.kuali.rice.kns.lookup.HtmlData;
+import org.kuali.rice.kns.web.struts.form.LookupForm;
+import org.kuali.rice.krad.bo.BusinessObject;
+
+public class AssetRetirementReasonLookupableHelperServiceImpl extends org.kuali.kfs.module.cam.businessobject.lookup.AssetRetirementReasonLookupableHelperServiceImpl {
+    
+    @Override
+    protected HtmlData getReturnAnchorHtmlData(BusinessObject businessObject, Properties parameters, LookupForm lookupForm, List returnKeys, BusinessObjectRestrictions businessObjectRestrictions) {
+        parameters.put(KFSConstants.BUSINESS_OBJECT_CLASS_ATTRIBUTE, edu.arizona.kfs.module.cam.businessobject.AssetRetirementGlobal.class.getName());
+        return super.getReturnAnchorHtmlData(businessObject, parameters, lookupForm, returnKeys, businessObjectRestrictions);
+    }
+}

--- a/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/businessobject/datadictionary/AssetRetirementGlobal.xml
+++ b/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/businessobject/datadictionary/AssetRetirementGlobal.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?><beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p" xmlns:dd="http://rice.kuali.org/dd" xsi:schemaLocation=" http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd http://rice.kuali.org/dd http://rice.kuali.org/dd/dd.xsd">
+
+  <bean id="AssetRetirementGlobal" parent="AssetRetirementGlobal-parentBean">
+    <property name="businessObjectClass" value="edu.arizona.kfs.module.cam.businessobject.AssetRetirementGlobal"/>
+    <property name="objectLabel" value="Asset Retirement Global"/>
+  </bean>
+  
+</beans>

--- a/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/document/datadictionary/AssetRetirementGlobalMaintenanceDocument.xml
+++ b/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/document/datadictionary/AssetRetirementGlobalMaintenanceDocument.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?><beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p" xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+  <bean id="AssetRetirementGlobalMaintenanceDocument" parent="AssetRetirementGlobalMaintenanceDocument-parentBean">
+    <property name="businessObjectClass" value="edu.arizona.kfs.module.cam.businessobject.AssetRetirementGlobal"/>
+    <property name="documentTypeName" value="ARG"/>
+  </bean>
+  
+</beans>

--- a/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/ojb-cam.xml
+++ b/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/ojb-cam.xml
@@ -1,0 +1,57 @@
+<descriptor-repository version="1.0">
+	<class-descriptor class="edu.arizona.kfs.module.cam.businessobject.AssetRetirementGlobal" table="CM_AST_RETIRE_DOC_T">
+	    <field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" index="true"/>
+	    <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true"/>
+	    <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true"/>
+	    <field-descriptor name="mergedTargetCapitalAssetNumber" column="MERGED_TGT_CPTLAST_NBR" jdbc-type="BIGINT"/>
+	    <field-descriptor name="retirementReasonCode" column="AST_RETIRE_REAS_CD" jdbc-type="VARCHAR" index="true"/>
+	    <field-descriptor name="retirementDate" column="CPTLAST_RETIRE_DT" jdbc-type="DATE"/>
+	    <field-descriptor name="mergedTargetCapitalAssetDescription" column="MERGED_TGT_CPTLAST_DESC" jdbc-type="VARCHAR"/>
+	    <field-descriptor name="retirementChartOfAccountsCode" column="AST_RETIR_COA_CD" jdbc-type="VARCHAR"/>
+	    <field-descriptor name="retirementAccountNumber" column="AST_RETIR_ACCT_NBR" jdbc-type="VARCHAR"/>
+	    <field-descriptor name="retirementContactName" column="AST_RETIR_CNTCT_NM" jdbc-type="VARCHAR"/>
+	    <field-descriptor name="retirementInstitutionName" column="AST_RETIR_INST_NM" jdbc-type="VARCHAR"/>
+	    <field-descriptor name="retirementStreetAddress" column="AST_RETIRSTRT_ADDR" jdbc-type="VARCHAR"/>
+	    <field-descriptor name="retirementCityName" column="AST_RETIR_CITY_NM" jdbc-type="VARCHAR"/>
+	    <field-descriptor name="retirementStateCode" column="AST_RETIR_STATE_CD" jdbc-type="VARCHAR"/>
+	    <field-descriptor name="retirementZipCode" column="AST_RETIR_ZIP_CD" jdbc-type="VARCHAR"/>
+	    <field-descriptor name="retirementCountryCode" column="AST_RETIR_CNTRY_CD" jdbc-type="VARCHAR"/>
+	    <field-descriptor name="retirementPhoneNumber" column="AST_RETIR_PHN_NBR" jdbc-type="VARCHAR"/>
+	    <field-descriptor name="estimatedSellingPrice" column="AST_EST_SELL_PRC" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
+	    <field-descriptor name="salePrice" column="CPTLAST_SALE_PRC" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
+	    <field-descriptor name="cashReceiptFinancialDocumentNumber" column="CASH_RCPT_FDOC_NBR" jdbc-type="VARCHAR"/>
+	    <field-descriptor name="handlingFeeAmount" column="AST_HANDLG_FEE_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
+	    <field-descriptor name="preventiveMaintenanceAmount" column="AST_PRVNTMAINT_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion"/>
+	    <field-descriptor name="buyerDescription" column="CPTLAST_BUYER_DESC" jdbc-type="VARCHAR"/>
+	    <field-descriptor name="paidCaseNumber" column="AST_PD_CASE_NBR" jdbc-type="VARCHAR"/>
+	
+	    <reference-descriptor name="documentHeader" class-ref="org.kuali.kfs.sys.businessobject.FinancialSystemDocumentHeader" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" >
+	        <foreignkey field-ref="documentNumber" />
+	    </reference-descriptor>
+	    <reference-descriptor name="mergedTargetCapitalAsset" class-ref="org.kuali.kfs.module.cam.businessobject.Asset" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" >
+	        <foreignkey field-ref="mergedTargetCapitalAssetNumber" />
+	    </reference-descriptor>
+	    <reference-descriptor name="retirementReason" class-ref="org.kuali.kfs.module.cam.businessobject.AssetRetirementReason" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" >
+	        <foreignkey field-ref="retirementReasonCode" />
+	    </reference-descriptor>
+	    <collection-descriptor name="assetRetirementGlobalDetails" element-class-ref="org.kuali.kfs.module.cam.businessobject.AssetRetirementGlobalDetail" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-delete="object" auto-update="object" proxy="true">
+	        <orderby name="capitalAssetNumber" sort="ASC" />
+	        <inverse-foreignkey field-ref="documentNumber" />       
+	    </collection-descriptor>
+	    <reference-descriptor name="retirementAccount" class-ref="org.kuali.kfs.coa.businessobject.Account" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" >
+	        <foreignkey field-ref="retirementChartOfAccountsCode" />
+	        <foreignkey field-ref="retirementAccountNumber" />
+	    </reference-descriptor>
+	    <reference-descriptor name="retirementChartOfAccounts" class-ref="org.kuali.kfs.coa.businessobject.Chart" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" >
+	        <foreignkey field-ref="retirementChartOfAccountsCode" />
+	    </reference-descriptor>
+	    <reference-descriptor name="cashReceiptFinancialDocument" class-ref="org.kuali.kfs.sys.businessobject.FinancialSystemDocumentHeader" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true" >
+	        <foreignkey field-ref="cashReceiptFinancialDocumentNumber" />
+	    </reference-descriptor>
+	    <!-- General ledger entries  -->
+	    <collection-descriptor name="generalLedgerPendingEntries" proxy="true" element-class-ref="org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntry" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-update="object" auto-delete="object">
+	        <orderby name="transactionLedgerEntrySequenceNumber" sort="ASC" />
+	        <inverse-foreignkey field-ref="documentNumber" />
+	    </collection-descriptor>
+	</class-descriptor>
+</descriptor-repository>

--- a/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/spring-cam.xml
+++ b/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/spring-cam.xml
@@ -21,6 +21,12 @@
         <property name="dataDictionaryPackages">
             <list merge="true">
                 <value>classpath:edu/arizona/kfs/module/cam/document/datadictionary/*.xml</value>
+                <value>classpath:edu/arizona/kfs/module/cam/businessobject/datadictionary/*.xml</value>
+            </list>
+        </property>
+        <property name="databaseRepositoryFilePaths">
+            <list merge="true">
+                <value>edu/arizona/kfs/module/cam/ojb-cam.xml</value>
             </list>
         </property>
     </bean>
@@ -38,5 +44,7 @@
     	<property name="paymentSummaryService" ref="paymentSummaryService" />
     	<property name="businessObjectService" ref="businessObjectService" />
     </bean>
-
+    
+    <bean id="assetRetirementReasonLookupableHelperService" scope="prototype" parent="assetRetirementReasonLookupableHelperService-parentBean" class="edu.arizona.kfs.module.cam.businessobject.lookup.AssetRetirementReasonLookupableHelperServiceImpl"/>
+    
 </beans>


### PR DESCRIPTION
Added new file AssetRetirementGlobal.java to override the setAssetForPersist method where the asset Status Code is set.
Added new file AssetRetirementReasonLookupableHelperServiceImpl.java to override the getReturnAnchorHtmlData method. This changes the businessObjectClassName of the href in the 'return value' link on the Asset Retirement Reason Lookup from the org/kuali to edu/arizona version of the AssetRetirementGlobal class.
Added new files AssetRetirementGlobal.xml and AssetRetirementGlobalMaintenanceDocument.xml to use the new edu/arizona version of the AssetRetirementGlobal class.
Added new file ojb-cam.xml to add a database mapping for the edu/arizona version of AssetRetirementGlobal.
Modified spring-cam.xml to point to the new files that were created.