### PR TITLE
UAF-2788 disbursementVoucherPreDisbursementProcessorExtractJob is not…

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/dataaccess/impl/DisbursementVoucherDaoOjb.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/dataaccess/impl/DisbursementVoucherDaoOjb.java
@@ -1,0 +1,29 @@
+package edu.arizona.kfs.fp.dataaccess.impl;
+
+import java.util.Collection;
+
+import org.apache.ojb.broker.query.Criteria;
+import org.apache.ojb.broker.query.QueryByCriteria;
+
+import edu.arizona.kfs.fp.document.DisbursementVoucherDocument;
+import edu.arizona.kfs.sys.KFSConstants;
+import edu.arizona.kfs.sys.KFSPropertyConstants;
+
+public class DisbursementVoucherDaoOjb extends org.kuali.kfs.fp.dataaccess.impl.DisbursementVoucherDaoOjb {
+    private static org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(DisbursementVoucherDaoOjb.class);
+    private static final String FINANCIAL_DOCUMENT_STATUS_CODE = KFSConstants.DOCUMENT_HEADER_PROPERTY_NAME + "." + KFSPropertyConstants.FINANCIAL_DOCUMENT_STATUS_CODE;
+    
+    @Override
+    public Collection<DisbursementVoucherDocument> getDocumentsByHeaderStatus(String statusCode, boolean immediatesOnly) {
+        LOG.debug("getDocumentsByHeaderStatus() started");
+
+        Criteria criteria = new Criteria();
+        criteria.addEqualTo(FINANCIAL_DOCUMENT_STATUS_CODE, statusCode);
+        criteria.addEqualTo(KFSPropertyConstants.DISB_VCHR_PAYMENT_METHOD_CODE, KFSConstants.PaymentSourceConstants.PAYMENT_METHOD_CHECK);
+        if (immediatesOnly) {
+            criteria.addEqualTo(KFSPropertyConstants.IMMEDIATE_PAYMENT_INDICATOR, Boolean.TRUE);
+        }
+
+        return getPersistenceBrokerTemplate().getCollectionByQuery(new QueryByCriteria(DisbursementVoucherDocument.class, criteria));
+    }
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/DisbursementVoucherDocument.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/DisbursementVoucherDocument.java
@@ -64,7 +64,7 @@ public class DisbursementVoucherDocument extends org.kuali.kfs.fp.document.Disbu
         super.prepareForSave();
 
         DocumentDictionaryService documentDictionaryService = SpringContext.getBean(DocumentDictionaryService.class);
-        DocumentAuthorizer docAuth = documentDictionaryService.getDocumentAuthorizer(this);
+        DocumentAuthorizer docAuth = documentDictionaryService.getDocumentAuthorizer(DisbursementVoucherConstants.DOCUMENT_TYPE_CODE);
 
         // First, only do this if the document is in initiated status - after that, we don't want to 
         // accidentally reset the bank code
@@ -83,7 +83,7 @@ public class DisbursementVoucherDocument extends org.kuali.kfs.fp.document.Disbu
             }
         } 
         else{           
-            TransactionalDocumentPresentationController presentationController = (TransactionalDocumentPresentationController) documentDictionaryService.getDocumentPresentationController(this);
+            TransactionalDocumentPresentationController presentationController = (TransactionalDocumentPresentationController) documentDictionaryService.getDocumentPresentationController(DisbursementVoucherConstants.DOCUMENT_TYPE_CODE);
             if(presentationController.getEditModes(this).contains(KFSConstants.Authorization.PAYMENT_METHOD_EDIT_MODE)){
                 synchronizeBankCodeWithPaymentMethod();
             }

--- a/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSConstants.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSConstants.java
@@ -168,4 +168,8 @@ public class KFSConstants extends org.kuali.kfs.sys.KFSConstants {
             }
         }
     }
+    
+    public static class PaymentSourceConstants {
+        public static final String PAYMENT_METHOD_CHECK = "A";
+    }
 }

--- a/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSPropertyConstants.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSPropertyConstants.java
@@ -30,4 +30,5 @@ public class KFSPropertyConstants extends org.kuali.kfs.sys.KFSPropertyConstants
     public static final String PAYMENT_METHOD_CODE = "paymentMethodCode";
     public static final String PAID_DATE = "paidDate";
 
+    public static final String IMMEDIATE_PAYMENT_INDICATOR = "immediatePaymentIndicator";
 }

--- a/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/changesets/db.changelog-UAF-2788.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/changesets/db.changelog-UAF-2788.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="UAF-2788-1" author="Mark Moen">
+        <preConditions onError="HALT" onFail="HALT">
+            <sqlCheck expectedResult="1">
+                SELECT COUNT(*) FROM KRCR_PARM_T
+                    WHERE NMSPC_CD='KFS-FP'
+                        AND CMPNT_CD='DisbursementVoucher'
+                        AND PARM_NM='PAYMENT_REASON_CODE_ROYALTIES'
+                        AND APPL_ID='KFS'
+            </sqlCheck>
+        </preConditions>
+        <comment>
+            UAF-2788 disbursementVoucherPreDisbursementProcessorExtractJob is not working
+        </comment>
+        <update tableName="KRCR_PARM_T">
+            <column name="VAL" value="R"/>
+            <where>NMSPC_CD='KFS-FP'
+                    AND CMPNT_CD='DisbursementVoucher'
+                    AND PARM_NM='PAYMENT_REASON_CODE_ROYALTIES'
+                    AND APPL_ID='KFS'
+            </where>
+        </update>
+        <rollback>
+            <update tableName="KRCR_PARM_T">
+                <column name="VAL" value="" />
+                <where>NMSPC_CD='KFS-FP'
+                    AND CMPNT_CD='DisbursementVoucher'
+                    AND PARM_NM='PAYMENT_REASON_CODE_ROYALTIES'
+                    AND APPL_ID='KFS'
+            </where>
+            </update>
+        </rollback>
+    </changeSet>
+    
+    <changeSet id="UAF-2788-2" author="Mark Moen">
+        <preConditions onError="HALT" onFail="HALT">
+            <sqlCheck expectedResult="1">
+                SELECT COUNT(*) FROM KRCR_PARM_T
+                    WHERE NMSPC_CD='KFS-FP'
+                        AND CMPNT_CD='DisbursementVoucher'
+                        AND PARM_NM='PAYMENT_REASON_CODE_RENTAL_PAYMENT'
+                        AND APPL_ID='KFS'
+            </sqlCheck>
+        </preConditions>
+        <comment>
+            UAF-2788 disbursementVoucherPreDisbursementProcessorExtractJob is not working
+        </comment>
+        <update tableName="KRCR_PARM_T">
+            <column name="VAL" value="T"/>
+            <where>NMSPC_CD='KFS-FP'
+                    AND CMPNT_CD='DisbursementVoucher'
+                    AND PARM_NM='PAYMENT_REASON_CODE_RENTAL_PAYMENT'
+                    AND APPL_ID='KFS'
+            </where>
+        </update>
+        <rollback>
+            <update tableName="KRCR_PARM_T">
+                <column name="VAL" value="" />
+                <where>NMSPC_CD='KFS-FP'
+                    AND CMPNT_CD='DisbursementVoucher'
+                    AND PARM_NM='PAYMENT_REASON_CODE_RENTAL_PAYMENT'
+                    AND APPL_ID='KFS'
+                </where>
+            </update>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/db.changelog-master.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/db.changelog-master.xml
@@ -24,4 +24,5 @@
   <include file="changesets/db.changelog-UAF-2791.xml" />
   <include file="changesets/db.changelog-UAF-2877.xml" />
   <include file="changesets/db.changelog-UAF-3004.xml" />
+  <include file="changesets/db.changelog-UAF-2788.xml" />
 </databaseChangeLog>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/spring-fp.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/spring-fp.xml
@@ -109,5 +109,7 @@
 			<ref bean="parameterEvaluatorService" />
 		</property>
 	</bean>
+	
+	<bean id="disbursementVoucherDao" class="edu.arizona.kfs.fp.dataaccess.impl.DisbursementVoucherDaoOjb" parent="platformAwareDao" />
 
 </beans>


### PR DESCRIPTION
… working

Added new file DisbursementVoucherDaoOjb.java to override the getDocumentsByHeaderStatus method to use the new payment method code for ACH/Check.
Modified DisbursementVoucherDocument.java because passing in 'this' as the argument was causing java.lang.IllegalArgumentException: invalid (null) document.documentHeader.workflowDocument. Possibly because it was looking for the wrong DisbursementVoucherDocument (edu/arizona vs org/kuali).
Modified KFSConstants.java to override PAYMENT_METHOD_CHECK. This values has changed from 'P' to 'A'.
Modified KFSPropertyConstants.java to include IMMEDIATE_PAYMENT_INDICATOR.
Added new file db.changelog-UAF-2788.xml to give values R and T for parameters PAYMENT_REASON_CODE_ROYALTIES and PAYMENT_REASON_CODE_RENTAL_PAYMENT respectively. Without these values, it will throw a null pointer exception at DisbursementVoucherExtractionHelperServiceImpl.java line 194.
Modified db.changelog-master.xml to include new changelog db.changelog-UAF-2788.xml.
Modified spring-fp.xml to point to the new DisbursementVoucherDaoOjb.java.