### PR TITLE
UAF-4499 Bug - ST ERE amounts not posting to the Labor Ledger

### DIFF
--- a/kfs-ld/src/main/java/edu/arizona/kfs/module/ld/document/service/impl/LaborPendingEntryConverterServiceImpl.java
+++ b/kfs-ld/src/main/java/edu/arizona/kfs/module/ld/document/service/impl/LaborPendingEntryConverterServiceImpl.java
@@ -1,0 +1,44 @@
+package edu.arizona.kfs.module.ld.document.service.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.coa.businessobject.ObjectCode;
+import org.kuali.kfs.module.ld.businessobject.ExpenseTransferAccountingLine;
+import org.kuali.kfs.module.ld.businessobject.LaborLedgerPendingEntry;
+import org.kuali.kfs.module.ld.document.LaborLedgerPostingDocument;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntrySequenceHelper;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+
+import edu.arizona.kfs.module.ld.LaborConstants;
+
+public class LaborPendingEntryConverterServiceImpl extends org.kuali.kfs.module.ld.document.service.impl.LaborPendingEntryConverterServiceImpl {
+
+	@Override
+	public LaborLedgerPendingEntry getBenefitPendingEntry(LaborLedgerPostingDocument document, ExpenseTransferAccountingLine accountingLine, GeneralLedgerPendingEntrySequenceHelper sequenceHelper, KualiDecimal benefitAmount, String fringeBenefitObjectCode) {
+		LaborLedgerPendingEntry pendingEntry = getDefaultPendingEntry(document, accountingLine);
+		
+		// if account doesn't accept fringe charges, use reports to account
+		if (!accountingLine.getAccount().isAccountsFringesBnftIndicator()) {
+			pendingEntry.setChartOfAccountsCode(accountingLine.getAccount().getReportsToChartOfAccountsCode());
+			pendingEntry.setAccountNumber(accountingLine.getAccount().getReportsToAccountNumber());
+		}
+		
+		pendingEntry.setFinancialBalanceTypeCode(LaborConstants.BALANCE_TYPE_ACTUAL);
+		pendingEntry.setFinancialObjectCode(pickValue(fringeBenefitObjectCode, KFSConstants.getDashFinancialObjectCode()));
+		
+		ObjectCode fringeObjectCode = getObjectCodeService().getByPrimaryId(accountingLine.getPayrollEndDateFiscalYear(), accountingLine.getChartOfAccountsCode(), fringeBenefitObjectCode);
+		pendingEntry.setFinancialObjectTypeCode(fringeObjectCode.getFinancialObjectTypeCode());
+
+		pendingEntry.setFinancialSubObjectCode(KFSConstants.getDashFinancialSubObjectCode());
+		pendingEntry.setTransactionLedgerEntryAmount(benefitAmount.abs());
+		pendingEntry.setPositionNumber(StringUtils.isBlank(accountingLine.getPositionNumber()) ? LaborConstants.getDashPositionNumber() : accountingLine.getPositionNumber());
+		pendingEntry.setEmplid(StringUtils.isBlank(accountingLine.getEmplid()) ? LaborConstants.getDashEmplId() : accountingLine.getEmplid());
+		pendingEntry.setTransactionLedgerEntrySequenceNumber(getNextSequenceNumber(sequenceHelper));
+		
+		// year end document should post to previous fiscal year and final period
+		overrideEntryForYearEndIfNecessary(document, pendingEntry);
+
+		return pendingEntry;
+	}
+	
+}

--- a/kfs-ld/src/main/resources/edu/arizona/kfs/module/ld/spring-ld.xml
+++ b/kfs-ld/src/main/resources/edu/arizona/kfs/module/ld/spring-ld.xml
@@ -254,4 +254,6 @@
 
     <bean id="accountExtensionDao" class="edu.arizona.kfs.module.ld.dataaccess.impl.AccountExtensionDaoOjb" parent="platformAwareDao" />
 
+    <bean id="laborPendingEntryConverterService" parent="laborPendingEntryConverterService-parentBean" class="edu.arizona.kfs.module.ld.document.service.impl.LaborPendingEntryConverterServiceImpl" />
+
 </beans>


### PR DESCRIPTION
Overrode getBenefitPendingEntry() method on LaborPendingEntryConverterServiceImpl.java to make sure the position number and employee id were set and saved to pending entry. This were automatically set to dashes instead of the actual value, making the batch not able to post these entries to the Labor Ledger View.

Overrode laborPendingEntryConverterService bean on spring-ld.xml to point to the new LaborPendingEntryConverterServiceImpl class.