### PR TITLE
UAF-2419 B2B Shop Catalog Receiving/Direct Ship

### DIFF
--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/PurapConstants.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/PurapConstants.java
@@ -6,5 +6,7 @@ public class PurapConstants extends org.kuali.kfs.module.purap.PurapConstants {
     
     // Add New Search Fields to DV, PREQ and CM Documents 
     public static final String INCOME_TYPE_NON_REPORTABLE_CODE = "NR";
+    
+    public static final String B2B_DIRECT_SHIP_ROUTE_CODES_PARM = "B2B_DIRECT_SHIP_ROUTE_CODE";
 
 }

--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/authorization/PurchaseOrderAmendmentDocumentPresentationController.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/authorization/PurchaseOrderAmendmentDocumentPresentationController.java
@@ -1,0 +1,69 @@
+package edu.arizona.kfs.module.purap.document.authorization;
+
+import java.util.Set;
+
+import org.kuali.kfs.module.purap.PurapParameterConstants;
+import org.kuali.kfs.module.purap.PurapAuthorizationConstants.PurchaseOrderEditMode;
+import org.kuali.kfs.module.purap.PurapAuthorizationConstants.RequisitionEditMode;
+import org.kuali.kfs.module.purap.PurapConstants.PurchaseOrderStatuses;
+import org.kuali.kfs.module.purap.document.PurchaseOrderDocument;
+import org.kuali.kfs.module.purap.document.PurchasingAccountsPayableDocument;
+import org.kuali.kfs.module.purap.document.service.PurapService;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.kfs.sys.service.impl.KfsParameterConstants;
+
+import org.kuali.rice.krad.document.Document;
+import org.kuali.rice.coreservice.framework.parameter.ParameterService;
+import org.kuali.rice.kew.api.WorkflowDocument;
+
+public class PurchaseOrderAmendmentDocumentPresentationController extends org.kuali.kfs.module.purap.document.authorization.PurchaseOrderAmendmentDocumentPresentationController {
+
+    @Override
+    public Set<String> getEditModes(Document document) {
+        Set<String> editModes = super.getEditModes(document);
+        PurchaseOrderDocument poDocument = (PurchaseOrderDocument) document;
+
+        if (PurchaseOrderStatuses.APPDOC_CHANGE_IN_PROCESS.equals(poDocument.getApplicationDocumentStatus())) {
+            WorkflowDocument workflowDoc = document.getDocumentHeader().getWorkflowDocument();
+            // amendment doc needs to lock its field for initiator while enroute
+            if (workflowDoc.isInitiated() || workflowDoc.isSaved()) {
+                editModes.add(PurchaseOrderEditMode.AMENDMENT_ENTRY);
+            }
+        }
+        if (PurchaseOrderStatuses.APPDOC_AWAIT_NEW_UNORDERED_ITEM_REVIEW.equals(poDocument.getApplicationDocumentStatus())) {
+            editModes.add(PurchaseOrderEditMode.AMENDMENT_ENTRY);
+        }
+
+        if (SpringContext.getBean(PurapService.class).isDocumentStoppedInRouteNode((PurchasingAccountsPayableDocument) document, "New Unordered Items")) {
+            editModes.add(PurchaseOrderEditMode.UNORDERED_ITEM_ACCOUNT_ENTRY);
+        }
+
+        //make clear tax button always available like REQS
+        boolean salesTaxInd = SpringContext.getBean(ParameterService.class).getParameterValueAsBoolean(KfsParameterConstants.PURCHASING_DOCUMENT.class, PurapParameterConstants.ENABLE_SALES_TAX_IND);
+        if (salesTaxInd) {
+            editModes.add(PurchaseOrderEditMode.CLEAR_ALL_TAXES);
+        }
+
+        if (isAccountNode(document)) {
+            editModes.add(RequisitionEditMode.RESTRICT_FISCAL_ENTRY);
+        }
+
+        return editModes;
+    }
+
+
+    /**
+     * determine whether the current route node is account
+     * 
+     * @param document the given POA document
+     * @return true if the current route node is account
+     */
+    protected boolean isAccountNode(Document document) {
+        WorkflowDocument workflowDocument = document.getDocumentHeader().getWorkflowDocument();
+
+        Set<String> currentRouteLevels = workflowDocument.getNodeNames();
+
+        return workflowDocument.isEnroute() && currentRouteLevels.contains(KFSConstants.RouteLevelNames.ACCOUNT);
+    }
+}

--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/authorization/PurchaseOrderDocumentPresentationController.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/authorization/PurchaseOrderDocumentPresentationController.java
@@ -1,0 +1,26 @@
+package edu.arizona.kfs.module.purap.document.authorization;
+
+import java.util.Set;
+
+import org.kuali.kfs.module.purap.PurapAuthorizationConstants.PurchaseOrderEditMode;
+import org.kuali.kfs.module.purap.PurapParameterConstants;
+import org.kuali.kfs.sys.service.impl.KfsParameterConstants;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.rice.krad.document.Document;
+import org.kuali.rice.coreservice.framework.parameter.ParameterService;
+
+public class PurchaseOrderDocumentPresentationController extends org.kuali.kfs.module.purap.document.authorization.PurchaseOrderDocumentPresentationController {
+    
+    @Override
+    public Set<String> getEditModes(Document document) {
+        Set<String> editModes = super.getEditModes(document);
+        
+        //make clear tax button always available like REQS
+        boolean salesTaxInd = SpringContext.getBean(ParameterService.class).getParameterValueAsBoolean(KfsParameterConstants.PURCHASING_DOCUMENT.class, PurapParameterConstants.ENABLE_SALES_TAX_IND);
+        if (salesTaxInd) {
+            editModes.add(PurchaseOrderEditMode.CLEAR_ALL_TAXES);
+        }
+        
+        return editModes;
+    }
+}

--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/authorization/RequisitionDocumentPresentationController.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/authorization/RequisitionDocumentPresentationController.java
@@ -1,0 +1,67 @@
+package edu.arizona.kfs.module.purap.document.authorization;
+
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.module.purap.PurapConstants.RequisitionStatuses;
+import org.kuali.kfs.module.purap.document.PurchaseOrderDocument;
+import org.kuali.kfs.module.purap.document.RequisitionDocument;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.rice.krad.document.Document;
+import org.kuali.rice.core.api.parameter.ParameterEvaluator;
+import org.kuali.rice.core.api.parameter.ParameterEvaluatorService;
+
+import edu.arizona.kfs.module.purap.PurapConstants;
+
+public class RequisitionDocumentPresentationController extends org.kuali.kfs.module.purap.document.authorization.RequisitionDocumentPresentationController {
+    private static final String LOCK_TO_RECEIVING_ADDRESS = "lockToReceivingAddress";
+
+    @Override
+    public boolean canEdit(Document document) {
+        RequisitionDocument reqDocument = (RequisitionDocument) document;
+        if (RequisitionStatuses.APPDOC_AWAIT_FISCAL_REVIEW.equals(reqDocument.getApplicationDocumentStatus())
+            || RequisitionStatuses.APPDOC_AWAIT_CHART_REVIEW.equals(reqDocument.getApplicationDocumentStatus())
+            || RequisitionStatuses.APPDOC_AWAIT_SUB_ACCT_REVIEW.equals(reqDocument.getApplicationDocumentStatus())
+            || RequisitionStatuses.APPDOC_AWAIT_OBJECT_SUB_TYPE_CODE_REVIEW.equals(reqDocument.getApplicationDocumentStatus())) {
+            return true;
+        }
+        return super.canEdit(document);
+    }
+
+    @Override
+    public Set<String> getEditModes(Document document) {
+        Set<String> editModes = super.getEditModes(document);
+    
+        if (!canEditReceivingAddress((RequisitionDocument) document)) {
+            editModes.add(LOCK_TO_RECEIVING_ADDRESS);
+            // setting the receving address lock-down here as well, since
+            // the point of locking this down is that it also needs to be
+            // set to true and switched to the default receiving address
+            ((RequisitionDocument) document).loadReceivingAddress();
+            ((RequisitionDocument) document).setAddressToVendorIndicator(true);
+        }
+        return editModes;
+    }
+
+    /**
+     * Receiving address will be locked down if a B2B order to a campus matching
+     * a system parameter is used.
+     */
+    protected boolean canEditReceivingAddress(RequisitionDocument reqn) {
+        // only need to check if B2B
+        if (StringUtils.equals(reqn.getRequisitionSourceCode(), PurapConstants.RequisitionSources.B2B)) {
+            // check the route code on the delivery address to the parameter
+            // if it matches, then it is a route Code which is allowed to set their
+            // delivery address
+            
+            if(StringUtils.isBlank(reqn.getRouteCode())) {
+                return true;
+            }
+            
+            ParameterEvaluator param = SpringContext.getBean(ParameterEvaluatorService.class).getParameterEvaluator(PurchaseOrderDocument.class, PurapConstants.B2B_DIRECT_SHIP_ROUTE_CODES_PARM, reqn.getRouteCode());
+            
+            return param.evaluationSucceeds();
+        }
+        return true;
+    }
+}

--- a/kfs-purap/src/main/resources/edu/arizona/kfs/module/purap/document/datadictionary/PurchaseOrderAmendmentDocument.xml
+++ b/kfs-purap/src/main/resources/edu/arizona/kfs/module/purap/document/datadictionary/PurchaseOrderAmendmentDocument.xml
@@ -3,6 +3,7 @@
   <bean id="PurchaseOrderAmendmentDocument" parent="PurchaseOrderAmendmentDocument-parentBean">
     <property name="documentClass" value="edu.arizona.kfs.module.purap.document.PurchaseOrderAmendmentDocument"/>
     <property name="baseDocumentClass" value="org.kuali.kfs.module.purap.document.PurchaseOrderAmendmentDocument"/>
+    <property name="documentPresentationControllerClass" value="edu.arizona.kfs.module.purap.document.authorization.PurchaseOrderAmendmentDocumentPresentationController"/>
     <property name="attributes">
       <list merge="true">
         <ref bean="PurchaseOrderAmendmentDocument-routeCode"/>

--- a/kfs-purap/src/main/resources/edu/arizona/kfs/module/purap/document/datadictionary/PurchaseOrderDocument.xml
+++ b/kfs-purap/src/main/resources/edu/arizona/kfs/module/purap/document/datadictionary/PurchaseOrderDocument.xml
@@ -2,6 +2,7 @@
 
   <bean id="PurchaseOrderDocument" parent="PurchaseOrderDocument-parentBean">
     <property name="documentClass" value="org.kuali.kfs.module.purap.document.PurchaseOrderDocument"/>
+    <property name="documentPresentationControllerClass" value="edu.arizona.kfs.module.purap.document.authorization.PurchaseOrderDocumentPresentationController"/>
     <property name="attributes">
       <list merge="true">
         <ref bean="PurchaseOrderDocument-routeCode"/>

--- a/kfs-purap/src/main/resources/edu/arizona/kfs/module/purap/document/datadictionary/RequisitionDocument.xml
+++ b/kfs-purap/src/main/resources/edu/arizona/kfs/module/purap/document/datadictionary/RequisitionDocument.xml
@@ -7,6 +7,7 @@ xsi:schemaLocation="http://www.springframework.org/schema/beans         http://w
 	
 	<bean id="RequisitionDocument" parent="RequisitionDocument-parentBean">
 	    <property name="documentClass" value="org.kuali.kfs.module.purap.document.RequisitionDocument"/>
+	    <property name="documentPresentationControllerClass" value="edu.arizona.kfs.module.purap.document.authorization.RequisitionDocumentPresentationController"/>
 	    <property name="attributes">
 	      <list merge="true">
 	        <ref bean="RequisitionDocument-routeCode"/>

--- a/kfs-web/src/main/webapp/WEB-INF/tags/module/purap/delivery.tag
+++ b/kfs-web/src/main/webapp/WEB-INF/tags/module/purap/delivery.tag
@@ -37,6 +37,9 @@
 <c:set var="lockAddressToVendor" value="${(not empty KualiForm.editingMode['lockAddressToVendor'])}" />
 <c:set var="tabindexOverrideBase" value="20" />
 
+<%--provide support for locking down receiving address and direct ship option --%>
+<c:set var="lockToReceivingAddress" value="${(not empty KualiForm.editingMode['lockToReceivingAddress'])}" />
+
 <kul:tab tabTitle="Delivery" defaultOpen="true" tabErrorKey="${PurapConstants.DELIVERY_TAB_ERRORS}">
     <div class="tab-container" align=center>
     
@@ -384,7 +387,7 @@
                    	</c:if>
             	</td>
                 <td align=left valign=middle class="datacell">
-                    <c:if test="${fullEntryMode || amendmentEntry}" > 
+                    <c:if test="${(fullEntryMode || amendmentEntry) && !lockToReceivingAddress}" > 
                     	<kul:lookup boClassName="org.kuali.kfs.module.purap.businessobject.ReceivingAddress"
                     		lookupParameters="'Y':active,document.chartOfAccountsCode:chartOfAccountsCode,document.organizationCode:organizationCode"
                     		fieldConversions="receivingName:document.receivingName,receivingCityName:document.receivingCityName,receivingLine1Address:document.receivingLine1Address,receivingLine2Address:document.receivingLine2Address,receivingCityName:document.receivingCityName,receivingStateCode:document.receivingStateCode,receivingPostalCode:document.receivingPostalCode,receivingCountryCode:document.receivingCountryCode,useReceivingIndicator:document.addressToVendorIndicator"/>
@@ -401,7 +404,7 @@
 				<th align=right valign=middle class="bord-l-b">
 					<div align="right">
 						<c:choose>
-							<c:when test="${(fullEntryMode || amendmentEntry) && !lockAddressToVendor}" >
+							<c:when test="${(fullEntryMode || amendmentEntry) && !lockAddressToVendor && !lockToReceivingAddress}" >
 								<kul:htmlAttributeLabel attributeEntry="${documentAttributes.addressToVendorIndicator}" />
 							</c:when>
 							<c:otherwise>
@@ -412,7 +415,7 @@
 				</th>
 				<td align=left valign=middle class="datacell">
                     <kul:htmlControlAttribute attributeEntry="${documentAttributes.addressToVendorIndicator}" property="document.addressToVendorIndicator" 
-                    	readOnly="${!(fullEntryMode || amendmentEntry) || lockAddressToVendor}" tabindexOverride="${tabindexOverrideBase + 5}"/><br>				
+                    	readOnly="${!(fullEntryMode || amendmentEntry) || lockAddressToVendor || lockToReceivingAddress}" tabindexOverride="${tabindexOverrideBase + 5}"/><br>				
 					<!--
 					<c:choose>
 						<c:when test="${KualiForm.document.addressToVendorIndicator == 'true'}">


### PR DESCRIPTION
Added a constant to PurapConstants.java for use in other files.
Added new files PurchaseOrderAmendmentDocumentPresentationController.java, PurchaseOrderDocumentPresentationController.java, and RequisitionDocumentPresentationController.java to have Shipping Address on B2B Shop Catalog Purchase Orders default to Final Delivery Address when the building does not have a Route Code in the Delivery Address. Default shipping address for all other B2B Shop Catalog Orders with a Route Code in the Delivery Address defaults to Shipping Address of Central Receiving.
Modified PurchaseOrderAmendmentDocument.xml, PurchaseOrderDocument.xml, and RequisitionDocument.xml to use the new presentation controllers.
Modified delivery.tag to show fields based on the value of lockToReceivingAddress.