### PR TITLE
UAF-3159 / UAF-4566 Exception when routing new Check Reconciliation Maintenance Document

### DIFF
--- a/kfs-cr/src/main/java/edu/arizona/kfs/module/cr/businessobject/CheckReconciliation.java
+++ b/kfs-cr/src/main/java/edu/arizona/kfs/module/cr/businessobject/CheckReconciliation.java
@@ -30,7 +30,7 @@ public class CheckReconciliation extends PersistableBusinessObjectBase implement
     private KualiDecimal amount;
     private String status;
     private Timestamp lastUpdate;
-    private Boolean glTransIndicator;
+    private Boolean glTransIndicator = Boolean.FALSE;
     private String sourceCode;
     private String payeeId;
     private String payeeTypeCode;


### PR DESCRIPTION
Setting the default value for the glTransIndicator field on Check Reconciliation. This is needed to prevent the field from being instantiated as null in certain instances. There are many examples of this in other KFS6 bo classes that use a Boolean instead of a boolean.