### PR TITLE
UAF-3434 BUG - PO - Use Tax incorrectly included on PO PDF

### DIFF
--- a/kfs-purap/src/main/java/org/kuali/kfs/module/purap/pdf/PurchaseOrderPdf.java
+++ b/kfs-purap/src/main/java/org/kuali/kfs/module/purap/pdf/PurchaseOrderPdf.java
@@ -803,11 +803,22 @@ public class PurchaseOrderPdf extends PurapPdf {
         itemsTable.addCell(tableCell);
         itemsTable.addCell(" ");
         KualiDecimal totalDollarAmount = new KualiDecimal(BigDecimal.ZERO);
-        if (po instanceof PurchaseOrderRetransmitDocument) {
-            totalDollarAmount = ((PurchaseOrderRetransmitDocument) po).getTotalDollarAmountForRetransmit();
+        if (!po.isUseTaxIndicator()){
+	        if (po instanceof PurchaseOrderRetransmitDocument) {
+	            totalDollarAmount = ((PurchaseOrderRetransmitDocument) po).getTotalDollarAmountForRetransmit();
+	        }
+	        else {
+	            totalDollarAmount = po.getTotalDollarAmount();
+	        }
         }
         else {
-            totalDollarAmount = po.getTotalDollarAmount();
+        	// For PO and PORT, use tax should be excluded from invoice to vendor so it can be paid by university to state directly.
+        	if (po instanceof PurchaseOrderRetransmitDocument) {
+	            totalDollarAmount = ((PurchaseOrderRetransmitDocument) po).getTotalPreTaxDollarAmountForRetransmit();
+	        }
+	        else {
+	            totalDollarAmount = po.getTotalPreTaxDollarAmount();
+	        }
         }
         tableCell = new PdfPCell(new Paragraph(numberFormat.format(totalDollarAmount) + " ", cour_9_normal));
         tableCell.setHorizontalAlignment(Element.ALIGN_RIGHT);


### PR DESCRIPTION
Fixed for PO,POSP,PORT PDF to exclude use tax. POSP edoc contains tax now which is no longer issue to fix