### PR TITLE
UAF-4155 Non-Check Non-ACH Payments Step 11 (Non-Taxable Vendor Payme…

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/validation/impl/DisbursementVoucherVendorInformationValidation.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/validation/impl/DisbursementVoucherVendorInformationValidation.java
@@ -1,0 +1,61 @@
+package edu.arizona.kfs.fp.document.validation.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.fp.businessobject.DisbursementVoucherPayeeDetail;
+import org.kuali.kfs.fp.document.DisbursementVoucherDocument;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.kfs.sys.document.validation.event.AttributedDocumentEvent;
+import org.kuali.kfs.vnd.businessobject.VendorDetail;
+import org.kuali.rice.krad.service.BusinessObjectService;
+import org.kuali.rice.krad.util.GlobalVariables;
+import org.kuali.rice.krad.util.MessageMap;
+import org.kuali.rice.krad.util.ObjectUtils;
+
+import edu.arizona.kfs.sys.KFSKeyConstants;
+import edu.arizona.kfs.fp.businessobject.PaymentMethod;
+import edu.arizona.kfs.vnd.businessobject.VendorDetailExtension;
+
+/**
+ * Adding check to make sure default payment method on the vendor is valid for use on the DV document.
+ */
+public class DisbursementVoucherVendorInformationValidation extends org.kuali.kfs.fp.document.validation.impl.DisbursementVoucherVendorInformationValidation {
+
+    protected BusinessObjectService businessObjectService;
+    
+    @Override
+    public boolean validate(AttributedDocumentEvent event) {
+        boolean result = super.validate(event);
+        if ( result ) { // only continue check if vendor is otherwise valid
+            DisbursementVoucherDocument document = (DisbursementVoucherDocument) getAccountingDocumentForValidation();
+            DisbursementVoucherPayeeDetail payeeDetail = document.getDvPayeeDetail();
+
+            if (payeeDetail.isVendor()) { // only continue check if a vendor
+                VendorDetail vendor = retrieveVendorDetail(payeeDetail.getDisbVchrVendorHeaderIdNumberAsInteger(), payeeDetail.getDisbVchrVendorDetailAssignedIdNumberAsInteger());
+
+                MessageMap errors = GlobalVariables.getMessageMap();
+                errors.addToErrorPath(KFSPropertyConstants.DOCUMENT);
+                
+                // check if we have a proper extension object to work with
+                if ( ObjectUtils.isNotNull( vendor.getExtension() ) && vendor.getExtension() instanceof VendorDetailExtension ) {
+                    VendorDetailExtension ve = (VendorDetailExtension)vendor.getExtension();
+                    if ( StringUtils.isNotBlank( ve.getDefaultB2BPaymentMethodCode() ) ) {
+                        PaymentMethod pm = businessObjectService.findBySinglePrimaryKey(PaymentMethod.class, ve.getDefaultB2BPaymentMethodCode() );
+                        // finally, if we can get to the flag on the payment method and it is not allowed on the DV, set the result to false
+                        // and include an error message
+                        if ( pm != null && !pm.isDisplayOnDisbursementVoucherDocument() ) {
+                            errors.putError(DV_PAYEE_ID_NUMBER_PROPERTY_PATH, KFSKeyConstants.ERROR_DV_DISALLOWED_BY_PAYMENT_METHOD);
+                            result = false;
+                        }
+                    }
+                }
+                
+                errors.removeFromErrorPath(KFSPropertyConstants.DOCUMENT);
+            }
+        }
+        return result;
+    }
+
+    public void setBusinessObjectService(BusinessObjectService businessObjectService) {
+        this.businessObjectService = businessObjectService;
+    }
+}

--- a/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSKeyConstants.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSKeyConstants.java
@@ -27,6 +27,7 @@ public class KFSKeyConstants extends org.kuali.kfs.sys.KFSKeyConstants {
     
     //DV NonEmployee
     public static final String ERROR_DV_PER_DIEM_START_DT_AFTER_END_DT = "error.dv.perDiemStartDtBeforeAfterEndDt";
+    public static final String ERROR_DV_DISALLOWED_BY_PAYMENT_METHOD = "error.dv.disallowedByPaymentMethod";
 
     // Income Type Error messages
     public static final String ERROR_INVALID_INCOME_TYPES_TOTAL_AMOUNT = "errors.document.ap.incomeTypesTotalAmount.invalid";

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/validation/configuration/FinancialProcessingValidators.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/validation/configuration/FinancialProcessingValidators.xml
@@ -35,4 +35,9 @@
   
   <bean id="DisbursementVoucher-incomeTypeTotalsValidation" class="edu.arizona.kfs.fp.document.validation.impl.DisbursementVoucherIncomeTypeTotalsValidation" abstract="true"/>
   
+  <bean id="DisbursementVoucher-vendorInformationValidation" class="edu.arizona.kfs.fp.document.validation.impl.DisbursementVoucherVendorInformationValidation" abstract="true">
+    <property name="parameterService" ref="parameterService" />
+    <property name="businessObjectService" ref="businessObjectService" />
+  </bean>
+  
 </beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/fp-resources.properties
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/fp-resources.properties
@@ -37,6 +37,7 @@ warning.dv.paymentReason.nonEmployeeTravelTab = Payment reason of Travel Expense
 
 # DisbursementVoucher Error messages
 error.dv.perDiemStartDtBeforeAfterEndDt=The per diem travel start date occurred after the travel end date.  Please correct this error.
+error.dv.disallowedByPaymentMethod=This vendor may not be used on the DV document.  Only vendors with payment methods allowed on the DV may be selected.
 
 # PCard Errors
 warning.document.procurementcardholderdetail.cardholder.last.active = Cardholder is the only active member of the selected PCard Reconciler workgroup.


### PR DESCRIPTION
…nts)

Added new file DisbursementVoucherVendorInformationValidation.java to add check to make sure default payment method on the vendor is valid for use on the DV document.
Modified KFSKeyConstants.java to add constant for the error message.
Modified FinancialProcessingValidators.xml to point to the new edu/arizon DisbursementVoucherVendorInformationValidation class.
Modified fp-resources.properties to define the new error message.