### PR TITLE
UAF-4337 : Change Parm value for Cash Receipt. 

### DIFF
--- a/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/changesets/db.changelog-UAF-4337.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/changesets/db.changelog-UAF-4337.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="UAF-4337" author="Jim Reese">
+        <comment>
+            UAF-4337 : Change Parm value for Cash Receipt. Changes the parameter from the Kuali foundation default of 'Y' to UA's preferred 'N'.
+        </comment>
+        <sql>
+            UPDATE KULOWNER.KRCR_PARM_T SET VAL = 'N' WHERE PARM_NM='DISPLAY_CASH_RECEIPT_DENOMINATION_DETAIL_IND';
+        </sql>
+        <rollback>
+            <sql>
+                UPDATE KULOWNER.KRCR_PARM_T SET VAL = 'Y' WHERE PARM_NM='DISPLAY_CASH_RECEIPT_DENOMINATION_DETAIL_IND';
+            </sql>
+        </rollback>
+
+    </changeSet>
+</databaseChangeLog>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/db.changelog-master.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/db.changelog-master.xml
@@ -26,4 +26,5 @@
   <include file="changesets/db.changelog-UAF-3004.xml" />
   <include file="changesets/db.changelog-UAF-2788.xml" />
   <include file="changesets/db.changelog-UAF-2808.xml" />
+  <include file="changesets/db.changelog-UAF-4337.xml" />  
 </databaseChangeLog>


### PR DESCRIPTION
UAF-4337 : Change Parm value for Cash Receipt. Created Liquibase SQL UPDATE db.changelog script in '/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/changesets/db.changelog-UAF-4337.xml' and modified file '/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/db.changelog-master.xml' to invoke it.