### PR TITLE
UAF-46 / UAF-2973 Procurement Card Reconciliation Step 10 (Notes and Attachments)

### DIFF
--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardHolder.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardHolder.xml
@@ -205,6 +205,9 @@
 		<property name="label" value="Card Holder Postal (ZIP) Code" />
 		<property name="shortLabel" value="Code" />
 		<property name="required" value="false"/>
+		<property name="validationPattern">
+			<bean parent="AnyCharacterValidationPattern"/>
+		</property>
 	</bean>
 	<bean id="ProcurementCardHolder-cardLimit" parent="ProcurementCardHolder-cardLimit-parentBean" />
 

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardTransactionDetail.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardTransactionDetail.xml
@@ -106,6 +106,11 @@ http://rice.kuali.org/dd http://rice.kuali.org/dd/dd.xsd">
 </bean>
 
 <!-- Attribute Definitions -->
+    <bean id="ProcurementCardTransactionDetail-transactionOriginalCurrencyAmount" parent="ProcurementCardTransactionDetail-transactionOriginalCurrencyAmount-parentBean">
+        <property name="validationPattern">
+            <bean parent="FloatingPointValidationPattern" p:allowNegative="true" />
+        </property>
+    </bean>
 
   <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.invoiceNumber" parent="ProcurementCardTransactionDetail-procurementCardLevel3Add.invoiceNumber-parentBean" />  
   <bean id="ProcurementCardTransactionDetail-procurementCardLevel3Add.invoiceNumber-parentBean" parent="ProcurementCardLevel3Add-invoiceNumber" abstract="true">
@@ -576,6 +581,7 @@ http://rice.kuali.org/dd http://rice.kuali.org/dd/dd.xsd">
 
     <bean id="ProcurementCardTransactionDetail-transactionSalesTaxAmount" parent="ProcurementCardTransactionDetail-transactionSalesTaxAmount-parentBean">
         <property name="label" value="Sales Tax Amount" />
+        <property name="required" value="false" />
     </bean>
 
 <!-- Business Object Inquiry Definition -->


### PR DESCRIPTION
Note: The scenario for "Enter Sales Tax Amount" could not be properly tested. This field is added in UAF-2972, and was not available at this time for proper testing. Based on the code currently available, it *should* work. Once the code's been reviewed and merged, this may need to be revisited.