### PR TITLE
UAF-2392 UAF-2394 Banking Information from External Sources Step 1 (Modify pdpLoadFederalReserveBankDataJob)

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/pdp/batch/LoadFederalReserveBankDataStep.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/pdp/batch/LoadFederalReserveBankDataStep.java
@@ -1,0 +1,18 @@
+package edu.arizona.kfs.pdp.batch;
+
+import java.util.Date;
+
+import edu.arizona.kfs.sys.KFSConstants;
+
+public class LoadFederalReserveBankDataStep extends org.kuali.kfs.pdp.batch.LoadFederalReserveBankDataStep {
+	private static org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(LoadFederalReserveBankDataStep.class);
+
+	@Override
+	public boolean execute(String jobName, Date jobRunDate) throws InterruptedException {
+		LOG.debug("execute() started");
+		//for the moment this job will be deprecated as new functionality will be addressed on UAF-3059 per epic specs
+		throw new RuntimeException(KFSConstants.DEPRECATED_PDP_LOAD_FEDERAL_RESERVE_BANK_DATA_STEP_JOB);
+		
+	}
+
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSConstants.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSConstants.java
@@ -39,6 +39,9 @@ public class KFSConstants extends org.kuali.kfs.sys.KFSConstants {
     
     public static final String DOCUWARE_DV_DOC_TYPE = "DV";
     public static final String DOCUWARE_PREQ_DOC_TYPE = "PREQ";
+    
+    //PDP Batch
+    public static final String DEPRECATED_PDP_LOAD_FEDERAL_RESERVE_BANK_DATA_STEP_JOB = "This job is deprecated; not intended to be used in UA implementation.";
 
     public static class CreateAndUpdateNotePrefixes {
         public static final String ADD = "Add";

--- a/kfs-core/src/main/resources/edu/arizona/kfs/pdp/spring-pdp.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/pdp/spring-pdp.xml
@@ -94,7 +94,8 @@
     <bean id="pdpLoadFederalReserveBankDataJob" parent="unscheduledJobDescriptor">
         <property name="steps">
             <list>
-                <ref bean="pdpDownloadFederalReserveBankFileStep" />
+            <!-- pdpDownloadFederalReserveBankFileStep was commented out because the fix will be addressed on UAF-3059 per epic specs -->
+            <!-- <ref bean="pdpDownloadFederalReserveBankFileStep" /> -->
                 <ref bean="pdpLoadFederalReserveBankDataStep" />
             </list>
         </property>
@@ -237,5 +238,8 @@
             <ref bean="shippingInvoiceProcessService" />
         </property>	
 	</bean>	
+	
+	<bean id="pdpLoadFederalReserveBankDataStep" class="edu.arizona.kfs.pdp.batch.LoadFederalReserveBankDataStep" parent="step" />
+	
 
 </beans>


### PR DESCRIPTION
File(s) created
1. edu\arizona\kfs\pdp\batch\LoadFederalReserveBankDataStep
* overrode execute method to throw a RuntimeException when pdpLoadFederalReserveBankDataJob is being ran. This job will be deprecated at the moment because the functionality does not comply with UofA business criteria. This will be addressed on UAF-3059 per epic specs.

File(s) modified
1. edu\arizona\kfs\pdp\spring-pdp.xml --> 
* pdpLoadFederalReserveBankDataJob bean was modified to only take  into account step 2(pdpLoadFederalReserveBankDataStep) as step 1 (pdpDownloadFederalReserveBankFileStep) was failing because the url from which the file was being downloaded is not longer functional. This will be addressed on UAF-3059 per epic specs.

* overrode pdpLoadFederalReserveBankDataStep bean to make reference to the new LoadFederalReserveBankDataStep class

2. edu\arizona\kfs\sys\KFSConstants
* added constant DEPRECATED_PDP_LOAD_FEDERAL_RESERVE_BANK_DATA_STEP_JOB = "This job is deprecated; not intended to be used in UA implementation."; which will contain the error message pdpLoadFederalReserveBankDataJob will throw.