### PR TITLE
UAF-2967 Procurement Card Reconciliation Step 4 (Postback)

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/impl/ProcurementCardCreateDocumentServiceImpl.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/impl/ProcurementCardCreateDocumentServiceImpl.java
@@ -14,6 +14,8 @@ import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.fp.batch.ProcurementCardAutoApproveDocumentsStep;
 import org.kuali.kfs.fp.batch.ProcurementCardCreateDocumentsStep;
 import org.kuali.kfs.fp.businessobject.CapitalAssetInformation;
+import org.kuali.kfs.fp.businessobject.ProcurementCardSourceAccountingLine;
+import org.kuali.kfs.fp.businessobject.ProcurementCardTargetAccountingLine;
 import org.kuali.kfs.fp.document.validation.impl.ProcurementCardDocumentRuleConstants;
 import org.kuali.kfs.sys.KFSPropertyConstants;
 import org.kuali.kfs.sys.context.SpringContext;
@@ -38,6 +40,7 @@ import edu.arizona.kfs.fp.batch.ProcurementCardRerouteDocumentsStep;
 import edu.arizona.kfs.fp.businessobject.ProcurementCardDefault;
 import edu.arizona.kfs.fp.businessobject.ProcurementCardHolder;
 import edu.arizona.kfs.fp.businessobject.ProcurementCardTransaction;
+import edu.arizona.kfs.fp.businessobject.ProcurementCardTransactionDetail;
 import edu.arizona.kfs.fp.document.ProcurementCardDocument;
 
 public class ProcurementCardCreateDocumentServiceImpl extends org.kuali.kfs.fp.batch.service.impl.ProcurementCardCreateDocumentServiceImpl {
@@ -243,8 +246,6 @@ public class ProcurementCardCreateDocumentServiceImpl extends org.kuali.kfs.fp.b
             }
 
             pcardDocument.getFinancialSystemDocumentHeader().setFinancialDocumentTotalAmount(documentTotalAmount);
-            // PCDO Default Description
-            setupDocumentDescription(pcardDocument);
 
             // In case errorText is still too long, truncate it and indicate so.
             if (documentExplanationMaxLength != null && transactionIssuesSummary.length() > documentExplanationMaxLength.intValue()) {
@@ -396,6 +397,25 @@ public class ProcurementCardCreateDocumentServiceImpl extends org.kuali.kfs.fp.b
         }
 
         return true;
+    }
+    
+    @Override
+    protected String createAndValidateAccountingLines(org.kuali.kfs.fp.document.ProcurementCardDocument pcardDocument, ProcurementCardTransaction transaction, ProcurementCardTransactionDetail docTransactionDetail) {
+        //get default values from custom Procurement Cardholder table
+        ProcurementCardDefault procurementCardHolderDetail = getProcurementCardDefault(transaction.getTransactionCreditCardNumber());
+
+        String cardHolderName = transaction.getCardHolderName();
+        if (cardHolderName.length() > 24) {
+            cardHolderName = transaction.getCardHolderName().substring(0, 24);
+        }
+        if(ObjectUtils.isNotNull(procurementCardHolderDetail)) {
+            pcardDocument.getDocumentHeader().setDocumentDescription(procurementCardHolderDetail.getCreditCardLastFour().trim() + " / " + cardHolderName);
+        }
+        else {
+            pcardDocument.getDocumentHeader().setDocumentDescription("None / " + cardHolderName);
+        }
+        
+        return super.createAndValidateAccountingLines(pcardDocument, transaction, docTransactionDetail);
     }
     
     /**

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/impl/ProcurementCardCreateDocumentServiceImpl.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/impl/ProcurementCardCreateDocumentServiceImpl.java
@@ -48,6 +48,7 @@ public class ProcurementCardCreateDocumentServiceImpl extends org.kuali.kfs.fp.b
     private static org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(ProcurementCardCreateDocumentServiceImpl.class);
     
     private GroupService procurementCardGroupService;
+    private static final int CARDHOLDER_NAME_MAX_LENGTH = 24;
     
     public GroupService getProcurementCardGroupService(){
         return procurementCardGroupService;
@@ -405,8 +406,8 @@ public class ProcurementCardCreateDocumentServiceImpl extends org.kuali.kfs.fp.b
         ProcurementCardDefault procurementCardHolderDetail = getProcurementCardDefault(transaction.getTransactionCreditCardNumber());
 
         String cardHolderName = transaction.getCardHolderName();
-        if (cardHolderName.length() > 24) {
-            cardHolderName = transaction.getCardHolderName().substring(0, 24);
+        if (cardHolderName.length() > CARDHOLDER_NAME_MAX_LENGTH) {
+            cardHolderName = transaction.getCardHolderName().substring(0, CARDHOLDER_NAME_MAX_LENGTH);
         }
         if(ObjectUtils.isNotNull(procurementCardHolderDetail)) {
             pcardDocument.getDocumentHeader().setDocumentDescription(procurementCardHolderDetail.getCreditCardLastFour().trim() + " / " + cardHolderName);

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/ProcurementCardDocument.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/ProcurementCardDocument.java
@@ -1,11 +1,20 @@
 package edu.arizona.kfs.fp.document;
 
+import java.sql.Date;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
 
+import org.kuali.kfs.fp.batch.ProcurementCardLoadStep;
+import org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntry;
+import org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntrySourceDetail;
+import org.kuali.kfs.sys.businessobject.SourceAccountingLine;
+import org.kuali.kfs.sys.businessobject.TargetAccountingLine;
 import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.rice.kim.api.group.GroupService;
 import org.kuali.rice.krad.util.ObjectUtils;
+import org.kuali.kfs.sys.service.UniversityDateService;
+import org.kuali.rice.coreservice.framework.parameter.ParameterService;
 
 import edu.arizona.kfs.fp.businessobject.ProcurementCardHolder;
 import org.apache.commons.lang.StringUtils;
@@ -21,6 +30,8 @@ public class ProcurementCardDocument extends org.kuali.kfs.fp.document.Procureme
     private static final long serialVersionUID = 1L;
     
     private static final String HAS_RECONCILER_NODE = "HasReconciler";
+    private static final String FINAL_ACCOUNTING_PERIOD = "13";
+    private static final String ALLOW_BACKPOST_DAYS = "ALLOW_BACKPOST_DAYS";
     
     protected ProcurementCardHolder procurementCardHolder;
     
@@ -31,6 +42,55 @@ public class ProcurementCardDocument extends org.kuali.kfs.fp.document.Procureme
 
     public void setProcurementCardHolder(ProcurementCardHolder procurementCardHolder) {
         this.procurementCardHolder = procurementCardHolder;
+    }
+    
+    /**
+     * @return the previous fiscal year used with all GLPE
+     */
+    protected static final Integer getPreviousFiscalYear() {
+        int i = SpringContext.getBean(UniversityDateService.class).getCurrentFiscalYear().intValue() - 1;
+        return new Integer(i);
+    }
+
+    @Override
+    public void customizeExplicitGeneralLedgerPendingEntry(GeneralLedgerPendingEntrySourceDetail postable, GeneralLedgerPendingEntry explicitEntry) {
+        Date temp = getProcurementCardTransactionPostingDetailDate();
+        
+        if( temp != null && allowBackpost(temp) ) {
+            Integer prevFiscYr = getPreviousFiscalYear();
+            
+            explicitEntry.setUniversityFiscalPeriodCode(FINAL_ACCOUNTING_PERIOD);
+            explicitEntry.setUniversityFiscalYear(prevFiscYr);
+            
+            if( !getDocumentHeader().getDocumentDescription().contains("FY " + prevFiscYr) ) {
+                getDocumentHeader().setDocumentDescription("FY " + prevFiscYr + " " + getDocumentHeader().getDocumentDescription());
+            } 
+            
+            List<SourceAccountingLine> srcLines = getSourceAccountingLines();
+            
+            for(SourceAccountingLine src : srcLines) {
+                src.setPostingYear(prevFiscYr);
+            }
+
+            List<TargetAccountingLine> trgLines = getTargetAccountingLines();
+            
+            for(TargetAccountingLine trg : trgLines) {
+                trg.setPostingYear(prevFiscYr);
+            }
+        }
+    }
+    
+    /**
+     * Get Transaction Date - CSU assumes there will be only one
+     */
+    private Date getProcurementCardTransactionPostingDetailDate() {
+        Date date = null;
+        
+        if(!getTransactionEntries().isEmpty()) {
+            date = ((ProcurementCardTransactionDetail)getTransactionEntries().get(0)).getTransactionPostingDate();
+        }
+        
+        return date;
     }
 
     /**
@@ -92,5 +152,37 @@ public class ProcurementCardDocument extends org.kuali.kfs.fp.document.Procureme
         title = title + " / " + tranNumber + " / " + vendorName + " / $" + totAmount;
          
         return title;
+    }
+    
+    protected boolean allowBackpost(Date tranDate) {
+        ParameterService parameterService = SpringContext.getBean(ParameterService.class);
+        UniversityDateService universityDateService = SpringContext.getBean(UniversityDateService.class);
+       
+        int allowBackpost = (Integer.parseInt(parameterService.getParameterValueAsString(ProcurementCardLoadStep.class, ALLOW_BACKPOST_DAYS)));
+
+        Calendar today = Calendar.getInstance();
+        Integer currentFY = universityDateService.getCurrentUniversityDate().getUniversityFiscalYear();
+        java.util.Date priorClosingDateTemp = universityDateService.getLastDateOfFiscalYear(currentFY - 1);
+        
+        Calendar priorClosingDate = Calendar.getInstance();
+        priorClosingDate.setTime(priorClosingDateTemp);
+
+        // adding 1 to set the date to midnight the day after backpost is allowed so that preqs allow backpost on the last day
+        Calendar allowBackpostDate = Calendar.getInstance();
+        allowBackpostDate.setTime(priorClosingDate.getTime());
+        allowBackpostDate.add(Calendar.DATE, allowBackpost + 1);
+
+        Calendar tranCal = Calendar.getInstance();
+        tranCal.setTime(tranDate);
+
+        // if today is after the closing date but before/equal to the allowed backpost date and the transaction date is for the
+        // prior year, set the year to prior year
+        if ((today.compareTo(priorClosingDate) > 0) && (today.compareTo(allowBackpostDate) <= 0) && (tranCal.compareTo(priorClosingDate) <= 0)) {
+            LOG.debug("allowBackpost() within range to allow backpost; posting entry to period 12 of previous FY");
+            return true;
+        }
+
+        LOG.debug("allowBackpost() not within range to allow backpost; posting entry to current FY");
+        return false;
     }
 }

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/ProcurementCardDocument.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/ProcurementCardDocument.java
@@ -62,8 +62,9 @@ public class ProcurementCardDocument extends org.kuali.kfs.fp.document.Procureme
             explicitEntry.setUniversityFiscalPeriodCode(FINAL_ACCOUNTING_PERIOD);
             explicitEntry.setUniversityFiscalYear(prevFiscYr);
             
-            if( !getDocumentHeader().getDocumentDescription().contains("FY " + prevFiscYr) ) {
-                getDocumentHeader().setDocumentDescription("FY " + prevFiscYr + " " + getDocumentHeader().getDocumentDescription());
+            String documentDescription = getDocumentHeader().getDocumentDescription();
+            if(StringUtils.isNotEmpty(documentDescription) && !documentDescription.contains("FY " + prevFiscYr) ) {
+                getDocumentHeader().setDocumentDescription("FY " + prevFiscYr + " " + documentDescription);
             } 
             
             List<SourceAccountingLine> srcLines = getSourceAccountingLines();
@@ -158,7 +159,15 @@ public class ProcurementCardDocument extends org.kuali.kfs.fp.document.Procureme
         ParameterService parameterService = SpringContext.getBean(ParameterService.class);
         UniversityDateService universityDateService = SpringContext.getBean(UniversityDateService.class);
        
-        int allowBackpost = (Integer.parseInt(parameterService.getParameterValueAsString(ProcurementCardLoadStep.class, ALLOW_BACKPOST_DAYS)));
+        String allowBackpostParam = parameterService.getParameterValueAsString(ProcurementCardLoadStep.class, ALLOW_BACKPOST_DAYS);
+        int allowBackpost = 0;
+        if (StringUtils.isNotEmpty(allowBackpostParam) && StringUtils.isNumeric(allowBackpostParam)) {
+            allowBackpost = (Integer.parseInt(allowBackpostParam));
+        }
+        else {
+            LOG.debug("Invalid value for allowBackpostParam: " + allowBackpostParam + ". Returning false");
+            return false;
+        }
 
         Calendar today = Calendar.getInstance();
         Integer currentFY = universityDateService.getCurrentUniversityDate().getUniversityFiscalYear();


### PR DESCRIPTION
Modified ProcurementCardCreateDocumentServiceImpl.java to set the description the same way it is done in KFS 3.0. This fixes the issue where backpost is allowed and the description is changed to add additional text to the beginning of the descripition. When the GLPE's were saved, transactionLedgerEntryDescription was over the maximum 40 characters the database allows for that field.
Modified ProcurementCardDocument.java to override the customizeExplicitGeneralLedgerPendingEntry method to include backposting, plus helper methods.