### PR TITLE
UAF-4123 : BUG - MOD-PA1031-05 B2B (Shop Catalog) eInvoicing file fails to produce PREQ documents. 

### DIFF
--- a/kfs-web/src/main/webapp/static/xsd/purap/electronicInvoice.xsd
+++ b/kfs-web/src/main/webapp/static/xsd/purap/electronicInvoice.xsd
@@ -537,7 +537,7 @@
   						<xsd:choice minOccurs="0">
   							<xsd:sequence>
 								<xsd:element name="ManufacturerPartID" type="hundredCharsType" />
-  								<xsd:element name="ManufacturerName">
+  								<xsd:element name="ManufacturerName" minOccurs="0">
   									<xsd:complexType>
   										<xsd:simpleContent>
 											<xsd:extension base="hundredCharsType">


### PR DESCRIPTION
UAF-4123 : BUG - MOD-PA1031-05 B2B (Shop Catalog) eInvoicing file fails to produce PREQ documents. Modified 'kfs-web/src/main/webapp/static/xsd/purap/electronicInvoice.xsd' to make 'ManufacturerName' optional (minOccurs='0') when 'ManufacturerPartID' exists.