### PR TITLE
UAF-2966 Procurement Card Reconciliation Step 3 (Return to Reconciler)

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/ProcurementCardCreateDocumentService.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/ProcurementCardCreateDocumentService.java
@@ -1,0 +1,13 @@
+package edu.arizona.kfs.fp.batch.service;
+
+public interface ProcurementCardCreateDocumentService extends org.kuali.kfs.fp.batch.service.ProcurementCardCreateDocumentService {
+    
+    /**
+     * Puts the document back into action list of reconciler
+     * @param pcardDocumentId id of the procurement card document
+     * @param node document route node
+     * @param prevNode previous document route node
+     * @param annotation
+     */
+    public void requeueDocument(String pcardDocumentId, String node, String prevNode, String annotation);
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/impl/ProcurementCardCreateDocumentServiceImpl.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/impl/ProcurementCardCreateDocumentServiceImpl.java
@@ -18,6 +18,7 @@ import org.kuali.kfs.fp.document.validation.impl.ProcurementCardDocumentRuleCons
 import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.kfs.sys.document.validation.event.DocumentSystemSaveEvent;
+import org.kuali.kfs.sys.service.impl.KfsParameterConstants;
 import org.kuali.kfs.sys.util.KfsDateUtils;
 import org.kuali.rice.core.api.util.type.KualiDecimal;
 import org.kuali.rice.kew.api.KewApiConstants;
@@ -32,6 +33,7 @@ import org.kuali.rice.kew.api.exception.WorkflowException;
 import org.kuali.rice.kim.api.group.GroupService;
 import org.kuali.rice.krad.bo.DocumentHeader;
 import org.kuali.rice.krad.util.ObjectUtils;
+import org.kuali.rice.krad.util.KRADConstants;
 import org.springframework.transaction.annotation.Transactional;
 
 import edu.arizona.kfs.fp.batch.ProcurementCardRerouteDocumentsStep;
@@ -39,8 +41,11 @@ import edu.arizona.kfs.fp.businessobject.ProcurementCardDefault;
 import edu.arizona.kfs.fp.businessobject.ProcurementCardHolder;
 import edu.arizona.kfs.fp.businessobject.ProcurementCardTransaction;
 import edu.arizona.kfs.fp.document.ProcurementCardDocument;
+import org.kuali.rice.kim.api.identity.Person;
+import org.kuali.rice.kim.api.identity.PersonService;
+import edu.arizona.kfs.sys.KFSConstants;
 
-public class ProcurementCardCreateDocumentServiceImpl extends org.kuali.kfs.fp.batch.service.impl.ProcurementCardCreateDocumentServiceImpl {
+public class ProcurementCardCreateDocumentServiceImpl extends org.kuali.kfs.fp.batch.service.impl.ProcurementCardCreateDocumentServiceImpl implements edu.arizona.kfs.fp.batch.service.ProcurementCardCreateDocumentService {
 
     private static org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(ProcurementCardCreateDocumentServiceImpl.class);
     
@@ -79,7 +84,7 @@ public class ProcurementCardCreateDocumentServiceImpl extends org.kuali.kfs.fp.b
 
         for (ProcurementCardDocument pcardDocument : documents) {
         
-        	String pcardDocumentId = pcardDocument.getDocumentNumber();
+            String pcardDocumentId = pcardDocument.getDocumentNumber();
             //get document route node
             List<RouteNodeInstance> routeNodeInstances = pcardDocument.getDocumentHeader().getWorkflowDocument().getCurrentRouteNodeInstances();
             String node = routeNodeInstances.get(0).getName();
@@ -96,13 +101,13 @@ public class ProcurementCardCreateDocumentServiceImpl extends org.kuali.kfs.fp.b
                     pcardDocument.getTargetAccountingLine(0).setSubAccountNumber(procurementCardHolderDetail.getSubAccountNumber());
                     pcardDocument.getTargetAccountingLine(0).setFinancialSubObjectCode(procurementCardHolderDetail.getFinancialSubObjectCode());
                     LOG.info("Rerouting doc #" + pcardDocumentId + " at AccountFullEdit for error account Fiscal Officer.");             
-                    requeueDocument(pcardDocument, pcardDocumentId, node, "HasReconciler"); 
+                    requeueDocument(pcardDocumentId, node, "HasReconciler", " Batch Reroute to Reconciler"); 
                     // pause between reroutes
                     try {
                         Thread.sleep(3000);
                     }
                     catch (InterruptedException e) {
-                        throw new RuntimeException(e);
+                        LOG.error("Thread interrupted in rerouteProcurementCardDocuments method " + e.getMessage());
                     }
                 }
                 
@@ -117,7 +122,7 @@ public class ProcurementCardCreateDocumentServiceImpl extends org.kuali.kfs.fp.b
                     LOG.info("Rerouting doc #" + pcardDocumentId + " at ProcurementCardReconciler, in "
                             + RECONCILER_GROUPS_TO_REROUTE_PARM_NM + " group "
                             + procurementCardHolderDetail.getReconcilerGroupId());
-                    requeueDocument(pcardDocument, pcardDocumentId, node, "ProcurementCardReconciler"); 
+                    requeueDocument(pcardDocumentId, node, "ProcurementCardReconciler", " Batch Reroute to Reconciler"); 
                     // pause between reroutes
                     try {
                         Thread.sleep(3000);
@@ -146,16 +151,17 @@ public class ProcurementCardCreateDocumentServiceImpl extends org.kuali.kfs.fp.b
         return procurementCardDefault;
     }
     
-    private void requeueDocument(ProcurementCardDocument pcardDocument, String pcardDocumentId, String node, String prevNode) {
+    @Override
+    public void requeueDocument(String pcardDocumentId, String node, String prevNode, String annotation) {
         //pcardDocumentId could have leading 0's; want these removed for processing calls
         String documentId = StringUtils.stripStart(pcardDocumentId, "0");
         WorkflowDocumentActionsService documentActions = KewApiServiceLocator.getWorkflowDocumentActionsService();
-        // Updated System User ID, should change this to use the parameter
-        DocumentActionParameters actionParameters = DocumentActionParameters.create(documentId, "T000000000000005493", node+" Batch Reroute to Reconciler");
+        String systemUserPrincipalId = getSystemUserPrincipalId();
+        DocumentActionParameters actionParameters = DocumentActionParameters.create(documentId, systemUserPrincipalId, node + annotation);
         ReturnPoint returnPoint = ReturnPoint.create(prevNode);
         documentActions.superUserReturnToPreviousNode(actionParameters, false, returnPoint);
         // Use requeuer service to put the document back into action list of reconciler
-        DocumentRefreshQueue docRequeue = KewApiServiceLocator.getDocumentRequeuerService("KFS",documentId, 0x0);
+        DocumentRefreshQueue docRequeue = KewApiServiceLocator.getDocumentRequeuerService(KFSConstants.APPLICATION_NAMESPACE_CODE, documentId, 0x0);
         docRequeue.refreshDocument(documentId);    
        
         LOG.info("Rerouting PCDO document # " + pcardDocumentId + ".");
@@ -433,5 +439,11 @@ public class ProcurementCardCreateDocumentServiceImpl extends org.kuali.kfs.fp.b
             }
         }
         return retCode;
+    }
+    
+    protected String getSystemUserPrincipalId() {
+        String systemUserName = parameterService.getParameterValueAsString(KRADConstants.KNS_NAMESPACE, KfsParameterConstants.ALL_COMPONENT, KFSConstants.SYSTEM_USER_NAME);
+        Person systemUser = SpringContext.getBean(PersonService.class).getPersonByPrincipalName(systemUserName);
+        return systemUser.getPrincipalId();
     }
 }

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/impl/ProcurementCardCreateDocumentServiceImpl.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/impl/ProcurementCardCreateDocumentServiceImpl.java
@@ -79,7 +79,7 @@ public class ProcurementCardCreateDocumentServiceImpl extends org.kuali.kfs.fp.b
 
         for (ProcurementCardDocument pcardDocument : documents) {
         
-            String pcardDocumentId = pcardDocument.getObjectId();
+        	String pcardDocumentId = pcardDocument.getDocumentNumber();
             //get document route node
             List<RouteNodeInstance> routeNodeInstances = pcardDocument.getDocumentHeader().getWorkflowDocument().getCurrentRouteNodeInstances();
             String node = routeNodeInstances.get(0).getName();

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/authorization/ProcurementCardAccountingLineAuthorizer.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/authorization/ProcurementCardAccountingLineAuthorizer.java
@@ -1,0 +1,22 @@
+package edu.arizona.kfs.fp.document.authorization;
+
+import java.util.Map;
+
+import org.kuali.kfs.sys.businessobject.AccountingLine;
+import org.kuali.kfs.sys.document.AccountingDocument;
+import org.kuali.rice.kim.api.identity.Person;
+
+public class ProcurementCardAccountingLineAuthorizer extends org.kuali.kfs.fp.document.authorization.ProcurementCardAccountingLineAuthorizer {
+    
+    /**
+     * The delivered code is incorrect. A Fiscal Officer should be able to change any of their own accounts, but not other Fiscal Officers accounts.
+     * This is a copy of org.kuali.kfs.sys.document.authorization.AccountingLineAuthorizerBase#determineEditPermissionByFieldName(AccountingDocument,AccountingLine,String,Person)
+     */
+    @Override
+    protected boolean determineEditPermissionByFieldName(AccountingDocument accountingDocument, AccountingLine accountingLine, String fieldName, Person currentUser) {
+        Map<String,String> roleQualifiers = getRoleQualifiers(accountingDocument, accountingLine);
+        Map<String,String> permissionDetail = getPermissionDetails( accountingDocument, fieldName);
+
+        return this.hasEditPermission(accountingDocument, currentUser, permissionDetail, roleQualifiers);
+    }
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/web/struts/ProcurementCardAction.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/web/struts/ProcurementCardAction.java
@@ -7,6 +7,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import edu.arizona.kfs.sys.KFSConstants;
 import edu.arizona.kfs.sys.KFSKeyConstants;
+import edu.arizona.kfs.fp.batch.service.ProcurementCardCreateDocumentService;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.struts.action.ActionForm;
@@ -104,15 +105,7 @@ public class ProcurementCardAction extends org.kuali.kfs.fp.document.web.struts.
         
         List<RouteNodeInstance> routeNodeInstances = procurementCardForm.getProcurementCardDocument().getDocumentHeader().getWorkflowDocument().getCurrentRouteNodeInstances();
         String node = routeNodeInstances.get(0).getName();
-        String documentId = StringUtils.stripStart(procurementCardForm.getDocId(), "0");
-        WorkflowDocumentActionsService documentActions = KewApiServiceLocator.getWorkflowDocumentActionsService();
-        DocumentActionParameters actionParameters = DocumentActionParameters.create(documentId, systemUserPrincipalId, node + ANNOTATION);
-        ReturnPoint returnPoint = ReturnPoint.create(HAS_RECONCILER_NODE);
-        documentActions.superUserReturnToPreviousNode(actionParameters, false, returnPoint);
-
-        // Use requeuer service to put the document back into action list of reconciler
-        DocumentRefreshQueue docRequeue =   KewApiServiceLocator.getDocumentRequeuerService(KFSConstants.APPLICATION_NAMESPACE_CODE, documentId, 0x0);
-        docRequeue.refreshDocument(documentId);
+        SpringContext.getBean(ProcurementCardCreateDocumentService.class).requeueDocument(procurementCardForm.getDocId(), node, HAS_RECONCILER_NODE, ANNOTATION);
 
         return returnToSender(request, mapping, procurementCardForm);
     }

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/web/struts/ProcurementCardAction.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/web/struts/ProcurementCardAction.java
@@ -1,0 +1,125 @@
+package edu.arizona.kfs.fp.document.web.struts;
+
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import edu.arizona.kfs.sys.KFSConstants;
+import edu.arizona.kfs.sys.KFSKeyConstants;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.kuali.kfs.sys.service.impl.KfsParameterConstants;
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.rice.core.api.util.RiceConstants;
+import org.kuali.rice.kew.api.document.DocumentRefreshQueue;
+import org.kuali.rice.krad.bo.Note;
+import org.kuali.rice.kns.question.ConfirmationQuestion;
+import org.kuali.rice.krad.service.NoteService;
+import org.kuali.rice.krad.util.KRADConstants;
+import org.kuali.rice.core.api.util.RiceKeyConstants;
+import org.kuali.rice.kew.api.KewApiServiceLocator;
+import org.kuali.rice.krad.util.KRADUtils;
+import org.kuali.rice.kew.api.action.WorkflowDocumentActionsService;
+import org.kuali.rice.kew.api.action.ReturnPoint;
+import org.kuali.rice.kew.api.document.node.RouteNodeInstance;
+import org.kuali.rice.kew.api.action.DocumentActionParameters;
+import org.kuali.rice.kim.api.identity.Person;
+import org.kuali.rice.kim.api.identity.PersonService;
+import org.kuali.rice.coreservice.framework.parameter.ParameterService;
+
+public class ProcurementCardAction extends org.kuali.kfs.fp.document.web.struts.ProcurementCardAction {
+
+    private static org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(ProcurementCardAction.class);
+    
+    private static final String REASON = "reason";
+    private static final String HAS_RECONCILER_NODE = "HasReconciler";
+    private static final String ANNOTATION = " Approver Return to Reconciler";
+
+    /**
+     *  Provide a mechanism to route/return the pcard document back to the first approval node (reconciler).
+     */
+    public ActionForward returnToReconciler(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        LOG.info("entering ProcurementCardAction returnToReconciler() ...");
+        
+        Object question = request.getParameter(KRADConstants.QUESTION_INST_ATTRIBUTE_NAME);
+        String reason = request.getParameter(KRADConstants.QUESTION_REASON_ATTRIBUTE_NAME);
+        String disapprovalNoteText = KFSConstants.EMPTY_STRING;
+
+        // Use the Disapproval mechanism of forcing a note to be supplied when returning document
+        // back to the reconciler.
+        if (question == null) {
+            // ask question if not already asked
+            return this.performQuestionWithInput(mapping, form, request, response, KRADConstants.DOCUMENT_DISAPPROVE_QUESTION, getKualiConfigurationService().getPropertyValueAsString(KFSKeyConstants.QUESTION_RETURN_DOCUMENT), KRADConstants.CONFIRMATION_QUESTION, KRADConstants.MAPPING_DISAPPROVE, "");
+        }
+        else {
+            Object buttonClicked = request.getParameter(KRADConstants.QUESTION_CLICKED_BUTTON);
+            if ((KRADConstants.DOCUMENT_DISAPPROVE_QUESTION.equals(question)) && ConfirmationQuestion.NO.equals(buttonClicked)) {
+                // if no button clicked just reload the doc
+                return mapping.findForward(RiceConstants.MAPPING_BASIC);
+            }
+            else {
+                // have to check length on value entered
+                String introNoteMessage = getKualiConfigurationService().getPropertyValueAsString(KFSKeyConstants.MESSAGE_RETURN_NOTE_TEXT_INTRO) + KRADConstants.BLANK_SPACE;
+
+                // build out full message
+                disapprovalNoteText = introNoteMessage + reason;
+                int disapprovalNoteTextLength = disapprovalNoteText.length();
+
+                // get note text max length from DD
+                int noteTextMaxLength = getDataDictionaryService().getAttributeMaxLength(Note.class, KRADConstants.NOTE_TEXT_PROPERTY_NAME).intValue();
+
+                if (StringUtils.isBlank(reason) || (disapprovalNoteTextLength > noteTextMaxLength)) {
+                    // figure out exact number of characters that the user can enter
+                    int reasonLimit = noteTextMaxLength - disapprovalNoteTextLength;
+
+                    if (reason == null) {
+                        // prevent a NPE by setting the reason to a blank string
+                        reason = KFSConstants.EMPTY_STRING;
+                    }
+                    return this.performQuestionWithInputAgainBecauseOfErrors(mapping, form, request, response, KRADConstants.DOCUMENT_DISAPPROVE_QUESTION, getKualiConfigurationService().getPropertyValueAsString(KFSKeyConstants.QUESTION_RETURN_DOCUMENT), KRADConstants.CONFIRMATION_QUESTION, KRADConstants.MAPPING_DISAPPROVE, "", reason, KFSKeyConstants.ERROR_DOCUMENT_RETURN_REASON_REQUIRED, KRADConstants.QUESTION_REASON_ATTRIBUTE_NAME, new Integer(reasonLimit).toString());
+                }
+
+                if (KRADUtils.containsSensitiveDataPatternMatch(disapprovalNoteText)) {
+                    return this.performQuestionWithInputAgainBecauseOfErrors(mapping, form, request, response,
+                            KRADConstants.DOCUMENT_DISAPPROVE_QUESTION, getKualiConfigurationService().getPropertyValueAsString(KFSKeyConstants.QUESTION_RETURN_DOCUMENT),
+                            KRADConstants.CONFIRMATION_QUESTION, KRADConstants.MAPPING_DISAPPROVE, "", reason, RiceKeyConstants.ERROR_DOCUMENT_FIELD_CONTAINS_POSSIBLE_SENSITIVE_DATA,
+                            KRADConstants.QUESTION_REASON_ATTRIBUTE_NAME, REASON);
+                }
+            }
+        }
+        
+        Note returnNote = new Note();
+        returnNote.setNoteText(disapprovalNoteText);
+        NoteService noteService = SpringContext.getBean(NoteService.class);
+        ProcurementCardForm procurementCardForm = (ProcurementCardForm) form;
+        
+        String systemUserPrincipalId = getSystemUserPrincipalId();
+        returnNote = noteService.createNote(returnNote, procurementCardForm.getDocument().getNoteTarget(), systemUserPrincipalId);
+        returnNote.setNotePostedTimestampToCurrent();
+        noteService.save(returnNote);
+        
+        List<RouteNodeInstance> routeNodeInstances = procurementCardForm.getProcurementCardDocument().getDocumentHeader().getWorkflowDocument().getCurrentRouteNodeInstances();
+        String node = routeNodeInstances.get(0).getName();
+        String documentId = StringUtils.stripStart(procurementCardForm.getDocId(), "0");
+        WorkflowDocumentActionsService documentActions = KewApiServiceLocator.getWorkflowDocumentActionsService();
+        DocumentActionParameters actionParameters = DocumentActionParameters.create(documentId, systemUserPrincipalId, node + ANNOTATION);
+        ReturnPoint returnPoint = ReturnPoint.create(HAS_RECONCILER_NODE);
+        documentActions.superUserReturnToPreviousNode(actionParameters, false, returnPoint);
+
+        // Use requeuer service to put the document back into action list of reconciler
+        DocumentRefreshQueue docRequeue =   KewApiServiceLocator.getDocumentRequeuerService(KFSConstants.APPLICATION_NAMESPACE_CODE, documentId, 0x0);
+        docRequeue.refreshDocument(documentId);
+
+        return returnToSender(request, mapping, procurementCardForm);
+    }
+    
+    protected String getSystemUserPrincipalId() {
+        String systemUserName = SpringContext.getBean(ParameterService.class).getParameterValueAsString(KRADConstants.KNS_NAMESPACE, KfsParameterConstants.ALL_COMPONENT, KFSConstants.SYSTEM_USER_NAME);
+        Person systemUser = SpringContext.getBean(PersonService.class).getPersonByPrincipalName(systemUserName);
+        return systemUser.getPrincipalId();
+    }
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/web/struts/ProcurementCardForm.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/web/struts/ProcurementCardForm.java
@@ -19,6 +19,8 @@ public class ProcurementCardForm extends org.kuali.kfs.fp.document.web.struts.Pr
     private static final String BUTTON_PROPERTY = "methodToCall.returnToReconciler";
     private static final String BUTTON_SOURCE = "${" + KFSConstants.EXTERNALIZABLE_IMAGES_URL_KEY + "}buttonsmall_return.gif";
     private static final String BUTTON_ALT_TEXT = "Return To Reconciler";
+    
+    private ExtraButton returnButton;
 
     /**
      * Constructs a ProcurementCardForm
@@ -57,10 +59,12 @@ public class ProcurementCardForm extends org.kuali.kfs.fp.document.web.struts.Pr
     }
 
     private ExtraButton returnToReconcilerButton() {
-        ExtraButton returnButton = new ExtraButton();
-        returnButton.setExtraButtonProperty(BUTTON_PROPERTY);
-        returnButton.setExtraButtonSource(BUTTON_SOURCE);
-        returnButton.setExtraButtonAltText(BUTTON_ALT_TEXT);
+        if(returnButton == null) {
+            returnButton = new ExtraButton();
+            returnButton.setExtraButtonProperty(BUTTON_PROPERTY);
+            returnButton.setExtraButtonSource(BUTTON_SOURCE);
+            returnButton.setExtraButtonAltText(BUTTON_ALT_TEXT);
+        }
         return returnButton;
     }
     

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/web/struts/ProcurementCardForm.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/web/struts/ProcurementCardForm.java
@@ -6,12 +6,19 @@ import java.util.List;
 import org.kuali.kfs.fp.document.ProcurementCardDocument;
 import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.rice.coreservice.framework.parameter.ParameterService;
+import org.kuali.rice.kns.web.ui.ExtraButton;
+import org.kuali.rice.kew.api.document.node.RouteNodeInstance;
 
 import edu.arizona.kfs.sys.KFSConstants;
 import edu.arizona.kfs.sys.KFSParameterKeyConstants;
 
 public class ProcurementCardForm extends org.kuali.kfs.fp.document.web.struts.ProcurementCardForm {
     protected static org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(ProcurementCardForm.class);
+    
+    private static final String PROCUREMENT_CARD_RECONCILER = "ProcurementCardReconciler";
+    private static final String BUTTON_PROPERTY = "methodToCall.returnToReconciler";
+    private static final String BUTTON_SOURCE = "${" + KFSConstants.EXTERNALIZABLE_IMAGES_URL_KEY + "}buttonsmall_return.gif";
+    private static final String BUTTON_ALT_TEXT = "Return To Reconciler";
 
     /**
      * Constructs a ProcurementCardForm
@@ -28,6 +35,41 @@ public class ProcurementCardForm extends org.kuali.kfs.fp.document.web.struts.Pr
      */
     public String getDocuwareTableParam() {
         return SpringContext.getBean(ParameterService.class).getParameterValueAsString(ProcurementCardDocument.class, KFSConstants.DOCUWARE_TABLE_PARAMETER);
+    }
+    
+    @Override
+    public List<ExtraButton> getExtraButtons() {
+        extraButtons.clear();
+
+        //Needed to refresh workflow doc to get the state and approval flag set correctly
+        getProcurementCardDocument().getDocumentHeader().getWorkflowDocument().refresh();
+
+        List<RouteNodeInstance> routeNodeInstances = getProcurementCardDocument().getDocumentHeader().getWorkflowDocument().getCurrentRouteNodeInstances();
+        String node = routeNodeInstances.get(0).getName();
+        
+        //Show RETURN to Reconciler button only if user is an approver (and not reconciler)
+        if (getProcurementCardDocument().getDocumentHeader().getWorkflowDocument().isEnroute() &&
+                getProcurementCardDocument().getDocumentHeader().getWorkflowDocument().isApprovalRequested() &&
+                !node.equalsIgnoreCase(PROCUREMENT_CARD_RECONCILER)) {
+            extraButtons.add(returnToReconcilerButton());
+       }
+        return extraButtons;
+    }
+
+    private ExtraButton returnToReconcilerButton() {
+        ExtraButton returnButton = new ExtraButton();
+        returnButton.setExtraButtonProperty(BUTTON_PROPERTY);
+        returnButton.setExtraButtonSource(BUTTON_SOURCE);
+        returnButton.setExtraButtonAltText(BUTTON_ALT_TEXT);
+        return returnButton;
+    }
+    
+    public ProcurementCardDocument getProcurementCardDocument() {
+        return (ProcurementCardDocument) getDocument();
+    }
+
+    public void setProcurementCardDocument(ProcurementCardDocument procurementCardDocument) {
+        setDocument(procurementCardDocument);
     }
 
     /**

--- a/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSConstants.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSConstants.java
@@ -9,6 +9,7 @@ public class KFSConstants extends org.kuali.kfs.sys.KFSConstants {
 
     public static final String INVOICE_NUMBER = "Invoice Number";
     public static final String DUPLICATE_INVOICE_QUESTION_ID = "DVDuplicateInvoice";
+    public static final String SYSTEM_USER_NAME = "SYSTEM_USER_NAME";
 
     public static final String GL_ENTRY_IMPORTING = "glEntryImporting";
     public static final String DOC_FORM_KEY_VALUE_88888888 = "88888888";

--- a/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSKeyConstants.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSKeyConstants.java
@@ -27,5 +27,10 @@ public class KFSKeyConstants extends org.kuali.kfs.sys.KFSKeyConstants {
     
     //DV NonEmployee
     public static final String ERROR_DV_PER_DIEM_START_DT_AFTER_END_DT = "error.dv.perDiemStartDtBeforeAfterEndDt";
+    
+    //PCDO
+    public static final String QUESTION_RETURN_DOCUMENT = "document.question.return.text";
+    public static final String MESSAGE_RETURN_NOTE_TEXT_INTRO = "message.return.noteTextIntro";
+    public static final String ERROR_DOCUMENT_RETURN_REASON_REQUIRED = "error.document.return.reasonRequired";
 
 }

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardHolder.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardHolder.xml
@@ -76,6 +76,7 @@
 		abstract="true" parent="Account-accountNumber">
 		<property name="label" value="Default Account" />
 		<property name="shortLabel" value="Dflt Acct" />
+		<property name="required" value="false" />
 	</bean>
 	<bean id="ProcurementCardHolder-cardCycleAmountLimit" parent="ProcurementCardHolder-cardCycleAmountLimit-parentBean" />
 
@@ -257,6 +258,7 @@
 		abstract="true" parent="Chart-chartOfAccountsCode">
 		<property name="label" value="Default Chart" />
 		<property name="shortLabel" value="Dflt Chrt" />
+		<property name="required" value="false" />
 	</bean>
 	<bean id="ProcurementCardHolder-documentNumber" parent="ProcurementCardHolder-documentNumber-parentBean" />
 

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/ProcurementCardDocument.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/ProcurementCardDocument.xml
@@ -70,7 +70,7 @@
 	  <property name="accountingLineView" ref="ProcurementCard-accountingLineView"/>
 	  <property name="accountingLineClass" value="org.kuali.kfs.fp.businessobject.ProcurementCardTargetAccountingLine"/>
 	  <property name="groupLabel" value="Accounting Lines"/>
-	  <property name="accountingLineAuthorizerClass" value="org.kuali.kfs.fp.document.authorization.ProcurementCardAccountingLineAuthorizer"/>
+	  <property name="accountingLineAuthorizerClass" value="edu.arizona.kfs.fp.document.authorization.ProcurementCardAccountingLineAuthorizer"/>
 	  <property name="importedLinePropertyPrefix" value="target"/>
 	  <property name="totals" ref="ProcurementCard-targetGroupTotals"/>
 	  <property name="errorKey" value="document.targetAccounting*,targetAccountingLines,newTargetLine*"/>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/fp-resources.properties
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/fp-resources.properties
@@ -40,3 +40,8 @@ error.dv.perDiemStartDtBeforeAfterEndDt=The per diem travel start date occurred 
 
 # PCard Errors
 warning.document.procurementcardholderdetail.cardholder.last.active = Cardholder is the only active member of the selected PCard Reconciler workgroup.
+
+# Return to Reconciler
+document.question.return.text=You must enter a reason when Returning Document to Reconciler for correction.  The reason must be no more than 775 characters long.
+message.return.noteTextIntro=Return To Reconciler reason -
+error.document.return.reasonRequired=A reason is required in order to return the pCard back to Reconciler.  Click the no button to CANCEL the return to Reconciler action.

--- a/kfs-web/src/main/webapp/WEB-INF/struts-config.xml
+++ b/kfs-web/src/main/webapp/WEB-INF/struts-config.xml
@@ -1031,6 +1031,16 @@
 			<forward name="running" path="/jsp/pdp/format/processRunning.jsp" />
 		</action>
 		
+        <action path="/financialProcurementCard"
+            name="ProcurementCardForm"
+            input="/jsp/fp/ProcurementCard.jsp"
+            type="edu.arizona.kfs.fp.document.web.struts.ProcurementCardAction"
+            scope="request" parameter="methodToCall" validate="true"
+            attribute="KualiForm">
+            <set-property property="cancellable" value="true"/>
+            <forward name="basic" path="/jsp/fp/ProcurementCard.jsp"/>
+        </action>
+		
 		<action path="/glTrialBalance"
 		    name="TrialBalanceReportForm"
 		    type="org.kuali.kfs.gl.web.struts.TrialBalanceReportAction"

--- a/kfs-web/src/main/webapp/jsp/fp/ProcurementCard.jsp
+++ b/kfs-web/src/main/webapp/jsp/fp/ProcurementCard.jsp
@@ -53,6 +53,12 @@
 
 	<kul:panelFooter />
 
-	<sys:documentControls transactionalDocument="true" />
-
+    <!-- Add the pCard Return to Reconciler button -->
+    <c:set var="extraButtons" value="${KualiForm.extraButtons}"/>
+    
+    <sys:documentControls
+        transactionalDocument="true"
+        extraButtons="${extraButtons}"
+        suppressRoutingControls="${KualiForm.editingMode['displayInitTab']}" />
+        
 </kul:documentPage>


### PR DESCRIPTION
Modified ProcurementCardCreateDocumentServiceImpl.java to change String pcardDocumentId from pcardDocument.getObjectId() to pcardDocument.getDocumentNumber(). This change fixes the following error when running the procurementCardDocumentJob: org.kuali.rice.core.api.exception.RiceIllegalArgumentException: Failed to locate a document for document id: ab1da34d-0393-4005-9496-e78baf06f58b
Added ProcurementCardAccountingLineAuthorizer.java which overrides the determineEditPermissionByFieldName method. Confirmed with the BA, the delivered method is incorrect, the FO should only be able to edit their own account.
Added ProcurementCardAction.java to add the returnToReconciler method which returns the procurement card document back to the first approval node (reconciler).
Modified ProcurementCardForm.java to define the 'return' button and when it should be displayed on the page.
Modified KFSConstants.java to add a constant.
Modified KFSKeyConstants.java to add some constants.
Modified ProcurementCardHolder.xml to remove validation from some fields which caused errors. Becuase this info comes from our vendors and cannot be edited, we cannot have the system validate.
Modified ProcurementCardDocument.xml to point to the new ProcurementCardAccountingLineAuthorizer class
Modified fp-resources.properties to add Return to Reconciler messages.
Modified struts-config.xml to use the new ProcurementCardAction.java class.
Modified ProcurementCard.jsp to include the extra buttons.