### PR TITLE
UAF-3005 - Activating override for GEC lines with expired accounts.

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/web/struts/GeneralErrorCorrectionAction.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/web/struts/GeneralErrorCorrectionAction.java
@@ -81,6 +81,9 @@ public class GeneralErrorCorrectionAction extends org.kuali.kfs.fp.document.web.
                     gecDoc.getGecEntryRelationships().add(gecEntryRelationship);
                 }
 
+                processAccountingLineOverrides(gecDoc, gecDoc.getSourceAccountingLines());
+                processAccountingLineOverrides(gecDoc, gecDoc.getTargetAccountingLines());
+
                 // next refresh should not attempt to retrieve these objects.
                 gecForm.setLookupResultsSequenceNumber(KFSConstants.EMPTY_STRING);
 
@@ -293,13 +296,17 @@ public class GeneralErrorCorrectionAction extends org.kuali.kfs.fp.document.web.
 
     public ActionForward copyAllAccountingLines(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) throws Exception {
         GeneralErrorCorrectionForm gecForm = (GeneralErrorCorrectionForm) form;
+        GeneralErrorCorrectionDocument gecDoc = (GeneralErrorCorrectionDocument) gecForm.getDocument();
+
         for (Object line : gecForm.getFinancialDocument().getSourceAccountingLines()) {
             AccountingLine sourceLine = (AccountingLine) line;
             AccountingLine targetLine = (AccountingLine) gecForm.getFinancialDocument().getTargetAccountingLineClass().newInstance();
             reverseAccountingLine(sourceLine, targetLine);
             insertAccountingLine(false, gecForm, targetLine);
-            processAccountingLineOverrides(targetLine);
         }
+
+        processAccountingLineOverrides(gecDoc, gecDoc.getSourceAccountingLines());
+        processAccountingLineOverrides(gecDoc, gecDoc.getTargetAccountingLines());
 
         resequenceAccountingLines(gecForm);
         return mapping.findForward(KFSConstants.MAPPING_BASIC);
@@ -395,6 +402,8 @@ public class GeneralErrorCorrectionAction extends org.kuali.kfs.fp.document.web.
 
         reverseAccountingLine(sourceLine, targetLine);
         insertAccountingLine(false, gecForm, targetLine);
+
+        processAccountingLineOverrides(sourceLine);
         processAccountingLineOverrides(targetLine);
 
         resequenceAccountingLines(gecForm);
@@ -413,6 +422,8 @@ public class GeneralErrorCorrectionAction extends org.kuali.kfs.fp.document.web.
         copyAccountingLine(gecDocument, originalLine, targetLine);
         targetLine.setAmount(KualiDecimal.ZERO);
         insertAccountingLine(false, gecForm, targetLine);
+
+        processAccountingLineOverrides(originalLine);
         processAccountingLineOverrides(targetLine);
 
         resequenceAccountingLines(gecForm);

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/GeneralErrorCorrectionDocumentSourceAccountingLine.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/GeneralErrorCorrectionDocumentSourceAccountingLine.xml
@@ -89,6 +89,12 @@
         <property name="webUILeaveFieldFunction" value="loadAccountInfo" />
         <property name="dynamicLabelProperty" value="account.accountName" />
         <property name="useShortLabel" value="true" />
+        <property name="overrideFields">
+            <list>
+                <bean parent="AccountingLineView-overrideField" p:name="accountExpiredOverride" />
+                <bean parent="AccountingLineView-overrideField" p:name="nonFringeAccountOverride" />
+            </list>
+        </property>
     </bean>
 
     <bean id="GeneralErrorCorrectionDocument-sourceAccountingField-subAccountNumber" parent="AccountingLineView-field">

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/GeneralErrorCorrectionDocumentTargetAccountingLine.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/GeneralErrorCorrectionDocumentTargetAccountingLine.xml
@@ -88,6 +88,12 @@
         <property name="webUILeaveFieldFunction" value="loadAccountInfo" />
         <property name="dynamicLabelProperty" value="account.accountName" />
         <property name="useShortLabel" value="true" />
+        <property name="overrideFields">
+            <list>
+                <bean parent="AccountingLineView-overrideField" p:name="accountExpiredOverride" />
+                <bean parent="AccountingLineView-overrideField" p:name="nonFringeAccountOverride" />
+            </list>
+        </property>
     </bean>
 
     <bean id="GeneralErrorCorrectionDocument-targetAccountingField-subAccountNumber" parent="AccountingLineView-field">


### PR DESCRIPTION
This fix is two part: 1. adding spring wiring to turn on control, 2. adding in java code to ensure newly copied lines have had their flags set for any needed overrides. The is done in the spring config for the source/target lines, and in the GEC action -- noteworthy is that these changes only affect GEC, so should carry lower risk.