### PR TITLE
UAF-2969 Procurement Card Reconciliation Step 6 (FYI to Cardholder & …

### DIFF
--- a/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/changesets/db.changelog-UAF-2969.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/changesets/db.changelog-UAF-2969.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="UAF-2969-1" author="Mark Moen">
+        <preConditions onError="HALT" onFail="HALT">
+            <sqlCheck expectedResult="1">
+                SELECT COUNT(*) FROM KRCR_PARM_T
+                    WHERE NMSPC_CD='KFS-FP'
+                        AND CMPNT_CD='ProcurementCardCreateDocumentsStep'
+                        AND PARM_NM='PROCUREMENT_CARD_HOLDER_DEFAULT_IND'
+                        AND APPL_ID='KFS'
+            </sqlCheck>
+        </preConditions>
+        <comment>
+            UAF-2969 Procurement Card Reconciliation Step 6 (FYI to Cardholder and Original Vendor Name Mapping)
+        </comment>
+        <update tableName="KRCR_PARM_T">
+            <column name="VAL" value="N"/>
+            <where>NMSPC_CD='KFS-FP'
+                    AND CMPNT_CD='ProcurementCardCreateDocumentsStep'
+                    AND PARM_NM='PROCUREMENT_CARD_HOLDER_DEFAULT_IND'
+                    AND APPL_ID='KFS'
+            </where>
+        </update>
+        <rollback>
+            <update tableName="KRCR_PARM_T">
+                <column name="VAL" value="Y" />
+                <where>NMSPC_CD='KFS-FP'
+                    AND CMPNT_CD='ProcurementCardCreateDocumentsStep'
+                    AND PARM_NM='PROCUREMENT_CARD_HOLDER_DEFAULT_IND'
+                    AND APPL_ID='KFS'
+                </where>
+            </update>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/db.changelog-master.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/db.changelog-master.xml
@@ -24,4 +24,5 @@
   <include file="changesets/db.changelog-UAF-2791.xml" />
   <include file="changesets/db.changelog-UAF-2877.xml" />
   <include file="changesets/db.changelog-UAF-3004.xml" />
+  <include file="changesets/db.changelog-UAF-2969.xml" />
 </databaseChangeLog>


### PR DESCRIPTION
…Original Vendor Name Mapping)

Added new file db.changelog-UAF-2969.xml to change the value of parameter PROCUREMENT_CARD_HOLDER_DEFAULT_IND from 'Y' to 'N'. This change will load data from the transaction file instead of the data in the cardholder default table.
Modified db.changelog-master.xml to include db.changelog-UAF-2969.xml