### PR TITLE
UAF-4294: Overriding ProcurementCardDefault Lookup to use cc number a…

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/lookup/ProcurementCardDefaultLookupableHelperServiceImpl.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/businessobject/lookup/ProcurementCardDefaultLookupableHelperServiceImpl.java
@@ -1,0 +1,41 @@
+package edu.arizona.kfs.fp.businessobject.lookup;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.rice.kns.lookup.HtmlData;
+import org.kuali.rice.kns.lookup.KualiLookupableHelperServiceImpl;
+import org.kuali.rice.krad.bo.BusinessObject;
+import org.kuali.rice.krad.util.UrlFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+
+public class ProcurementCardDefaultLookupableHelperServiceImpl extends KualiLookupableHelperServiceImpl{
+
+    @Override
+    public List<HtmlData> getCustomActionUrls(BusinessObject businessObject, List pkNames) {
+        //override pcard credit card number PK (which is encrypted and should not be displayed in links)  with pcard id
+        List overriddenKeys = new ArrayList(1);
+        overriddenKeys.add( new String(KFSConstants.PCARD_DEFAULT_ID_FIELD) );
+        List<HtmlData> htmlDataList = super.getCustomActionUrls(businessObject, overriddenKeys);
+
+        return htmlDataList;
+    }
+
+    @Override
+    protected String getActionUrlHref(BusinessObject businessObject, String methodToCall, List pkNames) {
+        Properties parameters = new Properties();
+        parameters.put("methodToCall", methodToCall);
+        parameters.put("businessObjectClassName", businessObject.getClass().getName());
+        //override pcard credit card number PK (which is encrypted and should not be displayed in links)  with pcard id
+        parameters.put(KFSConstants.OVERRIDE_KEYS, KFSConstants.PCARD_DEFAULT_ID_FIELD);
+        parameters.putAll(this.getParametersFromPrimaryKey(businessObject, pkNames));
+        if(StringUtils.isNotBlank(this.getReturnLocation())) {
+            parameters.put("returnLocation", this.getReturnLocation());
+        }
+
+        return UrlFactory.parameterizeUrl("maintenance.do", parameters);
+    }
+}

--- a/kfs-core/src/main/java/org/kuali/kfs/sys/KFSConstants.java
+++ b/kfs-core/src/main/java/org/kuali/kfs/sys/KFSConstants.java
@@ -1529,4 +1529,6 @@ public class KFSConstants {
         public static final String LIABILITIES = "LI";
     }
 
+    public static final String PCARD_DEFAULT_ID_FIELD = "id";
+
 }

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardDefault.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardDefault.xml
@@ -355,6 +355,7 @@ http://rice.kuali.org/dd http://rice.kuali.org/dd/dd.xsd">
 	<bean id="ProcurementCardDefault-lookupDefinition" parent="ProcurementCardDefault-lookupDefinition-parentBean" />
 	<bean id="ProcurementCardDefault-lookupDefinition-parentBean" abstract="true" parent="LookupDefinition">
 		<property name="title" value="Procurement Cardholder Lookup" />
+		<property name="lookupableID" value="procurementCardDefaultLookupable" />
 		<property name="defaultSort" >
 			<bean parent="SortDefinition">
 				<property name="attributeNames" >

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/ojb-fp.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/ojb-fp.xml
@@ -359,10 +359,10 @@
 </class-descriptor>
 
   <class-descriptor class="edu.arizona.kfs.fp.businessobject.ProcurementCardDefault" table="FP_PRCRMNT_CARD_DFLT_T">
-    <field-descriptor name="id" column="ID" jdbc-type="BIGINT" primarykey="true" index="true"/>
+    <field-descriptor name="id" column="ID" jdbc-type="BIGINT" index="true"/>
     <field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true" />
     <field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true" />
-    <field-descriptor name="creditCardNumber" column="CC_NBR" jdbc-type="VARCHAR" index="true"/>
+    <field-descriptor name="creditCardNumber" column="CC_NBR" jdbc-type="VARCHAR" primarykey="true" index="true"/>
     <field-descriptor name="creditCardLastFour" column="CC_LAST_FOUR" jdbc-type="VARCHAR" index="true"/>
     <field-descriptor name="cardHolderSystemId" column="CARD_HLDR_NET_ID" jdbc-type="VARCHAR"/>
     <field-descriptor name="cardHolderName" column="CARD_HLDR_NM" jdbc-type="VARCHAR" />

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/spring-fp.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/spring-fp.xml
@@ -174,4 +174,14 @@
         </property>
     </bean>
 
+    <bean id="procurementCardDefaultLookupableHelperService" scope="prototype" parent="procurementCardDefaultLookupableHelperService-parentBean" />
+    <bean id="procurementCardDefaultLookupableHelperService-parentBean" abstract="true"  class="edu.arizona.kfs.fp.businessobject.lookup.ProcurementCardDefaultLookupableHelperServiceImpl" scope="prototype" parent="lookupableHelperService" />
+
+    <bean id="procurementCardDefaultLookupable"  parent="procurementCardDefaultLookupable-parentBean" scope="prototype"/>
+    <bean id="procurementCardDefaultLookupable-parentBean" class="org.kuali.rice.kns.lookup.KualiLookupableImpl" abstract="true">
+      <property name="lookupableHelperService">
+        <ref bean="procurementCardDefaultLookupableHelperService" />
+      </property>
+    </bean>
+
 </beans>


### PR DESCRIPTION
…s primary key
Changes implemented:
1. Use creditCardNumber as PK on ProcurementCardDefault
2. Implement custom ProcurementCardDefaultLookupableHelperService to use the id instead of the cc number (which is encrypted and should be kept hidden) on the Custom Action Links in the lookup results.
3. Additional .sql to modify the pcard table to use credit card number as a default key instead of id.