### PR TITLE
UAF-3881 B2B Shop Catalog Receiving/Direct Ship - Buildings without Route Codes

### DIFF
--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/PurapPropertyConstants.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/PurapPropertyConstants.java
@@ -6,5 +6,6 @@ public class PurapPropertyConstants extends org.kuali.kfs.module.purap.PurapProp
     public static final String CREDIT_MEMO_INCOME_TYPE_IDENTIFIER = "creditMemoIncomeTypeIdentifier";
     public static final String PAYMENT_REQUEST_INCOME_TYPE_IDENTIFIER = "paymentRequestIncomeTypeIdentifier";
     public static final String INCOME_TYPE_LINE_NUMBER = "incomeTypeLineNumber";
+    public static final String BUILDING_OBJ = "buildingObj";
 
 }

--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/web/struts/RequisitionAction.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/web/struts/RequisitionAction.java
@@ -1,0 +1,108 @@
+package edu.arizona.kfs.module.purap.document.web.struts;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.kuali.rice.core.api.parameter.ParameterEvaluator;
+import org.kuali.rice.core.api.parameter.ParameterEvaluatorService;
+import org.kuali.rice.krad.service.BusinessObjectService;
+import org.kuali.kfs.module.purap.document.PurchaseOrderDocument;
+import org.kuali.kfs.module.purap.document.RequisitionDocument;
+import org.kuali.kfs.module.purap.document.service.PurapService;
+import org.kuali.kfs.module.purap.document.web.struts.PurchasingFormBase;
+import org.kuali.kfs.module.purap.document.web.struts.RequisitionForm;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.businessobject.Building;
+import org.kuali.kfs.sys.context.SpringContext;
+
+import edu.arizona.kfs.module.purap.PurapConstants;
+import edu.arizona.kfs.module.purap.PurapPropertyConstants;
+import edu.arizona.kfs.sys.KFSPropertyConstants;
+import edu.arizona.kfs.sys.businessobject.BuildingExtension;
+
+public class RequisitionAction extends org.kuali.kfs.module.purap.document.web.struts.RequisitionAction {
+    protected static org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(RequisitionDocument.class);
+    protected ParameterEvaluatorService parameterEvaluatorService;
+    
+    @Override
+    public ActionForward refresh(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        ActionForward forward = super.refresh(mapping, form, request, response);
+        RequisitionForm rqForm = (RequisitionForm) form;
+        RequisitionDocument document = (RequisitionDocument) rqForm.getDocument();
+        document.refreshReferenceObject(PurapPropertyConstants.BUILDING_OBJ);
+        document.setOrganizationAutomaticPurchaseOrderLimit(SpringContext.getBean(PurapService.class).getApoLimit(document.getVendorContractGeneratedIdentifier(), document.getChartOfAccountsCode(), document.getOrganizationCode()));
+        updateRouteCode(document);
+        return forward;
+    }
+    
+    @Override
+    public ActionForward useOtherDeliveryBuilding(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        super.useOtherDeliveryBuilding(mapping, form, request, response);
+        PurchasingFormBase baseForm = (PurchasingFormBase) form;
+        RequisitionDocument document = (RequisitionDocument) baseForm.getDocument();
+        document.setRouteCode("");
+        document.setAddressToVendorIndicator(false);
+        return mapping.findForward(KFSConstants.MAPPING_BASIC);
+    }
+    
+    /**
+     * Updated to detect when the delivery campus code changes and to apply the 
+     * proper default delivery type using the system parameter.
+     * 
+     * It will not be set if the value is unchanged or the prior value is blank.  
+     * The reason for this is that we don't want to override the calculations
+     * which may have been made by other code creating the requisition.
+     *
+     * Also - this mod should only take effect for B2B orders.  Non-B2B orders
+     * do not have as restricted delivery options.
+     */
+    protected void updateRouteCode(RequisitionDocument document) {
+        String routeCodeValue = null;
+        if ( StringUtils.equals(PurapConstants.RequisitionSources.B2B, document.getRequisitionSourceCode())) {
+            BusinessObjectService bos = SpringContext.getBean(BusinessObjectService.class);
+            
+            if(StringUtils.isNotBlank(document.getDeliveryBuildingCode())) {
+                Map<String, String> primaryKeys = new HashMap<String, String>();
+                primaryKeys.put(KFSPropertyConstants.BUILDING_CODE, document.getDeliveryBuildingCode());
+                List<Building> buildings = (List<Building>) bos.findMatching(Building.class, primaryKeys);
+                Building building =  (Building) buildings.get(0);
+                BuildingExtension buildingExt = (BuildingExtension) building.getExtension();
+                routeCodeValue = buildingExt.getRouteCode();
+            }
+            
+            document.setRouteCode(routeCodeValue);
+
+            if (StringUtils.isBlank(routeCodeValue)) {
+                document.setAddressToVendorIndicator(false); //default to final delivery address
+            }else{
+                try {
+                    ParameterEvaluator param;
+                    param = getParameterEvaluatorService().getParameterEvaluator(PurchaseOrderDocument.class, PurapConstants.B2B_DIRECT_SHIP_ROUTE_CODES_PARM, routeCodeValue.toUpperCase());
+
+                    if (param.getValue().contains(routeCodeValue)) {
+                        document.setAddressToVendorIndicator(true); //default to receiving address
+                    } else {
+                        document.setAddressToVendorIndicator(false); //default to final delivery address
+                    }
+                } catch ( Exception ex ) {
+                    LOG.error( "Exception while determining how to default delivery address.", ex );
+                }
+            }
+        }
+    }
+    
+    public ParameterEvaluatorService getParameterEvaluatorService() {
+        if(parameterEvaluatorService == null) {
+            parameterEvaluatorService = SpringContext.getBean(ParameterEvaluatorService.class);
+        }
+        return parameterEvaluatorService;
+    }
+}

--- a/kfs-purap/src/main/java/org/kuali/kfs/module/purap/document/PurchasingDocumentBase.java
+++ b/kfs-purap/src/main/java/org/kuali/kfs/module/purap/document/PurchasingDocumentBase.java
@@ -1591,12 +1591,15 @@ public abstract class PurchasingDocumentBase extends PurchasingAccountsPayableDo
     }
 
     public String getRouteCode() {
-        if (StringUtils.isBlank(routeCode)) {
-            try{
-                BuildingExtension be = (BuildingExtension)(getBuildingObj().getExtension());
-                routeCode = be.getRouteCode();
-            }catch(Exception e){
+        if (StringUtils.isBlank(routeCode) && StringUtils.isNotBlank(deliveryBuildingCode)) {
+            BuildingExtension be = null;
+            try {
+                be = (BuildingExtension)(getBuildingObj().getExtension());
+            } catch(Exception e) {
                 LOG.debug("Routing Code was not Retrieved");
+            }
+            if (be != null) {
+                routeCode = be.getRouteCode();
             }
         }
         return routeCode;

--- a/kfs-web/src/main/webapp/WEB-INF/struts-config.xml
+++ b/kfs-web/src/main/webapp/WEB-INF/struts-config.xml
@@ -857,6 +857,15 @@
              <forward name="basic" path="/jsp/module/purap/PaymentRequest.jsp" /> 
         </action>
         
+        <action path="/purapRequisition"
+             input="/jsp/module/purap/Requisition.jsp"
+             name="RequisitionForm"
+             type="edu.arizona.kfs.module.purap.document.web.struts.RequisitionAction"
+             scope="request" attribute="KualiForm">
+             <set-property property="cancellable" value="true" />
+             <forward name="basic" path="/jsp/module/purap/Requisition.jsp" />
+        </action>
+        
         <action path="/purapVendorCreditMemo"
              input="/jsp/module/purap/VendorCreditMemo.jsp" 
              name="VendorCreditMemoForm"


### PR DESCRIPTION
Created new file RequisitionDocument.java to override the setDeliveryBuildingCode and getRouteCode methods in order to calculate the correct Route Code when the delivery campus code changes.
Created new file RequisitionAction.java to override the refresh method to include refreshing the buildingObj object to get the correct route code.
Created new file PurapPropertyConstants.java to add a new constant.
Updated RequisitionDocument.xml and ojb-purap to point to the new edu/arizona RequisitionDocument.
Updated struts-config.xml to point to the new RequisitionAction class.