### PR TITLE
UAF-46 Procurement Card Reconciliation

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/ProcurementCardCreateDocumentService.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/ProcurementCardCreateDocumentService.java
@@ -1,13 +1,15 @@
 package edu.arizona.kfs.fp.batch.service;
 
+import edu.arizona.kfs.fp.document.ProcurementCardDocument; 
+
 public interface ProcurementCardCreateDocumentService extends org.kuali.kfs.fp.batch.service.ProcurementCardCreateDocumentService {
     
     /**
      * Puts the document back into action list of reconciler
-     * @param pcardDocumentId id of the procurement card document
+     * @param pcardDocument the procurement card document
      * @param node document route node
      * @param prevNode previous document route node
      * @param annotation
      */
-    public void requeueDocument(String pcardDocumentId, String node, String prevNode, String annotation);
+    public void requeueDocument(ProcurementCardDocument pcardDocument, String node, String prevNode, String annotation);
 }

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/validation/impl/ProcurementCardDefaultRule.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/validation/impl/ProcurementCardDefaultRule.java
@@ -4,9 +4,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.sys.KFSKeyConstants;
 import org.kuali.rice.kns.document.MaintenanceDocument;
 
 import edu.arizona.kfs.fp.businessobject.ProcurementCardDefault;
+import edu.arizona.kfs.sys.KFSPropertyConstants;
 
 @SuppressWarnings("deprecation")
 public class ProcurementCardDefaultRule extends org.kuali.kfs.fp.document.validation.impl.ProcurementCardDefaultRule {
@@ -47,6 +49,55 @@ public class ProcurementCardDefaultRule extends org.kuali.kfs.fp.document.valida
         }
         
         return result;      
+    }
+	
+	@Override
+    protected boolean validateCardHolderDefault(org.kuali.kfs.fp.businessobject.ProcurementCardDefault procurementCardDefault) {
+        ProcurementCardDefault newProcurementCardDefault = (ProcurementCardDefault)procurementCardDefault;
+        boolean valid = true;
+        if (isCardHolderDefaultTurnedOn()) {
+            if (StringUtils.isBlank(newProcurementCardDefault.getCardHolderLine1Address())) {
+                putFieldErrorWithLabel(KFSPropertyConstants.PROCUREMENT_CARD_HOLDER_LINE1_ADDRESS, KFSKeyConstants.ERROR_REQUIRED);
+                valid = false;
+            }
+            if (StringUtils.isBlank(newProcurementCardDefault.getCardHolderCityName())) {
+                putFieldErrorWithLabel(KFSPropertyConstants.PROCUREMENT_CARD_HOLDER_CITY_NAME, KFSKeyConstants.ERROR_REQUIRED);
+                valid = false;
+            }
+            if (StringUtils.isBlank(newProcurementCardDefault.getCardHolderStateCode())) {
+                putFieldErrorWithLabel(KFSPropertyConstants.PROCUREMENT_CARD_HOLDER_STATE, KFSKeyConstants.ERROR_REQUIRED);
+                valid = false;
+            }
+            if (StringUtils.isBlank(newProcurementCardDefault.getCardHolderZipCode())) {
+                putFieldErrorWithLabel(KFSPropertyConstants.PROCUREMENT_CARD_HOLDER_ZIP_CODE, KFSKeyConstants.ERROR_REQUIRED);
+                valid = false;
+            }
+            if (StringUtils.isBlank(newProcurementCardDefault.getCardHolderWorkPhoneNumber())) {
+                putFieldErrorWithLabel(KFSPropertyConstants.PROCUREMENT_CARD_HOLDER_WORK_PHONE_NUMBER, KFSKeyConstants.ERROR_REQUIRED);
+                valid = false;
+            }
+            if (newProcurementCardDefault.getCardLimit() == null) {
+                putFieldErrorWithLabel(KFSPropertyConstants.PROCUREMENT_CARD_LIMIT, KFSKeyConstants.ERROR_REQUIRED);
+                valid = false;
+            }
+            if (newProcurementCardDefault.getCardCycleAmountLimit() == null) {
+                putFieldErrorWithLabel(KFSPropertyConstants.PROCUREMENT_CARD_CYCLE_AMOUNT_LIMIT, KFSKeyConstants.ERROR_REQUIRED);
+                valid = false;
+            }
+            if (newProcurementCardDefault.getCardCycleVolLimit() == null) {
+                putFieldErrorWithLabel(KFSPropertyConstants.CARD_CYCLE_VOL_LIMIT, KFSKeyConstants.ERROR_REQUIRED);
+                valid = false;
+            }
+            if (StringUtils.isBlank(newProcurementCardDefault.getCardStatusCode())) {
+                putFieldErrorWithLabel(KFSPropertyConstants.PROCUREMENT_CARD_STATUS_CODE, KFSKeyConstants.ERROR_REQUIRED);
+                valid = false;
+            }
+            if (StringUtils.isBlank(newProcurementCardDefault.getCardNoteText())) {
+                putFieldErrorWithLabel(KFSPropertyConstants.PROCUREMENT_CARD_NOTE_TEXT, KFSKeyConstants.ERROR_REQUIRED);
+                valid = false;
+            }
+        }
+        return valid;
     }
 
 }

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/web/struts/ProcurementCardAction.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/web/struts/ProcurementCardAction.java
@@ -8,6 +8,7 @@ import javax.servlet.http.HttpServletResponse;
 import edu.arizona.kfs.sys.KFSConstants;
 import edu.arizona.kfs.sys.KFSKeyConstants;
 import edu.arizona.kfs.fp.batch.service.ProcurementCardCreateDocumentService;
+import edu.arizona.kfs.fp.document.ProcurementCardDocument;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.struts.action.ActionForm;
@@ -105,7 +106,7 @@ public class ProcurementCardAction extends org.kuali.kfs.fp.document.web.struts.
         
         List<RouteNodeInstance> routeNodeInstances = procurementCardForm.getProcurementCardDocument().getDocumentHeader().getWorkflowDocument().getCurrentRouteNodeInstances();
         String node = routeNodeInstances.get(0).getName();
-        SpringContext.getBean(ProcurementCardCreateDocumentService.class).requeueDocument(procurementCardForm.getDocId(), node, HAS_RECONCILER_NODE, ANNOTATION);
+        SpringContext.getBean(ProcurementCardCreateDocumentService.class).requeueDocument((ProcurementCardDocument)procurementCardForm.getDocument(), node, HAS_RECONCILER_NODE, ANNOTATION);
 
         return returnToSender(request, mapping, procurementCardForm);
     }

--- a/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSPropertyConstants.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSPropertyConstants.java
@@ -14,5 +14,6 @@ public class KFSPropertyConstants extends org.kuali.kfs.sys.KFSPropertyConstants
 
     public static final String GEC_DOCUMENT_NUMBER = "gecDocumentNumber";
     public static final String ENTRY_ID = "entryId";
+    public static final String CARD_CYCLE_VOL_LIMIT = "cardCycleVolLimit";
 
 }

--- a/kfs-web/src/main/webapp/WEB-INF/tags/fp/procurementCardTransactions.tag
+++ b/kfs-web/src/main/webapp/WEB-INF/tags/fp/procurementCardTransactions.tag
@@ -42,7 +42,7 @@
          <tr>
            <th scope="row"><div align="right"><kul:htmlAttributeLabel attributeEntry="${cardAttributes.transactionCreditCardNumber}" readOnly="true"/></div></th>
            <td>
-             <kul:inquiry boClassName="org.kuali.kfs.fp.businessobject.ProcurementCardHolder" keyValues="documentNumber=${currentTransaction.documentNumber}" render="true">
+             <kul:inquiry boClassName="edu.arizona.kfs.fp.businessobject.ProcurementCardHolder" keyValues="documentNumber=${currentTransaction.documentNumber}" render="true">
                <c:choose>
                  <c:when test="${KualiForm.transactionCreditCardNumbersViewStatus[ctr]}">
                    <bean:write name="KualiForm" property="document.procurementCardHolder.transactionCreditCardNumber" />


### PR DESCRIPTION
Modified ProcurementCardCreateDocumentService.java to pass in the pcard document into the requeueDocument method to gain access to its methods.
Modified ProcurementCardCreateDocumentServiceImpl.java. Changed the requeueDocument method to gain access to the pcards workflow document. The superUserReturnToPreviousNode of WorkflowDocumentActionsService was not updating the account number and object code when the procurementCardDocumentJob was run. Overrode the createTargetAccountingLine method to match KFS 3.0. Also overrode validateTargetAccountingLine to fix the error text.
Modified ProcurementCardDefaultRule.java to fix the validateCardHolderDefault method and use cardCycleVolLimit instead of cardCycleVolumeLimit when checking for null.
Modified ProcurementCardAction.java to pass in the procurement card document instead of just the id to the requeueDocument method to comply with the changed interface.
Modified procurementCardTransactions.tag to make the boClassName the edu.arizona verion of ProcurementCardHolder.java.
Modified KFSPropertyConstants.java to add constant CARD_CYCLE_VOL_LIMIT for use in other files.