### PR TITLE
UAF-32 UAF-3681 Inventory Unit Fields Step 3 - Asset Global Extension/Asset Global Doc

### DIFF
--- a/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/CamsConstants.java
+++ b/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/CamsConstants.java
@@ -6,4 +6,10 @@ public class CamsConstants extends org.kuali.kfs.module.cam.CamsConstants {
 
 		public static final String NEW_CONDITION_CODE_PARM = "NEW_ASSET_CONDITION_CODE";
 	}
+	
+	public static class AssetGlobal {
+		
+		public static final String PERIOD_THIRTEEN = "13";
+		public static final String JANUARY_FIRST = "01/01/";
+	}
 }

--- a/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/businessobject/AssetGlobalDetailExtension.java
+++ b/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/businessobject/AssetGlobalDetailExtension.java
@@ -1,0 +1,88 @@
+package edu.arizona.kfs.module.cam.businessobject;
+
+import java.util.LinkedHashMap;
+
+import org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectExtensionBase;
+
+import edu.arizona.kfs.sys.KFSPropertyConstants;
+
+public class AssetGlobalDetailExtension extends PersistableBusinessObjectExtensionBase {
+
+	private static final long serialVersionUID = 1L;
+	private Long capitalAssetNumber;
+	private String documentNumber;
+	private String inventoryUnitCode;
+	private String inventoryUnitOrganizationCode;
+	private String inventoryUnitChartOfAccountsCode;
+
+	private AssetInventoryUnit assetInvUnitObj;
+	private AssetGlobalDetail assetGlobalDetailObj;
+
+	public Long getCapitalAssetNumber() {
+		return capitalAssetNumber;
+	}
+
+	public void setCapitalAssetNumber(Long capitalAssetNumber) {
+		this.capitalAssetNumber = capitalAssetNumber;
+	}
+
+	public String getDocumentNumber() {
+		return documentNumber;
+	}
+
+	public void setDocumentNumber(String documentNumber) {
+		this.documentNumber = documentNumber;
+	}
+
+	public String getInventoryUnitCode() {
+		return inventoryUnitCode;
+	}
+
+	public void setInventoryUnitCode(String inventoryUnitCode) {
+		this.inventoryUnitCode = inventoryUnitCode;
+	}
+
+	public String getInventoryUnitOrganizationCode() {
+		return inventoryUnitOrganizationCode;
+	}
+
+	public void setInventoryUnitOrganizationCode(String inventoryUnitOrganizationCode) {
+		this.inventoryUnitOrganizationCode = inventoryUnitOrganizationCode;
+	}
+
+	public String getInventoryUnitChartOfAccountsCode() {
+		return inventoryUnitChartOfAccountsCode;
+	}
+
+	public void setInventoryUnitChartOfAccountsCode(String inventoryUnitChartOfAccountsCode) {
+		this.inventoryUnitChartOfAccountsCode = inventoryUnitChartOfAccountsCode;
+	}
+
+	public AssetInventoryUnit getAssetInvUnitObj() {
+		return assetInvUnitObj;
+	}
+
+	public void setAssetInvUnitObj(AssetInventoryUnit assetInvUnitObj) {
+		this.assetInvUnitObj = assetInvUnitObj;
+	}
+
+	public AssetGlobalDetail getAssetGlobalDetailObj() {
+		return assetGlobalDetailObj;
+	}
+
+	public void setAssetGlobalDetailObj(AssetGlobalDetail assetGlobalDetailObj) {
+		this.assetGlobalDetailObj = assetGlobalDetailObj;
+	}
+
+	protected LinkedHashMap<String, String> toStringMapper() {
+		LinkedHashMap<String, String> m = new LinkedHashMap<String, String>();
+		
+		if (this.capitalAssetNumber != null && this.documentNumber != null) {
+			m.put(KFSPropertyConstants.CAPITAL_ASSET_NUMBER, this.capitalAssetNumber.toString());
+			m.put(KFSPropertyConstants.DOCUMENT_NUMBER, this.documentNumber.toString());
+		}
+
+		return m;
+	}
+}

--- a/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/document/AssetGlobalMaintainableImpl.java
+++ b/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/document/AssetGlobalMaintainableImpl.java
@@ -1,0 +1,169 @@
+package edu.arizona.kfs.module.cam.document;
+
+import java.sql.Date;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.coa.businessobject.ObjectCode;
+import org.kuali.kfs.coa.service.ObjectCodeService;
+import org.kuali.kfs.gl.GeneralLedgerConstants;
+import org.kuali.kfs.module.cam.CamsPropertyConstants;
+import org.kuali.kfs.module.cam.businessobject.AssetDepreciationConvention;
+import org.kuali.kfs.module.cam.businessobject.AssetGlobal;
+import org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail;
+import org.kuali.kfs.module.cam.businessobject.AssetPaymentDetail;
+import org.kuali.kfs.module.cam.businessobject.AssetType;
+import org.kuali.kfs.module.cam.document.service.AssetDateService;
+import org.kuali.kfs.module.cam.document.service.AssetGlobalService;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.kfs.sys.service.impl.KfsParameterConstants;
+import org.kuali.rice.core.api.datetime.DateTimeService;
+import org.kuali.rice.coreservice.framework.parameter.ParameterService;
+import org.kuali.rice.krad.service.BusinessObjectService;
+import org.kuali.rice.krad.util.ObjectUtils;
+
+import edu.arizona.kfs.module.cam.CamsConstants;
+import edu.arizona.kfs.module.cam.businessobject.AssetGlobalDetailExtension;
+
+public class AssetGlobalMaintainableImpl extends org.kuali.kfs.module.cam.document.AssetGlobalMaintainableImpl {
+
+	private static final long serialVersionUID = 1L;
+	private static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(AssetGlobalMaintainableImpl.class);
+
+	@Override
+	public void prepareForSave() {
+		super.prepareForSave();
+		AssetGlobal assetGlobal = (AssetGlobal) this.getBusinessObject();
+
+		// we need to set the posting period and posting year from the value of the drop-down box...
+		if (StringUtils.isNotBlank(assetGlobal.getUniversityFiscalPeriodName())) {
+			assetGlobal.setFinancialDocumentPostingPeriodCode(StringUtils.left(assetGlobal.getUniversityFiscalPeriodName(), 2));
+			assetGlobal.setFinancialDocumentPostingYear(new Integer(StringUtils.right(assetGlobal.getUniversityFiscalPeriodName(), 4)));
+		}
+
+		List<AssetGlobalDetail> assetSharedDetails = assetGlobal.getAssetSharedDetails();
+		List<AssetGlobalDetail> newDetails = new ArrayList<AssetGlobalDetail>();
+		
+		if (!assetSharedDetails.isEmpty() && !assetSharedDetails.get(0).getAssetGlobalUniqueDetails().isEmpty()) {
+
+			for (AssetGlobalDetail locationDetail : assetSharedDetails) {
+				List<AssetGlobalDetail> assetGlobalUniqueDetails = locationDetail.getAssetGlobalUniqueDetails();
+
+				for (AssetGlobalDetail detail : assetGlobalUniqueDetails) {
+
+					detail.setDocumentNumber(assetGlobal.getDocumentNumber());
+					AssetGlobalDetailExtension assetGlobalDetailExtension = (AssetGlobalDetailExtension) detail.getExtension();
+					assetGlobalDetailExtension.setDocumentNumber(assetGlobal.getDocumentNumber());
+					assetGlobalDetailExtension.setCapitalAssetNumber(detail.getCapitalAssetNumber());
+
+					// read from location and set it to detail
+					if (ObjectUtils.isNotNull(locationDetail.getCampusCode())) {
+						detail.setCampusCode(locationDetail.getCampusCode().toUpperCase());
+					}
+					else {
+						detail.setCampusCode(locationDetail.getCampusCode());
+					}
+					if (ObjectUtils.isNotNull(locationDetail.getBuildingCode())) {
+						detail.setBuildingCode(locationDetail.getBuildingCode().toUpperCase());
+					}
+					else {
+						detail.setBuildingCode(locationDetail.getBuildingCode());
+					}
+					detail.setBuildingRoomNumber(locationDetail.getBuildingRoomNumber());
+					detail.setBuildingSubRoomNumber(locationDetail.getBuildingSubRoomNumber());
+					detail.setOffCampusName(locationDetail.getOffCampusName());
+					detail.setOffCampusAddress(locationDetail.getOffCampusAddress());
+					detail.setOffCampusCityName(locationDetail.getOffCampusCityName());
+					detail.setOffCampusStateCode(locationDetail.getOffCampusStateCode());
+					detail.setOffCampusCountryCode(locationDetail.getOffCampusCountryCode());
+					detail.setOffCampusZipCode(locationDetail.getOffCampusZipCode());
+					newDetails.add(detail);
+				}
+			}
+		}
+
+		if (assetGlobal.getCapitalAssetTypeCode() != null) {
+			assetGlobal.refreshReferenceObject(CamsPropertyConstants.AssetGlobal.CAPITAL_ASSET_TYPE);
+			AssetType capitalAssetType = assetGlobal.getCapitalAssetType();
+			if (ObjectUtils.isNotNull(capitalAssetType)) {
+				if (capitalAssetType.getDepreciableLifeLimit() != null && capitalAssetType.getDepreciableLifeLimit().intValue() != 0) {
+					assetGlobal.setCapitalAssetInServiceDate(assetGlobal.getCreateDate() == null ? getDateTimeService().getCurrentSqlDate() : assetGlobal.getCreateDate());
+				}
+				else {
+					assetGlobal.setCapitalAssetInServiceDate(null);
+				}
+				computeDepreciationDate(assetGlobal);
+				doPeriod13Changes(assetGlobal);
+				
+			}
+		}
+		assetGlobal.getAssetGlobalDetails().clear();
+		assetGlobal.getAssetGlobalDetails().addAll(newDetails);
+	}
+
+	private DateTimeService getDateTimeService() {
+		return SpringContext.getBean(DateTimeService.class);
+	}
+
+	private void computeDepreciationDate(AssetGlobal assetGlobal) {
+		List<AssetPaymentDetail> assetPaymentDetails = assetGlobal.getAssetPaymentDetails();
+		if (assetPaymentDetails != null && !assetPaymentDetails.isEmpty()) {
+
+			LOG.debug("Compute depreciation date based on asset type, depreciation convention and in-service date");
+			AssetPaymentDetail firstAssetPaymentDetail = assetPaymentDetails.get(0);
+			ObjectCode objectCode = SpringContext.getBean(ObjectCodeService.class).getByPrimaryId(firstAssetPaymentDetail.getPostingYear(), firstAssetPaymentDetail.getChartOfAccountsCode(), firstAssetPaymentDetail.getFinancialObjectCode());
+			if (ObjectUtils.isNotNull(objectCode)) {
+				Map<String, String> primaryKeys = new HashMap<String, String>();
+				primaryKeys.put(CamsPropertyConstants.AssetDepreciationConvention.FINANCIAL_OBJECT_SUB_TYPE_CODE, objectCode.getFinancialObjectSubTypeCode());
+				AssetDepreciationConvention depreciationConvention = SpringContext.getBean(BusinessObjectService.class).findByPrimaryKey(AssetDepreciationConvention.class, primaryKeys);
+				Date depreciationDate = SpringContext.getBean(AssetDateService.class).computeDepreciationDate(assetGlobal.getCapitalAssetType(),depreciationConvention, assetGlobal.getCapitalAssetInServiceDate());
+				assetGlobal.setCapitalAssetDepreciationDate(depreciationDate);
+			}
+		}
+	}
+
+	private void doPeriod13Changes(AssetGlobal assetGlobal) {
+		if (isPeriod13(assetGlobal)) {
+			Integer closingYear = new Integer(SpringContext.getBean(ParameterService.class).getParameterValueAsString(KfsParameterConstants.GENERAL_LEDGER_BATCH.class, GeneralLedgerConstants.ANNUAL_CLOSING_FISCAL_YEAR_PARM));
+			String closingDate = getClosingDate(closingYear);
+			try {
+				updateAssetGlobalForPeriod13(assetGlobal, closingYear, closingDate);
+			}
+			catch (Exception e) {
+				LOG.error(e);
+			}
+		}
+	}
+
+	private boolean isPeriod13(AssetGlobal assetGlobal) {
+		if (ObjectUtils.isNull(assetGlobal.getAccountingPeriod())) {
+			return false;
+		}
+		return CamsConstants.AssetGlobal.PERIOD_THIRTEEN.equals(assetGlobal.getAccountingPeriod().getUniversityFiscalPeriodCode());
+	}
+
+	private String getClosingDate(Integer closingYear) {
+		return getAssetGlobalService().getFiscalYearEndDayAndMonth() + closingYear.toString();
+	}
+
+	private void updateAssetGlobalForPeriod13(AssetGlobal assetGlobal, Integer closingYear, String closingDate) throws ParseException {
+		assetGlobal.setCreateDate(getDateTimeService().getCurrentSqlDate());
+		assetGlobal.setCapitalAssetInServiceDate(getDateTimeService().convertToSqlDate(closingDate));
+		assetGlobal.setCreateDate(getDateTimeService().convertToSqlDate(closingDate));
+		assetGlobal.setCapitalAssetDepreciationDate(getDateTimeService().convertToSqlDate(getClosingCalendarDate(closingYear)));
+		assetGlobal.setLastInventoryDate(getDateTimeService().getCurrentSqlDate());
+	}
+
+	private AssetGlobalService getAssetGlobalService() {
+		return SpringContext.getBean(AssetGlobalService.class);
+	}
+
+	private String getClosingCalendarDate(Integer closingYear) {
+		return CamsConstants.AssetGlobal.JANUARY_FIRST + closingYear.toString();
+	}
+
+}

--- a/kfs-cam/src/main/java/org/kuali/kfs/module/cam/businessobject/AssetBase.java
+++ b/kfs-cam/src/main/java/org/kuali/kfs/module/cam/businessobject/AssetBase.java
@@ -59,6 +59,9 @@ import org.kuali.rice.krad.util.UrlFactory;
 import org.kuali.rice.location.api.LocationConstants;
 import org.kuali.rice.location.framework.campus.CampusEbo;
 
+import edu.arizona.kfs.module.cam.businessobject.AssetExtension;
+import edu.arizona.kfs.module.cam.businessobject.AssetGlobalDetailExtension;
+
 public class AssetBase extends PersistableBusinessObjectBase {
 
     protected Long capitalAssetNumber;
@@ -238,6 +241,14 @@ public class AssetBase extends PersistableBusinessObjectBase {
         this.setGovernmentTagNumber(assetGlobalDetail.getGovernmentTagNumber());
         this.setCampusTagNumber(assetGlobalDetail.getCampusTagNumber());
         this.setNationalStockNumber(assetGlobalDetail.getNationalStockNumber());
+
+        AssetExtension assetExtension = (AssetExtension) this.getExtension();
+        AssetGlobalDetailExtension assetGlobalDetailExtension = (AssetGlobalDetailExtension) assetGlobalDetail.getExtension();
+
+        assetExtension.setInventoryUnitChartOfAccountsCode(assetGlobalDetailExtension.getInventoryUnitChartOfAccountsCode());
+        assetExtension.setInventoryUnitCode(assetGlobalDetailExtension.getInventoryUnitCode());
+        assetExtension.setInventoryUnitOrganizationCode(assetGlobalDetailExtension.getInventoryUnitOrganizationCode());
+        assetExtension.setCapitalAssetNumber(assetGlobalDetail.getCapitalAssetNumber());
 
         AssetOrganization assetOrganization = new AssetOrganization();
         assetOrganization.setCapitalAssetNumber(assetGlobalDetail.getCapitalAssetNumber());

--- a/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/businessobject/datadictionary/AssetGlobalDetail.xml
+++ b/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/businessobject/datadictionary/AssetGlobalDetail.xml
@@ -1,0 +1,37 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:p="http://www.springframework.org/schema/p"
+	xmlns:dd="http://rice.kuali.org/dd"
+	xsi:schemaLocation=" http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd http://rice.kuali.org/dd http://rice.kuali.org/dd/dd.xsd">
+
+	<bean id="AssetGlobalDetail" parent="AssetGlobalDetail-parentBean">
+		<property name="attributes">
+			<list merge="true">
+				<ref bean="AssetGlobalDetail-inventoryUnitCode" />
+				<ref bean="AssetGlobalDetail-inventoryUnitChartOfAccountsCode" />
+				<ref bean="AssetGlobalDetail-inventoryUnitOrganizationCode" />
+			</list>
+		</property>
+		<property name="relationships">
+			<list merge="true">
+				<dd:relationship objectAttribute="extension.assetInvUnitObj">
+					<dd:primitiveAttribute source="extension.inventoryUnitCode" target="inventoryUnitCode" />
+					<dd:primitiveAttribute source="extension.inventoryUnitChartOfAccountsCode" target="chartOfAccountsCode" />
+					<dd:primitiveAttribute source="extension.inventoryUnitOrganizationCode" target="organizationCode" />
+				</dd:relationship>
+			</list>
+		</property>
+	</bean>
+
+	<!-- Attribute Definitions -->
+
+	<bean id="AssetGlobalDetail-inventoryUnitCode" parent="AssetGlobalDetail-inventoryUnitCode-parentBean" />
+	<dd:boAttributeRef id="AssetGlobalDetail-inventoryUnitCode-parentBean" abstract="true" parent="AssetGlobalDetailExtension-inventoryUnitCode-parentBean" attributeName="extension.inventoryUnitCode" />
+
+	<bean id="AssetGlobalDetail-inventoryUnitChartOfAccountsCode" parent="AssetGlobalDetail-inventoryUnitChartOfAccountsCode-parentBean" />
+	<dd:boAttributeRef id="AssetGlobalDetail-inventoryUnitChartOfAccountsCode-parentBean" abstract="true" parent="AssetGlobalDetailExtension-inventoryUnitChartOfAccountsCode-parentBean" attributeName="extension.inventoryUnitChartOfAccountsCode" />
+
+	<bean id="AssetGlobalDetail-inventoryUnitOrganizationCode" parent="AssetGlobalDetail-inventoryUnitOrganizationCode-parentBean" />
+	<dd:boAttributeRef id="AssetGlobalDetail-inventoryUnitOrganizationCode-parentBean" abstract="true" parent="AssetGlobalDetailExtension-inventoryUnitOrganizationCode-parentBean" attributeName="extension.inventoryUnitOrganizationCode" />
+
+</beans>

--- a/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/businessobject/datadictionary/AssetGlobalDetailExtension.xml
+++ b/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/businessobject/datadictionary/AssetGlobalDetailExtension.xml
@@ -1,0 +1,58 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:p="http://www.springframework.org/schema/p"
+	xmlns:dd="http://rice.kuali.org/dd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd http://rice.kuali.org/dd http://rice.kuali.org/dd/dd.xsd">
+
+	<bean id="AssetGlobalDetailExtension" parent="AssetGlobalDetailExtension-parentBean" />
+	<bean id="AssetGlobalDetailExtension-parentBean" abstract="true" parent="BusinessObjectEntry">
+		<property name="businessObjectClass" value="edu.arizona.kfs.module.cam.businessobject.AssetGlobalDetailExtension" />
+		<property name="objectLabel" value="AssetGlobalDetailExtension" />
+		<property name="attributes">
+			<list>
+				<ref bean="AssetGlobalDetailExtension-documentNumber" />
+				<ref bean="AssetGlobalDetailExtension-capitalAssetNumber" />
+				<ref bean="AssetGlobalDetailExtension-inventoryUnitCode" />
+				<ref bean="AssetGlobalDetailExtension-inventoryUnitOrganizationCode" />
+				<ref bean="AssetGlobalDetailExtension-inventoryUnitChartOfAccountsCode" />
+				<ref bean="AssetGlobalDetailExtension-versionNumber" />
+			</list>
+		</property>
+		<property name="relationships">
+			<list>
+				<dd:relationship objectAttribute="assetGlobalDetailObj">
+					<dd:primitiveAttribute source="documentNumber" target="documentNumber" />
+					<dd:primitiveAttribute source="capitalAssetNumber" target="capitalAssetNumber" />
+				</dd:relationship>
+			</list>
+		</property>
+	</bean>
+	
+<!--  Attribute Definitions -->
+
+	<bean id="AssetGlobalDetailExtension-documentNumber" parent="AssetGlobalDetailExtension-documentNumber-parentBean" />
+	<dd:boAttributeRef id="AssetGlobalDetailExtension-documentNumber-parentBean" abstract="true" parent="AssetGlobal-documentNumber" attributeName="assetGlobalDetailObj.documentNumber" />
+
+	<bean id="AssetGlobalDetailExtension-capitalAssetNumber" parent="AssetGlobalDetailExtension-capitalAssetNumber-parentBean" />
+	<dd:boAttributeRef id="AssetGlobalDetailExtension-capitalAssetNumber-parentBean" abstract="true" parent="Asset-capitalAssetNumber-parentBean" attributeName="assetGlobalDetailObj.capitalAssetNumber" />
+
+	<bean id="AssetGlobalDetailExtension-inventoryUnitCode" parent="AssetGlobalDetailExtension-inventoryUnitCode-parentBean" />
+	<dd:boAttributeRef id="AssetGlobalDetailExtension-inventoryUnitCode-parentBean" abstract="true" parent="AssetInventoryUnit-inventoryUnitCode-parentBean" attributeName="assetInvUnitObj.inventoryUnitCode" label="Inventory Unit Code" shortLabel="Inv Unit Code" />
+
+	<bean id="AssetGlobalDetailExtension-inventoryUnitChartOfAccountsCode" parent="AssetGlobalDetailExtension-inventoryUnitChartOfAccountsCode-parentBean" />
+	<bean id="AssetGlobalDetailExtension-inventoryUnitChartOfAccountsCode-parentBean" abstract="true" parent="Chart-chartOfAccountsCode-parentBean">
+		<property name="name" value="inventoryUnitChartOfAccountsCode" />
+		<property name="label" value="Inventory Unit Chart Of Accounts Code" />
+		<property name="forceUppercase" value="true" />
+	</bean>
+
+	<bean id="AssetGlobalDetailExtension-inventoryUnitOrganizationCode" parent="AssetGlobalDetailExtension-inventoryUnitOrganizationCode-parentBean" />
+	<bean id="AssetGlobalDetailExtension-inventoryUnitOrganizationCode-parentBean" abstract="true" parent="Organization-organizationCode-parentBean">
+		<property name="name" value="inventoryUnitOrganizationCode" />
+		<property name="label" value="Inventory Unit Organization Code" />
+		<property name="forceUppercase" value="true" />
+	</bean>
+
+	<bean id="AssetGlobalDetailExtension-versionNumber" parent="AttributeReferenceDummy-versionNumber-parentBean" />
+
+</beans>

--- a/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/document/datadictionary/AssetGlobalMaintenanceDocument.xml
+++ b/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/document/datadictionary/AssetGlobalMaintenanceDocument.xml
@@ -1,0 +1,94 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:p="http://www.springframework.org/schema/p"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+
+	<bean id="AssetGlobalMaintenanceDocument" parent="AssetGlobalMaintenanceDocument-parentBean" >
+		<property name="maintainableClass" value="edu.arizona.kfs.module.cam.document.AssetGlobalMaintainableImpl" />
+	</bean>
+	
+	<!-- Maintainable Sections  -->
+	
+	<bean id="AssetGlobalMaintenanceDocument-CampusLocation" parent="AssetGlobalMaintenanceDocument-CampusLocation-parentBean">
+		<property name="maintainableItems">
+			<list>
+				<bean parent="MaintainableCollectionDefinition">
+					<property name="name" value="assetSharedDetails" />
+					<property name="businessObjectClass" value="org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail" />
+					<property name="summaryTitle" value="Asset Location" />
+					<property name="summaryFields">
+						<list>
+							<bean parent="MaintainableFieldDefinition" p:name="campusCode" p:required="true" />
+							<bean parent="MaintainableFieldDefinition" p:name="buildingCode" p:required="false" />
+							<bean parent="MaintainableFieldDefinition" p:name="buildingRoomNumber" p:required="false" />
+							<bean parent="MaintainableFieldDefinition" p:name="buildingSubRoomNumber" p:required="false" />
+							<bean parent="MaintainableFieldDefinition" p:name="offCampusName" p:required="false" />
+							<bean parent="MaintainableFieldDefinition" p:name="offCampusAddress" p:required="false" />
+							<bean parent="MaintainableFieldDefinition" p:name="offCampusCityName" p:required="false" />
+							<bean parent="MaintainableFieldDefinition" p:name="offCampusStateCode" p:required="false" />
+							<bean parent="MaintainableFieldDefinition" p:name="offCampusZipCode" p:required="false" />
+							<bean parent="MaintainableFieldDefinition" p:name="offCampusCountryCode" />
+						</list>
+					</property>
+					<property name="maintainableFields">
+						<list>
+							<bean parent="MaintainableFieldDefinition" p:name="campusCode" p:readOnlyAfterAdd="false" p:required="true" />
+							<bean parent="MaintainableFieldDefinition" p:name="buildingCode" p:readOnlyAfterAdd="false" p:required="false" />
+							<bean parent="MaintainableFieldDefinition" p:name="buildingRoomNumber" p:readOnlyAfterAdd="false" p:required="false" />
+							<bean parent="MaintainableFieldDefinition" p:name="buildingSubRoomNumber" p:readOnlyAfterAdd="false" p:required="false" />
+							<bean parent="MaintainableFieldDefinition" p:name="offCampusName" p:readOnlyAfterAdd="false" p:required="false" />
+							<bean parent="MaintainableFieldDefinition" p:name="offCampusAddress" p:readOnlyAfterAdd="false" p:required="false" />
+							<bean parent="MaintainableFieldDefinition" p:name="offCampusCityName" p:readOnlyAfterAdd="false" p:required="false" />
+							<bean parent="MaintainableFieldDefinition" p:name="offCampusStateCode" p:readOnlyAfterAdd="false" p:required="false" />
+							<bean parent="MaintainableFieldDefinition" p:name="offCampusZipCode" p:readOnlyAfterAdd="false" p:required="false" />
+							<bean parent="MaintainableFieldDefinition" p:name="offCampusCountryCode" p:readOnlyAfterAdd="false" />
+							<bean parent="MaintainableFieldDefinition" p:name="locationQuantity" p:readOnlyAfterAdd="true" p:required="true" />
+							<bean parent="MaintainableFieldDefinition" p:name="newCollectionRecord" />
+						</list>
+					</property>
+					<property name="maintainableCollections">
+						<list>
+							<bean parent="MaintainableCollectionDefinition">
+								<property name="name" value="assetGlobalUniqueDetails" />
+								<property name="businessObjectClass" value="org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail" />
+								<property name="summaryTitle" value="Asset Unique Information" />
+								<property name="summaryFields">
+									<list>
+										<bean parent="MaintainableFieldDefinition" p:name="capitalAssetNumber" />
+									</list>
+								</property>
+								<property name="maintainableFields">
+									<list>
+										<bean parent="MaintainableFieldDefinition" p:name="capitalAssetNumber" p:unconditionallyReadOnly="true" />
+										<bean parent="MaintainableFieldDefinition" p:name="serialNumber" p:readOnlyAfterAdd="false" />
+										<bean parent="MaintainableFieldDefinition" p:name="organizationInventoryName" p:readOnlyAfterAdd="false" />
+										<bean parent="MaintainableFieldDefinition" p:name="organizationAssetTypeIdentifier" p:readOnlyAfterAdd="false" />
+										<bean parent="MaintainableFieldDefinition" p:name="governmentTagNumber" p:readOnlyAfterAdd="false" />
+										<bean parent="MaintainableFieldDefinition" p:name="campusTagNumber" p:readOnlyAfterAdd="false" />
+										<bean parent="MaintainableFieldDefinition" p:name="nationalStockNumber" p:readOnlyAfterAdd="false" />
+										<bean parent="MaintainableFieldDefinition" p:name="extension.inventoryUnitCode" p:required="true" p:readOnlyAfterAdd="false" />
+										<bean parent="MaintainableFieldDefinition" p:name="extension.inventoryUnitChartOfAccountsCode" p:required="true" p:readOnlyAfterAdd="false" />
+										<bean parent="MaintainableFieldDefinition" p:name="extension.inventoryUnitOrganizationCode" p:required="true" p:readOnlyAfterAdd="false" />
+										<bean parent="MaintainableFieldDefinition" p:name="newCollectionRecord" p:defaultValue="true" />
+										<!-- Asset Separate - START -->
+										<bean parent="MaintainableFieldDefinition" p:name="representativeUniversalIdentifier" p:readOnlyAfterAdd="false" />
+										<bean parent="MaintainableFieldDefinition" p:name="assetRepresentative.principalName" />
+										<bean parent="MaintainableFieldDefinition" p:name="assetRepresentative.name" p:unconditionallyReadOnly="true" />
+										<bean parent="MaintainableFieldDefinition" p:name="capitalAssetTypeCode" p:readOnlyAfterAdd="false" />
+										<bean parent="MaintainableFieldDefinition" p:name="capitalAssetDescription" p:readOnlyAfterAdd="false" />
+										<bean parent="MaintainableFieldDefinition" p:name="manufacturerName" p:readOnlyAfterAdd="false" />
+										<bean parent="MaintainableFieldDefinition" p:name="organizationText" p:readOnlyAfterAdd="false" />
+										<bean parent="MaintainableFieldDefinition" p:name="manufacturerModelNumber" p:readOnlyAfterAdd="false" />
+										<bean parent="MaintainableFieldDefinition" p:name="separateSourceAmount" p:defaultValue="0.00" p:readOnlyAfterAdd="false" />
+										<!-- Asset Separate - END -->
+									</list>
+								</property>
+							</bean>
+						</list>
+					</property>
+				</bean>
+			</list>
+		</property>
+	</bean>
+
+</beans>

--- a/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/ojb-cam.xml
+++ b/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/ojb-cam.xml
@@ -342,6 +342,77 @@
 		
 	</class-descriptor>
 	
+	<class-descriptor class="edu.arizona.kfs.module.cam.businessobject.AssetGlobalDetailExtension" table="CM_CPTLAST_DTL_EXTEN_T">
+		<field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" index="true" />
+		<field-descriptor name="capitalAssetNumber" column="CPTLAST_NBR" jdbc-type="BIGINT" primarykey="true" index="true" />
+		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+		<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+		<field-descriptor name="inventoryUnitCode" column="INV_UNIT_CD" jdbc-type="VARCHAR" />
+		<field-descriptor name="inventoryUnitOrganizationCode" column="ORG_CD" jdbc-type="VARCHAR" />
+		<field-descriptor name="inventoryUnitChartOfAccountsCode" column="FIN_COA_CD" jdbc-type="VARCHAR" />
 	
+		<reference-descriptor name="assetGlobalDetailObj" class-ref="org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+			<foreignkey field-ref="documentNumber" />
+			<foreignkey field-ref="capitalAssetNumber" />
+		</reference-descriptor>
+		<reference-descriptor name="assetInvUnitObj" class-ref="edu.arizona.kfs.module.cam.businessobject.AssetInventoryUnit" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="false">
+			<foreignkey field-ref="inventoryUnitCode" />
+			<foreignkey field-ref="inventoryUnitChartOfAccountsCode" />
+			<foreignkey field-ref="inventoryUnitOrganizationCode" />
+		</reference-descriptor>
+		
+	</class-descriptor>
+
+	<class-descriptor class="org.kuali.kfs.module.cam.businessobject.AssetGlobalDetail" table="CM_CPTLAST_DTL_T">
+		<field-descriptor name="documentNumber" column="FDOC_NBR" jdbc-type="VARCHAR" primarykey="true" index="true" />
+		<field-descriptor name="capitalAssetNumber" column="CPTLAST_NBR" jdbc-type="BIGINT" primarykey="true" index="true" autoincrement="true" sequence-name="CPTLAST_NBR_SEQ" />
+		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
+		<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
+		<field-descriptor name="campusCode" column="CAMPUS_CD" jdbc-type="VARCHAR" />
+		<field-descriptor name="buildingCode" column="BLDG_CD" jdbc-type="VARCHAR" />
+		<field-descriptor name="serialNumber" column="CPTLAST_SERIAL_NBR" jdbc-type="VARCHAR" />
+		<field-descriptor name="buildingRoomNumber" column="BLDG_ROOM_NBR" jdbc-type="VARCHAR" />
+		<field-descriptor name="buildingSubRoomNumber" column="BLDG_SUB_ROOM_NBR" jdbc-type="VARCHAR" />
+		<field-descriptor name="campusTagNumber" column="CPTLAST_TAG_NBR" jdbc-type="VARCHAR" />
+		<field-descriptor name="organizationInventoryName" column="ORG_INVN_NM" jdbc-type="VARCHAR" />
+		<field-descriptor name="organizationAssetTypeIdentifier" column="ORG_CPTLAST_TYP_ID" jdbc-type="VARCHAR" />
+		<field-descriptor name="offCampusName" column="AST_OFFCMP_NM" jdbc-type="VARCHAR" />
+		<field-descriptor name="offCampusAddress" column="AST_OFFCMP_ADDR" jdbc-type="VARCHAR" />
+		<field-descriptor name="offCampusCityName" column="AST_OFFCMP_CITY_NM" jdbc-type="VARCHAR" />
+		<field-descriptor name="offCampusStateCode" column="AST_OFFCMP_ST_CD" jdbc-type="VARCHAR" />
+		<field-descriptor name="offCampusZipCode" column="AST_OFFCMP_ZIP_CD" jdbc-type="VARCHAR" />
+		<field-descriptor name="offCampusCountryCode" column="AST_OFFCMP_CNTRY_CD" jdbc-type="VARCHAR" />
+		<field-descriptor name="governmentTagNumber" column="CPTL_AST_GOV_TAG_NBR" jdbc-type="VARCHAR" />
+		<field-descriptor name="nationalStockNumber" column="CPTL_AST_NTL_STOCK_NBR" jdbc-type="VARCHAR" />
+		<field-descriptor name="representativeUniversalIdentifier" column="AST_REP_UNVL_ID" jdbc-type="VARCHAR" />
+		<field-descriptor name="capitalAssetTypeCode" column="CPTLAST_TYP_CD" jdbc-type="VARCHAR" />
+		<field-descriptor name="capitalAssetDescription" column="CPTLAST_DESC" jdbc-type="VARCHAR" />
+		<field-descriptor name="manufacturerName" column="CPTLAST_MFR_NM" jdbc-type="VARCHAR" />
+		<field-descriptor name="organizationText" column="ORG_TXT" jdbc-type="VARCHAR" />
+		<field-descriptor name="manufacturerModelNumber" column="CPTLAST_MFRMDL_NBR" jdbc-type="VARCHAR" />
+		<field-descriptor name="separateSourceAmount" column="SEP_SRC_AMT" jdbc-type="DECIMAL" conversion="org.kuali.rice.core.framework.persistence.ojb.conversion.OjbKualiDecimalFieldConversion" />
+
+		<reference-descriptor name="asset" class-ref="org.kuali.kfs.module.cam.businessobject.Asset" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+			<foreignkey field-ref="capitalAssetNumber" />
+		</reference-descriptor>
+		<reference-descriptor name="building" class-ref="org.kuali.kfs.sys.businessobject.Building" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+			<foreignkey field-ref="campusCode" />
+			<foreignkey field-ref="buildingCode" />
+		</reference-descriptor>
+		<reference-descriptor name="buildingRoom" class-ref="org.kuali.kfs.sys.businessobject.Room" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+			<foreignkey field-ref="campusCode" />
+			<foreignkey field-ref="buildingCode" />
+			<foreignkey field-ref="buildingRoomNumber" />
+		</reference-descriptor>
+		<reference-descriptor name="capitalAssetType" class-ref="org.kuali.kfs.module.cam.businessobject.AssetType" auto-retrieve="true" auto-update="none" auto-delete="none" proxy="true">
+			<foreignkey field-ref="capitalAssetTypeCode" />
+		</reference-descriptor>
+
+		<reference-descriptor name="extension" class-ref="edu.arizona.kfs.module.cam.businessobject.AssetGlobalDetailExtension" auto-retrieve="true" auto-update="object" auto-delete="object" proxy="false">
+			<foreignkey field-ref="documentNumber" />
+			<foreignkey field-ref="capitalAssetNumber" />
+		</reference-descriptor>
+
+	</class-descriptor>
 
 </descriptor-repository>


### PR DESCRIPTION
Files created
1. AssetGlobalDetailExtension.java -> new BO that will help to extend AssetGlobalDetail
2. AssetGlobalDetailExtension.xml-> Attribute definitions of AssetGlobalDetailExtension.java
3. AssetGlobalDetail.xml -> added extension relationship
4. AssetGlobalMaintenanceDocument.xml -> overrode maintainable class reference and CampusLocation section
5. AssetGlobalMaintainableImpl.java -> which extends org file with same name, overrides prepareToSave() so Inventory Unit Fields can be saved to the asset global

Files Modified
1. CamsConstans.java -> created 2 constants to replace magic strings used on AssetGlobalMaintainableImpl
2. ojb-cam.xml -> added mappings for AssetGlobalDetail and AssetGlobalDetailExtension
3. AssetBase.java -> added piece of code to constructor so Inventory Unit Fields on Asset Global can be saved to Asset. 
	- I attempted to follow coding standards and creating a new Asset BO in edu package to extend Asset org and modify the constructor here, but failed. Doing this, all sections/ Asset related BO's will throw exceptions. I tried to convert those to edu files and use edu package Asset but kept getting more and different exceptions. So, It was decided to make the change on this file.