### PR TITLE
UAF-2837 : Move 'Awaiting Receiving' doc status check to query critera

### DIFF
--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/dataaccess/impl/PaymentRequestDaoOjb.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/dataaccess/impl/PaymentRequestDaoOjb.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.apache.log4j.Logger;
 import org.apache.ojb.broker.query.Criteria;
 import org.apache.ojb.broker.query.QueryByCriteria;
+import org.kuali.kfs.module.purap.PurapConstants.PaymentRequestStatuses;
 import org.kuali.kfs.module.purap.document.PaymentRequestDocument;
 import org.kuali.kfs.module.purap.util.VendorGroupingHelper;
 
@@ -104,4 +105,18 @@ public class PaymentRequestDaoOjb extends org.kuali.kfs.module.purap.document.da
 
         return getPersistenceBrokerTemplate().getCollectionByQuery(new QueryByCriteria(edu.arizona.kfs.module.purap.document.PaymentRequestDocument.class, criteria));
     }
+    
+    @Override
+    public List<PaymentRequestDocument> getPaymentRequestInReceivingStatus() {
+        Criteria criteria = new Criteria();
+        criteria.addNotEqualTo("holdIndicator", "Y");
+        criteria.addNotEqualTo("paymentRequestedCancelIndicator", "Y");
+        // UAF-2837 : Added this criteria 
+    	criteria.addEqualTo("documentHeader.applicationDocumentStatus", PaymentRequestStatuses.APPDOC_AWAITING_RECEIVING_REVIEW);
+
+    	QueryByCriteria qbc = new QueryByCriteria(PaymentRequestDocument.class, criteria);
+        return this.getPaymentRequestsByQueryByCriteria(qbc);
+
+    }
+
 }

--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/service/impl/PaymentRequestServiceImpl.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/service/impl/PaymentRequestServiceImpl.java
@@ -235,4 +235,30 @@ public class PaymentRequestServiceImpl extends org.kuali.kfs.module.purap.docume
             }
         }
     }
+    
+    @Override
+    public void processPaymentRequestInReceivingStatus() {
+        List<PaymentRequestDocument> preqs = paymentRequestDao.getPaymentRequestInReceivingStatus();
+
+        List<PaymentRequestDocument> preqsAwaitingReceiving = new ArrayList<PaymentRequestDocument>();
+        for (PaymentRequestDocument preq : preqs) {
+
+            if (ObjectUtils.isNotNull(preq)) {
+                preqsAwaitingReceiving.add(preq);
+            }
+        }
+        for (PaymentRequestDocument preqDoc : preqsAwaitingReceiving) {
+        	// UAF-2837 : Removed doc status check of APPDOC_AWAITING_RECEIVING_REVIEW because it is handled in getcollection query criteria
+            if (preqDoc.isReceivingRequirementMet()) {
+                try {
+                    documentService.approveDocument(preqDoc, "Approved by Receiving Required PREQ job", null);
+                }
+                catch (WorkflowException e) {
+                    LOG.error("processPaymentRequestInReceivingStatus() Error approving payment request document from awaiting receiving", e);
+                    throw new RuntimeException("Error approving payment request document from awaiting receiving", e);
+                }
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Current code is checking 'Awaiting Receiving' doc status after the result set, whose size is too big, is returned. So, fix this by moving 'Awaiting Receiving' doc status to query criteria, and this reduced the size of the result set.