### PR TITLE
UAF-35 UAF-3195 Adding new Account Responsibility Tab on Asset Edit d…

### DIFF
--- a/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/CamsPropertyConstants.java
+++ b/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/CamsPropertyConstants.java
@@ -14,4 +14,9 @@ public class CamsPropertyConstants extends org.kuali.kfs.module.cam.CamsProperty
 
 	}
 
+	public static class AssetAccountResponsibility {
+		public static final String AGENCY_NUMBER = "agencyNumber";
+		public static final String ASSET_EXTENSION_ACCOUNT_RESPONSIBILITIES = "extension.assetAccountResponsibilities";
+		public static final String MAINT_SECTION_ID = "awardHistory";
+	}
 }

--- a/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/businessobject/AssetAccountResponsibility.java
+++ b/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/businessobject/AssetAccountResponsibility.java
@@ -1,0 +1,70 @@
+package edu.arizona.kfs.module.cam.businessobject;
+
+import java.sql.Date;
+
+import org.kuali.kfs.integration.cg.ContractsAndGrantsAgency;
+import org.kuali.rice.krad.bo.PersistableBusinessObjectBase;
+
+public class AssetAccountResponsibility extends PersistableBusinessObjectBase {
+	private static final long serialVersionUID = 1L;
+    private Long capitalAssetNumber;
+    private Long accountResponsibilityId;
+    private String sequenceId;
+    private String accountNumber;
+    private String agencyNumber;
+    private String grantNumber;
+    private Date effectiveDate;
+    
+    private ContractsAndGrantsAgency agency;
+    
+	public Long getCapitalAssetNumber() {
+		return capitalAssetNumber;
+	}
+	public void setCapitalAssetNumber(Long capitalAssetNumber) {
+		this.capitalAssetNumber = capitalAssetNumber;
+	}
+	public Long getAccountResponsibilityId() {
+		return accountResponsibilityId;
+	}
+	public void setAccountResponsibilityId(Long accountResponsibilityId) {
+		this.accountResponsibilityId = accountResponsibilityId;
+	}
+	public String getSequenceId() {
+		return sequenceId;
+	}
+	public void setSequenceId(String sequenceId) {
+		this.sequenceId = sequenceId;
+	}
+
+	public String getAccountNumber() {
+		return accountNumber;
+	}
+	public void setAccountNumber(String accountNumber) {
+		this.accountNumber = accountNumber;
+	}
+	public String getAgencyNumber() {
+		return agencyNumber;
+	}
+	public void setAgencyNumber(String agencyNumber) {
+		this.agencyNumber = agencyNumber;
+	}
+	public String getGrantNumber() {
+		return grantNumber;
+	}
+	public void setGrantNumber(String grantNumber) {
+		this.grantNumber = grantNumber;
+	}
+	public Date getEffectiveDate() {
+		return effectiveDate;
+	}
+	public void setEffectiveDate(Date effectiveDate) {
+		this.effectiveDate = effectiveDate;
+	}
+	public ContractsAndGrantsAgency getAgency() {
+		return agency;
+	}
+	public void setAgency(ContractsAndGrantsAgency agency) {
+		this.agency = agency;
+	}
+
+}

--- a/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/businessobject/AssetExtension.java
+++ b/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/businessobject/AssetExtension.java
@@ -1,10 +1,14 @@
 package edu.arizona.kfs.module.cam.businessobject;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.module.cam.businessobject.Asset;
 import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.rice.krad.bo.PersistableBusinessObject;
 import org.kuali.rice.krad.bo.PersistableBusinessObjectExtensionBase;
 import org.kuali.rice.krad.util.ObjectUtils;
 
@@ -18,7 +22,8 @@ public class AssetExtension extends PersistableBusinessObjectExtensionBase {
 	
 	private Asset assetObj;
 	private AssetInventoryUnit assetInvUnitObj;
-
+	private List<AssetAccountResponsibility> assetAccountResponsibilities;
+	
 	protected LinkedHashMap<String, String> toStringMapper() {
 		LinkedHashMap<String, String> m = new LinkedHashMap<String, String>();
 		if (this.capitalAssetNumber != null) {
@@ -91,5 +96,19 @@ public class AssetExtension extends PersistableBusinessObjectExtensionBase {
 	public void setAssetInvUnitObj(AssetInventoryUnit assetInvUnitObj) {
 		this.assetInvUnitObj = assetInvUnitObj;
 	}
+
+	public List<AssetAccountResponsibility> getAssetAccountResponsibilities() {
+		return assetAccountResponsibilities;
+	}
+
+	public void setAssetAccountResponsibilities(List<AssetAccountResponsibility> assetAccountResponsibilities) {
+		this.assetAccountResponsibilities = assetAccountResponsibilities;
+	}
 	
+	@Override
+	public List<Collection<PersistableBusinessObject>> buildListOfDeletionAwareLists() {
+		List<Collection<PersistableBusinessObject>> managedLists = super.buildListOfDeletionAwareLists();
+		managedLists.add(new ArrayList<PersistableBusinessObject>(getAssetAccountResponsibilities()));
+		return managedLists;
+	}
 }

--- a/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/document/AssetMaintainableImpl.java
+++ b/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/document/AssetMaintainableImpl.java
@@ -4,13 +4,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.sys.context.SpringContext;
 import org.kuali.rice.kns.document.MaintenanceDocument;
 import org.kuali.rice.krad.bo.Note;
 import org.kuali.rice.krad.service.KRADServiceLocator;
 import org.kuali.rice.krad.service.NoteService;
 import org.kuali.rice.krad.util.GlobalVariables;
+import org.kuali.rice.krad.util.KRADConstants;
+import org.kuali.rice.krad.util.ObjectUtils;
 
+import edu.arizona.kfs.module.cam.businessobject.AssetExtension;
 import edu.arizona.kfs.sys.KFSConstants;
 
 @SuppressWarnings("deprecation")
@@ -101,5 +105,19 @@ public class AssetMaintainableImpl extends org.kuali.kfs.module.cam.document.Ass
         newBoNote = SpringContext.getBean(NoteService.class).createNote(newBoNote, getBusinessObject(), GlobalVariables.getUserSession().getPrincipalId());
 
         return newBoNote;
+    }
+    
+    @Override
+    public void saveDataObject() {
+        // Save extension object first for Asset edit since Asset extension referenced collection can't be deleted though overriding BO buildListOfDeletionAwareLists, 
+    	// i.e. save Asset BO cannot delete BO reference list in depth.
+        if(KRADConstants.MAINTENANCE_EDIT_ACTION.equalsIgnoreCase(getMaintenanceAction())) {
+            if (ObjectUtils.isNotNull(this.getBusinessObject().getExtension()) ) {
+                AssetExtension assetExt = (AssetExtension)this.getBusinessObject().getExtension();
+                getBusinessObjectService().linkAndSave(assetExt);
+            }
+        }
+
+    	super.saveDataObject();
     }
 }

--- a/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/document/authorization/AssetAuthorizer.java
+++ b/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/document/authorization/AssetAuthorizer.java
@@ -1,0 +1,20 @@
+package edu.arizona.kfs.module.cam.document.authorization;
+
+import java.util.Set;
+
+import edu.arizona.kfs.module.cam.CamsPropertyConstants;
+
+/**
+ * @see org.kuali.kfs.module.cam.businessobject.authorization.AssetInquiryAuthorizer
+ */
+public class AssetAuthorizer extends org.kuali.kfs.module.cam.document.authorization.AssetAuthorizer {
+	 /**
+	  * Override to validate user permission to access account responsibility tab 
+	  */
+    @Override
+    public Set<String> getSecurePotentiallyReadOnlySectionIds() {
+    	Set<String> secureSectionIds = super.getSecurePotentiallyReadOnlySectionIds();
+    	secureSectionIds.add(CamsPropertyConstants.AssetAccountResponsibility.MAINT_SECTION_ID);
+    	return secureSectionIds;
+    }
+}

--- a/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/document/validation/impl/AssetRule.java
+++ b/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/document/validation/impl/AssetRule.java
@@ -4,16 +4,23 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.integration.cg.ContractsAndGrantsAgency;
 import org.kuali.kfs.module.cam.businessobject.Asset;
 import org.kuali.kfs.sys.KFSConstants;
 import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.rice.core.api.util.RiceKeyConstants;
 import org.kuali.rice.kns.document.MaintenanceDocument;
+import org.kuali.rice.krad.bo.PersistableBusinessObject;
 import org.kuali.rice.krad.service.BusinessObjectService;
+import org.kuali.rice.krad.service.KualiModuleService;
+import org.kuali.rice.krad.util.GlobalVariables;
 import org.kuali.rice.krad.util.ObjectUtils;
 
 import edu.arizona.kfs.module.cam.CamsConstants;
 import edu.arizona.kfs.module.cam.CamsKeyConstants;
 import edu.arizona.kfs.module.cam.CamsPropertyConstants;
+import edu.arizona.kfs.module.cam.businessobject.AssetAccountResponsibility;
 import edu.arizona.kfs.module.cam.businessobject.AssetExtension;
 import edu.arizona.kfs.module.cam.businessobject.AssetInventoryUnit;
 import edu.arizona.kfs.sys.KFSPropertyConstants;
@@ -76,4 +83,67 @@ public class AssetRule extends org.kuali.kfs.module.cam.document.validation.impl
 		
 	}
 
+	/**
+	 * Override to validate agency number from Account Responsibility tab upon add action 
+	 */
+	@Override
+	public boolean processCustomAddCollectionLineBusinessRules(MaintenanceDocument documentCopy, String collectionName,
+			PersistableBusinessObject bo) {
+		boolean valid = super.processCustomAddCollectionLineBusinessRules(documentCopy, collectionName, bo);
+		
+		if (collectionName.equals(CamsPropertyConstants.AssetAccountResponsibility.ASSET_EXTENSION_ACCOUNT_RESPONSIBILITIES)) {
+			valid &= validateAgency(bo,"");
+		}
+		
+		return valid;
+	}
+	
+	/**
+	 * validate agency existence in KFS-CG module (external module PBO)
+	 * 
+	 * @param bo
+	 * @return
+	 */
+	protected boolean validateAgency(PersistableBusinessObject bo, String errorPathPrefix) {
+		boolean valid = true;
+		AssetAccountResponsibility acctRsp = (AssetAccountResponsibility)bo;
+		if (ObjectUtils.isNull(bo) || StringUtils.isBlank(acctRsp.getAgencyNumber())) {
+			return valid;
+		}
+		
+		Map<String, Object> primaryKeys = new HashMap<String, Object>();
+		
+		primaryKeys.put(CamsPropertyConstants.AssetAccountResponsibility.AGENCY_NUMBER, acctRsp.getAgencyNumber());
+		ContractsAndGrantsAgency agency = (ContractsAndGrantsAgency) SpringContext.getBean(KualiModuleService.class).getResponsibleModuleService(ContractsAndGrantsAgency.class).getExternalizableBusinessObject(ContractsAndGrantsAgency.class,primaryKeys);
+		
+		if (ObjectUtils.isNull(agency)) {
+			GlobalVariables.getMessageMap().addToErrorPath(errorPathPrefix);
+			final String label = getDataDictionaryService().getAttributeLabel(AssetAccountResponsibility.class, CamsPropertyConstants.AssetAccountResponsibility.AGENCY_NUMBER);
+			GlobalVariables.getMessageMap().putError(CamsPropertyConstants.AssetAccountResponsibility.AGENCY_NUMBER, RiceKeyConstants.ERROR_EXISTENCE, label);
+			valid = false;
+			GlobalVariables.getMessageMap().removeFromErrorPath(errorPathPrefix);
+		}
+		
+		return valid;
+	}
+
+	/**
+	 * Override to validate agency number(s) from account responsibility tab
+	 */
+	@Override
+	 protected boolean processCustomSaveDocumentBusinessRules(MaintenanceDocument document) {
+		boolean valid = super.processCustomSaveDocumentBusinessRules(document);
+		
+		AssetExtension assetExt = (AssetExtension)newAsset.getExtension();
+		String errorPath = KFSConstants.MAINTENANCE_NEW_MAINTAINABLE + CamsPropertyConstants.AssetAccountResponsibility.ASSET_EXTENSION_ACCOUNT_RESPONSIBILITIES + KFSConstants.SQUARE_BRACKET_LEFT;
+		if (ObjectUtils.isNotNull(assetExt) && assetExt.getAssetAccountResponsibilities() != null && !assetExt.getAssetAccountResponsibilities().isEmpty()) {
+			int i = 0;
+			for (AssetAccountResponsibility acctRsp : assetExt.getAssetAccountResponsibilities()) {
+				valid &= validateAgency(acctRsp, errorPath + i + KFSConstants.SQUARE_BRACKET_RIGHT);
+				i++;
+			}
+		}
+		
+		return valid;
+	}
 }

--- a/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/businessobject/datadictionary/Asset.xml
+++ b/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/businessobject/datadictionary/Asset.xml
@@ -401,6 +401,31 @@
 				</bean>
 
 				<bean parent="InquirySectionDefinition">
+					<property name="title" value="Account Responsibility" />
+					<property name="defaultOpen" value="false" />
+					<property name="numberOfColumns" value="1" />
+					<property name="inquiryFields">
+						<list>
+							<bean parent="InquiryCollectionDefinition">
+								<property name="attributeName" value="extension.assetAccountResponsibilities" />
+								<property name="businessObjectClass" value="edu.arizona.kfs.module.cam.businessobject.AssetAccountResponsibility" />
+								<property name="numberOfColumns" value="2" />
+								<property name="summaryTitle" value="Source Asset" />
+								<property name="inquiryFields">
+									<list>
+										<bean parent="FieldDefinition" p:attributeName="sequenceId" />
+										<bean parent="FieldDefinition" p:attributeName="accountNumber" />
+										<bean parent="FieldDefinition" p:attributeName="effectiveDate" />
+										<bean parent="FieldDefinition" p:attributeName="agencyNumber" />
+										<bean parent="FieldDefinition" p:attributeName="grantNumber" />
+									</list>
+								</property>
+							</bean>
+						</list>
+					</property>
+				</bean>
+
+				<bean parent="InquirySectionDefinition">
 					<property name="title" value="Notes" />
 					<property name="numberOfColumns" value="1" />
 					<property name="inquiryFields">

--- a/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/businessobject/datadictionary/AssetAccountResponsibility.xml
+++ b/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/businessobject/datadictionary/AssetAccountResponsibility.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?><beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p" xmlns:dd="http://rice.kuali.org/dd" xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd         http://rice.kuali.org/dd http://rice.kuali.org/dd/dd.xsd">
+  <bean id="AssetAccountResponsibility" parent="AssetAccountResponsibility-parentBean"/>
+  <bean id="AssetAccountResponsibility-parentBean" abstract="true" parent="BusinessObjectEntry">
+    <property name="businessObjectClass" value="edu.arizona.kfs.module.cam.businessobject.AssetAccountResponsibility"/>
+    <property name="objectLabel" value="Asset Account Responsibility"/>
+    <property name="attributes">
+      <list>
+        <ref bean="AssetAccountResponsibility-capitalAssetNumber"/>
+        <ref bean="AssetAccountResponsibility-sequenceId"/>
+        <ref bean="AssetAccountResponsibility-accountNumber"/>
+        <ref bean="AssetAccountResponsibility-agencyNumber"/>
+        <ref bean="AssetAccountResponsibility-grantNumber"/>
+        <ref bean="AssetAccountResponsibility-effectiveDate"/>
+      </list>
+    </property>
+    <property name="relationships">
+      <list>
+        <dd:relationship objectAttribute="agency">
+			<dd:primitiveAttribute source="agencyNumber" target="agencyNumber"/>
+        </dd:relationship>
+      </list>
+    </property>
+  </bean>
+
+<!-- Attribute Definitions -->
+
+  <bean id="AssetAccountResponsibility-capitalAssetNumber" parent="AssetAccountResponsibility-capitalAssetNumber-parentBean"/>
+  <bean id="AssetAccountResponsibility-capitalAssetNumber-parentBean" abstract="true" parent="Asset-capitalAssetNumber">
+  </bean>
+  
+  <bean id="AssetAccountResponsibility-sequenceId" parent="AssetAccountResponsibility-sequenceId-parentBean"/>
+  <bean id="AssetAccountResponsibility-sequenceId-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="sequenceId"/>
+    <property name="label" value="Sequence Id"/>
+    <property name="forceUppercase" value="false"/>
+    <property name="shortLabel" value="id"/>
+    <property name="validationPattern">
+      <ref bean="AlphaNumericValidation" />
+    </property>
+    <property name="maxLength" value="3"/>
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="5"/>
+    </property>
+  </bean>
+  
+  <bean id="AssetAccountResponsibility-accountNumber" parent="AssetAccountResponsibility-accountNumber-parentBean"/>
+  <bean id="AssetAccountResponsibility-accountNumber-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="accountNumber"/>
+    <property name="forceUppercase" value="false"/>
+    <property name="label" value="Account Number"/>
+    <property name="shortLabel" value="Number"/>
+    <property name="maxLength" value="7"/>
+    <property name="validationPattern">
+      <ref bean="AlphaNumericValidation" />
+    </property>
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="9"/>
+    </property>
+  </bean>
+  
+  <bean id="AssetAccountResponsibility-agencyNumber" parent="AssetAccountResponsibility-agencyNumber-parentBean"/>
+  <bean id="AssetAccountResponsibility-agencyNumber-parentBean" abstract="true" parent="Agency-agencyNumber">
+    <property name="name" value="agencyNumber"/>
+    <property name="label" value="Agency Number"/>
+  </bean>
+  
+  <bean id="AssetAccountResponsibility-grantNumber" parent="AssetAccountResponsibility-grantNumber-parentBean"/>
+  <bean id="AssetAccountResponsibility-grantNumber-parentBean" abstract="true" parent="AttributeDefinition">
+    <property name="name" value="grantNumber"/>
+    <property name="forceUppercase" value="false"/>
+    <property name="label" value="Grant Number"/>
+    <property name="shortLabel" value="Number"/>
+    <property name="maxLength" value="20"/>
+    <property name="validationPattern">
+      <ref bean="AlphaNumericValidation" />
+    </property>
+    <property name="control">
+      <bean parent="TextControlDefinition" p:size="22"/>
+    </property>
+  </bean>
+  
+  <bean id="AssetAccountResponsibility-effectiveDate" parent="AssetAccountResponsibility-effectiveDate-parentBean"/>
+  <bean id="AssetAccountResponsibility-effectiveDate-parentBean" abstract="true" parent="GenericAttributes-genericDate">
+    <property name="name" value="effectiveDate"/>
+    <property name="label" value="Effective Date"/>
+  </bean>
+  
+</beans>

--- a/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/document/datadictionary/AssetMaintenanceDocument.xml
+++ b/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/document/datadictionary/AssetMaintenanceDocument.xml
@@ -4,8 +4,14 @@
     xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
     
   <bean id="AssetMaintenanceDocument" parent="AssetMaintenanceDocument-parentBean">
-        <property name="maintainableClass" value="edu.arizona.kfs.module.cam.document.AssetMaintainableImpl" />
-        <property name="businessRulesClass" value="edu.arizona.kfs.module.cam.document.validation.impl.AssetRule" />
+	  <property name="maintainableClass" value="edu.arizona.kfs.module.cam.document.AssetMaintainableImpl" />
+	  <property name="businessRulesClass" value="edu.arizona.kfs.module.cam.document.validation.impl.AssetRule" />
+	  <property name="documentAuthorizerClass" value="edu.arizona.kfs.module.cam.document.authorization.AssetAuthorizer"/>
+	  <property name="maintainableSections">
+		  <list merge="true">
+		  	<ref bean="AssetMaintenanceDocument-AccountResponsibility"/>
+		  </list>
+	  </property>
   </bean>
 
  <!--  Maintenance Section Definition -->
@@ -30,4 +36,29 @@
         </property>
   </bean>
 
+	<bean id="AssetMaintenanceDocument-AccountResponsibility" parent="AssetMaintenanceDocument-AccountResponsibility-parentBean"/>
+	  <bean id="AssetMaintenanceDocument-AccountResponsibility-parentBean" abstract="true" parent="MaintainableSectionDefinition">
+		<property name="id" value="awardHistory"/>  
+	    <property name="title" value="Account Responsibility"/>
+	    <property name="defaultOpen" value="false"/> 
+	    <property name="maintainableItems">
+	      <list>
+	        <bean parent="MaintainableCollectionDefinition">
+	          <property name="name" value="extension.assetAccountResponsibilities"/>
+	          <property name="businessObjectClass" value="edu.arizona.kfs.module.cam.businessobject.AssetAccountResponsibility"/>
+		      <property name="alwaysAllowCollectionDeletion" value="true" />
+			  <property name="includeAddLine" value="true" />	
+	          <property name="maintainableFields">
+	            <list>
+	              <bean parent="MaintainableFieldDefinition" p:name="sequenceId" p:required="true"/>
+	              <bean parent="MaintainableFieldDefinition" p:name="accountNumber" p:required="true" />
+	              <bean parent="MaintainableFieldDefinition" p:name="effectiveDate" p:required="true"/>
+	              <bean parent="MaintainableFieldDefinition" p:name="agencyNumber" p:required="true"/>
+	              <bean parent="MaintainableFieldDefinition" p:name="grantNumber" p:required="true"/>
+            </list>
+          </property>
+        </bean>
+      </list>
+    </property>
+	  </bean>
 </beans>

--- a/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/ojb-cam.xml
+++ b/kfs-cam/src/main/resources/edu/arizona/kfs/module/cam/ojb-cam.xml
@@ -35,7 +35,10 @@
 			<foreignkey field-ref="inventoryUnitChartOfAccountsCode" />
 			<foreignkey field-ref="inventoryUnitOrganizationCode" />
 		</reference-descriptor>
-		
+				
+		<collection-descriptor name="assetAccountResponsibilities" element-class-ref="edu.arizona.kfs.module.cam.businessobject.AssetAccountResponsibility" collection-class="org.apache.ojb.broker.util.collections.ManageableArrayList" auto-retrieve="true" auto-delete="object" auto-update="object" proxy="true">
+			<inverse-foreignkey field-ref="capitalAssetNumber" />
+		</collection-descriptor>
 	</class-descriptor>
 
 	<class-descriptor class="org.kuali.kfs.module.cam.businessobject.Asset" table="CM_CPTLAST_T">
@@ -543,4 +546,15 @@
 	    </collection-descriptor>
 	</class-descriptor>
 	
+	<class-descriptor class="edu.arizona.kfs.module.cam.businessobject.AssetAccountResponsibility" table="CM_CPTLAST_AWARD_HIST_T">
+		<field-descriptor name="accountResponsibilityId" column="CM_CPTLAST_AWARD_HIST_NBR" jdbc-type="BIGINT" primarykey="true" index="true" autoincrement="true" sequence-name="CM_CPTLAST_AWARD_HIST_NBR_SEQ"/>
+		<field-descriptor name="objectId" column="OBJ_ID" jdbc-type="VARCHAR" index="true"/>
+		<field-descriptor name="versionNumber" column="VER_NBR" jdbc-type="BIGINT" locking="true"/>
+		<field-descriptor name="capitalAssetNumber" column="CPTLAST_NBR" jdbc-type="BIGINT"/>
+		<field-descriptor name="accountNumber" column="ORG_OWNER_ACCT_NBR" jdbc-type="VARCHAR"/>
+		<field-descriptor name="agencyNumber" column="CG_AGENCY_NBR" jdbc-type="VARCHAR"/>
+		<field-descriptor name="grantNumber" column="GRANT_NBR" jdbc-type="VARCHAR"/>
+		<field-descriptor name="effectiveDate" column="EFFECTIVE_DT" jdbc-type="DATE"/>
+		<field-descriptor name="sequenceId" column="SEQUENCE_ID" jdbc-type="VARCHAR"/>
+	</class-descriptor>
 </descriptor-repository>


### PR DESCRIPTION
New BO AssetAccountResponsibility created and linked to AssetExtension. Modified BO DD, OJB for new BO definition. Modified CASM DD with new maint definition. Override authorizer class in order for authorized user to maintain new tab with permission 10141. Business rule class updated with checking external BO existence with support of moduleService either add collection action or doc actions. Managed collection deletion when persistent BO, persistent extension BO first due to restriction of buildDeletionAwareList can't step into multiple reference object collection.