### PR TITLE
UAF-46 / UAF-3948 Revert configuration/path value in the base pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
           <artifactId>tomcat7-maven-plugin</artifactId>
           <version>${plugin.tomcat.version}</version>
           <configuration>
-            <path>/kfs</path>
+            <path>/${project.artifactId}-${build.environment}</path>
           </configuration>
           <dependencies>
             <dependency>


### PR DESCRIPTION
This value was inadvertently changed in UAF-2965. Reverting this value will fix issues with accessing the web application in some environments.