### PR TITLE
UAF-3388 Fix Bug - Error returned when 'NO RM LC' used on REQ Capital Asset tab

### DIFF
--- a/kfs-purap/src/main/resources/edu/arizona/kfs/module/purap/businessobject/datadictionary/RequisitionCapitalAssetLocation.xml
+++ b/kfs-purap/src/main/resources/edu/arizona/kfs/module/purap/businessobject/datadictionary/RequisitionCapitalAssetLocation.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?><beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:p="http://www.springframework.org/schema/p" xmlns:dd="http://rice.kuali.org/dd" xsi:schemaLocation="http://www.springframework.org/schema/beans         http://www.springframework.org/schema/beans/spring-beans-2.0.xsd         http://rice.kuali.org/dd         http://rice.kuali.org/dd/dd.xsd">
+  <bean id="RequisitionCapitalAssetLocation-buildingRoomNumber" parent="RequisitionCapitalAssetLocation-buildingRoomNumber-parentBean">
+    <property name="validationPattern">
+      <ref bean="AnyCharacterWithWhitespaceValidation" />
+    </property>
+  </bean>
+</beans>


### PR DESCRIPTION
Fixed and override DD validation for room number in REQ Asset location tab to allow white space in order for 'NO RM LC' to be entered by user.  