### PR TITLE
UAF-69 / UAF-3941 Remaining 1099 Bugs

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/DisbursementVoucherDocument.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/DisbursementVoucherDocument.java
@@ -44,6 +44,9 @@ import edu.arizona.kfs.vnd.businessobject.VendorDetailExtension;
  * Document class override to ensure that the bank code is synchronized with the
  * payment method code.
  */
+// org.kuali.rice.kns.document.authorization.TransactionalDocumentPresentationController is deprecated
+// getReportable1099TransactionsFlag() and processAfterRetrieve() use unchecked Lists
+@SuppressWarnings({ "deprecation", "unchecked" })
 public class DisbursementVoucherDocument extends org.kuali.kfs.fp.document.DisbursementVoucherDocument implements IncomeTypeContainer <DisbursementVoucherIncomeType, String>{
 
     public static final String DOCUMENT_TYPE_DV_NON_CHECK = "DVNC";
@@ -96,33 +99,30 @@ public class DisbursementVoucherDocument extends org.kuali.kfs.fp.document.Disbu
             accountingLineExtension.setDocumentNumber(accountingLine.getDocumentNumber());
             accountingLineExtension.setSequenceNumber(accountingLine.getSequenceNumber());
         }
-        
-     // START KATTS-1961 Tag and JSP for DV, PREQ and CM Documents
+
         getIncomeTypeHandler().removeZeroValuedIncomeTypes();
-        // END KATTS-1961
-        
-        //KATTS-1939 Add New Search Fields to DV, PREQ and CM Documents 
-        // Only update paid year if the document is in final status 
-        if (KewApiConstants.ROUTE_HEADER_FINAL_CD.equals( getDocumentHeader().getWorkflowDocument().getStatus().getCode() ) ) {
-        	if (paidDate != null) {
-                setDvPaidYear(getPaidDate().toString().substring(0, 4));                
+
+        // Only update paid year if the document is in final status
+        if (KewApiConstants.ROUTE_HEADER_FINAL_CD.equals(getDocumentHeader().getWorkflowDocument().getStatus().getCode())) {
+            if (paidDate != null) {
+                setDvPaidYear(getPaidDate().toString().substring(0, 4));
+            } else {
+                setDvPaidYear(null);
             }
-            else {
-               setDvPaidYear(null);
-            }
-        }        
+        }
+
+        setDv1099Ind(false);
         for (DisbursementVoucherIncomeType incomeType : getIncomeTypes()) {
-            if ((StringUtils.isBlank(incomeType.getIncomeTypeCode()) || incomeType.getIncomeTypeCode().equals(KFSConstants.IncomeTypeConstants.INCOME_TYPE_NON_REPORTABLE_CODE))) {
-                setDv1099Ind(false);
-            }
-            else {
+            boolean isCodeExist = StringUtils.isNotBlank(incomeType.getIncomeTypeCode());
+            boolean isReportable = !incomeType.getIncomeTypeCode().equals(KFSConstants.IncomeTypeConstants.INCOME_TYPE_NON_REPORTABLE_CODE);
+            if (isCodeExist && isReportable) {
                 setDv1099Ind(true);
                 break;
             }
-        }      
-        //END KATTS-1939 
+        }
+
     }
-    
+
     public boolean isDv1099Ind() {
         return dv1099Ind;
     }
@@ -272,7 +272,6 @@ public class DisbursementVoucherDocument extends org.kuali.kfs.fp.document.Disbu
         }
     }
 
-    @SuppressWarnings("deprecation")
     private boolean isIncomeTypeUpdateAllowed() {
         boolean retval = false;
 

--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/VendorCreditMemoDocument.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/VendorCreditMemoDocument.java
@@ -102,10 +102,9 @@ public class VendorCreditMemoDocument extends org.kuali.kfs.module.purap.documen
                 refreshReferenceObject(BANK);
             }
         }
-        // Tag and JSP for DV, PREQ and CM Documents
+
         getIncomeTypeHandler().removeZeroValuedIncomeTypes();
 
-        // Add New Search Fields to DV, PREQ and CM Documents
         // Only update paid year if the document is in final status
         if (KewApiConstants.ROUTE_HEADER_FINAL_CD.equals(getDocumentHeader().getWorkflowDocument().getStatus().getCode())) {
             if (creditMemoPaidTimestamp != null) {
@@ -114,10 +113,12 @@ public class VendorCreditMemoDocument extends org.kuali.kfs.module.purap.documen
                 setPaymentPaidYear(null);
             }
         }
+
+        setPayment1099Indicator(false);
         for (CreditMemoIncomeType incomeType : getIncomeTypes()) {
-            if ((StringUtils.isBlank(incomeType.getIncomeTypeCode()) || incomeType.getIncomeTypeCode().equals(KFSConstants.IncomeTypeConstants.INCOME_TYPE_NON_REPORTABLE_CODE))) {
-                setPayment1099Indicator(false);
-            } else {
+            boolean isCodeExist = StringUtils.isNotBlank(incomeType.getIncomeTypeCode());
+            boolean isReportable = !incomeType.getIncomeTypeCode().equals(KFSConstants.IncomeTypeConstants.INCOME_TYPE_NON_REPORTABLE_CODE);
+            if (isCodeExist && isReportable) {
                 setPayment1099Indicator(true);
                 break;
             }

--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/service/impl/CreditMemoServiceImpl.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/service/impl/CreditMemoServiceImpl.java
@@ -2,6 +2,7 @@ package edu.arizona.kfs.module.purap.document.service.impl;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
@@ -12,8 +13,10 @@ import org.kuali.kfs.module.purap.businessobject.CreditMemoAccount;
 import org.kuali.kfs.module.purap.businessobject.CreditMemoItem;
 import org.kuali.kfs.module.purap.businessobject.PurApAccountingLine;
 import org.kuali.kfs.module.purap.businessobject.PurchaseOrderItem;
+import org.kuali.kfs.module.purap.document.PurchaseOrderDocument;
 import org.kuali.kfs.module.purap.document.VendorCreditMemoDocument;
 import org.kuali.kfs.module.purap.document.validation.event.AttributedContinuePurapEvent;
+import org.kuali.kfs.module.purap.util.ExpiredOrClosedAccountEntry;
 import org.kuali.kfs.module.purap.util.VendorGroupingHelper;
 import org.kuali.kfs.sys.businessobject.Bank;
 import org.kuali.kfs.sys.businessobject.SourceAccountingLine;
@@ -24,7 +27,6 @@ import org.kuali.rice.core.api.util.type.KualiDecimal;
 import org.kuali.rice.kew.api.exception.WorkflowException;
 import org.kuali.rice.krad.exception.ValidationException;
 import org.kuali.rice.krad.util.ObjectUtils;
-import org.kuali.kfs.module.purap.document.PurchaseOrderDocument;
 
 import edu.arizona.kfs.fp.service.PaymentMethodGeneralLedgerPendingEntryService;
 import edu.arizona.kfs.module.purap.PurapConstants;
@@ -251,6 +253,15 @@ public class CreditMemoServiceImpl extends org.kuali.kfs.module.purap.document.s
             }  
         }
         // end proration
+    }
+
+    // This method fixes a bug that was discovered in 3, supposedly fixed in 4, and reintroduced sometime afterward
+    // (UA:KFSI-3305, Foundation:KFSMI-6530)
+    @Override
+    protected void populateDocumentFromPO(VendorCreditMemoDocument cmDocument, HashMap<String, ExpiredOrClosedAccountEntry> expiredOrClosedAccountList) {
+        super.populateDocumentFromPO(cmDocument, expiredOrClosedAccountList);
+        PurchaseOrderDocument purchaseOrderDocument = purchaseOrderService.getCurrentPurchaseOrder(cmDocument.getPurchaseOrderIdentifier());
+        cmDocument.setUseTaxIndicator(purchaseOrderDocument.isUseTaxIndicator());
     }
 
 }


### PR DESCRIPTION
1) The methodology of determining whether the document should be displayed on a document search when the 1099 Classification option is set to Yes was rewritten to make it more easily readable on the DV and CM Documents, and applied the the PREQ.

2) The CreditMemoService was modified to fix a bug that was discovered in 3, supposedly fixed in 4, and reintroduced sometime afterward (UA: KFSI-3305, Foundation: KFSMI-6530)