### PR TITLE
UAF-3398 BUG - GL entries for vendor payment (cash outlay) includes federal withholding deduction on DV

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/DisbursementVoucherDocument.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/DisbursementVoucherDocument.java
@@ -1,5 +1,6 @@
 package edu.arizona.kfs.fp.document;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -7,17 +8,25 @@ import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
+import org.kuali.kfs.fp.businessobject.DisbursementVoucherNonResidentAlienTax;
 import org.kuali.kfs.fp.document.DisbursementVoucherConstants;
+import org.kuali.kfs.fp.document.service.DisbursementVoucherTaxService;
+import org.kuali.kfs.fp.document.validation.impl.AuxiliaryVoucherDocumentRuleConstants;
 import org.kuali.kfs.sys.businessobject.AccountingLine;
 import org.kuali.kfs.sys.businessobject.Bank;
 import org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntry;
 import org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntrySequenceHelper;
 import org.kuali.kfs.sys.businessobject.GeneralLedgerPendingEntrySourceDetail;
 import org.kuali.kfs.sys.businessobject.SourceAccountingLine;
+import org.kuali.kfs.sys.businessobject.SystemOptions;
 import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.kfs.sys.service.OptionsService;
+import org.kuali.kfs.sys.service.impl.KfsParameterConstants;
 import org.kuali.kfs.vnd.businessobject.VendorAddress;
 import org.kuali.kfs.vnd.businessobject.VendorDetail;
 import org.kuali.kfs.vnd.businessobject.VendorHeader;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.coreservice.framework.parameter.ParameterService;
 import org.kuali.rice.kew.api.KewApiConstants;
 import org.kuali.rice.kew.framework.postprocessor.DocumentRouteStatusChange;
 import org.kuali.rice.kim.api.KimConstants;
@@ -382,4 +391,116 @@ public class DisbursementVoucherDocument extends org.kuali.kfs.fp.document.Disbu
 		}
 		return retval;
 	}
+
+    @Override
+    public boolean generateGeneralLedgerPendingEntries(GeneralLedgerPendingEntrySourceDetail glpeSourceDetail, GeneralLedgerPendingEntrySequenceHelper sequenceHelper) {
+        LOG.debug("processGenerateGeneralLedgerPendingEntries(GeneralLedgerPendingEntrySourceDetail glpeSourceDetail, GeneralLedgerPendingEntrySequenceHelper sequenceHelper) - start");
+
+        // handle the explicit entry
+        // create a reference to the explicitEntry to be populated, so we can pass to the offset method later
+        GeneralLedgerPendingEntry explicitEntry = new GeneralLedgerPendingEntry();
+        processExplicitGeneralLedgerPendingEntry(sequenceHelper, glpeSourceDetail, explicitEntry);
+
+        // increment the sequence counter
+        sequenceHelper.increment();
+
+        // handle the offset entry
+        GeneralLedgerPendingEntry offsetEntry = new GeneralLedgerPendingEntry(explicitEntry);
+        boolean success = processOffsetGeneralLedgerPendingEntry(sequenceHelper, glpeSourceDetail, explicitEntry, offsetEntry);
+
+        processTaxWithholdingGeneralLedgerPendingEntries(sequenceHelper, glpeSourceDetail, explicitEntry, offsetEntry);
+
+        LOG.debug("processGenerateGeneralLedgerPendingEntries(GeneralLedgerPendingEntrySourceDetail, GeneralLedgerPendingEntrySequenceHelper) - end");
+        return success;
+    }
+
+    @Override
+    public boolean customizeOffsetGeneralLedgerPendingEntry(GeneralLedgerPendingEntrySourceDetail accountingLine, GeneralLedgerPendingEntry explicitEntry, GeneralLedgerPendingEntry offsetEntry) {
+        boolean value = super.customizeOffsetGeneralLedgerPendingEntry(accountingLine, explicitEntry, offsetEntry);
+        String taxAccount = getTaxAccount();
+        if (offsetEntry.getAccountNumber().equals(taxAccount)) {
+            // Get the object code for the tax offsets from the parameter
+            String glpeOffsetObjectCode = getGlpeOffsetObjectCode();
+            SystemOptions options = getOptionsService().getOptions(explicitEntry.getUniversityFiscalYear());
+            offsetEntry.setFinancialObjectCode(glpeOffsetObjectCode);
+            offsetEntry.refreshReferenceObject(KFSPropertyConstants.FINANCIAL_OBJECT);
+            offsetEntry.setFinancialObjectTypeCode(options.getFinancialObjectTypeAssetsCd());
+            offsetEntry.refreshReferenceObject(KFSPropertyConstants.OBJECT_TYPE);
+        }
+        return value;
+    }
+
+    private void processTaxWithholdingGeneralLedgerPendingEntries(GeneralLedgerPendingEntrySequenceHelper sequenceHelper, GeneralLedgerPendingEntrySourceDetail glpeSourceDetail, GeneralLedgerPendingEntry explicitEntry, GeneralLedgerPendingEntry offsetEntry) {
+        KualiDecimal dvnraTaxAmount = SpringContext.getBean(DisbursementVoucherTaxService.class).getNonResidentAlienTaxAmount(this);
+        if (!KualiDecimal.ZERO.equals(dvnraTaxAmount)) {
+            // Don't process actual withholding entry
+            String taxAccount = getTaxAccount();
+            if (!offsetEntry.getAccountNumber().equals(taxAccount)) {
+                DisbursementVoucherNonResidentAlienTax dvnrat = ((DisbursementVoucherDocument) this).getDvNonResidentAlienTax();
+                BigDecimal amount = offsetEntry.getTransactionLedgerEntryAmount().bigDecimalValue();
+                BigDecimal taxPercentWhole = dvnrat.getFederalIncomeTaxPercent().add(dvnrat.getStateIncomeTaxPercent()).bigDecimalValue();
+                BigDecimal taxPercent = taxPercentWhole.divide(new BigDecimal(100), 5, BigDecimal.ROUND_HALF_UP);
+                KualiDecimal withholdingAmount = new KualiDecimal(amount.multiply(taxPercent).setScale(KualiDecimal.SCALE, KualiDecimal.ROUND_BEHAVIOR));
+                KualiDecimal remitAmount = new KualiDecimal(amount).subtract(withholdingAmount);
+
+                if ((withholdingAmount != null) && KualiDecimal.ZERO.compareTo(withholdingAmount) != 0) {
+                    explicitEntry.setTransactionLedgerEntryAmount(remitAmount);
+                    offsetEntry.setTransactionLedgerEntryAmount(remitAmount);
+
+                    GeneralLedgerPendingEntry txWithholdingExplicit = new GeneralLedgerPendingEntry(explicitEntry);
+                    txWithholdingExplicit.setTransactionLedgerEntryAmount(withholdingAmount);
+                    // Using the Debit/Credit code from the offset entry so it's the opposite of the explicit entry
+                    txWithholdingExplicit.setTransactionDebitCreditCode(offsetEntry.getTransactionDebitCreditCode());
+                    GeneralLedgerPendingEntry txWithholdingOffset = new GeneralLedgerPendingEntry(offsetEntry);
+                    txWithholdingOffset.setTransactionLedgerEntryAmount(withholdingAmount);
+                    // Using the Debit/Credit code from the explicit entry so it's the opposite of the offset entry
+                    txWithholdingOffset.setTransactionDebitCreditCode(explicitEntry.getTransactionDebitCreditCode());
+                    processTaxWithholdingGeneralLedgerPendingEntries(sequenceHelper, glpeSourceDetail, txWithholdingExplicit, txWithholdingOffset, parameterService);
+                }
+            }
+        }
+    }
+
+    private void processTaxWithholdingGeneralLedgerPendingEntries(GeneralLedgerPendingEntrySequenceHelper sequenceHelper, GeneralLedgerPendingEntrySourceDetail glpeSourceDetail, GeneralLedgerPendingEntry explicitEntry, GeneralLedgerPendingEntry offsetEntry, ParameterService parameterService) {
+
+        // create the explicit entry
+        sequenceHelper.increment();
+
+        GeneralLedgerPendingEntry taxWithholdingExplicit = new GeneralLedgerPendingEntry(explicitEntry);
+        taxWithholdingExplicit.setTransactionLedgerEntrySequenceNumber(sequenceHelper.getSequenceCounter());
+        // Using the Debit/Credit code from the offset entry so it's the opposite of the explicit entry
+        taxWithholdingExplicit.setTransactionDebitCreditCode(offsetEntry.getTransactionDebitCreditCode());
+        addPendingEntry(taxWithholdingExplicit);
+
+        // create the offset entry
+        // Get the object code for the use tax offsets from the parameter
+        String glpeOffsetObjectCode = getGlpeOffsetObjectCode();
+        SystemOptions options = getOptionsService().getOptions(explicitEntry.getUniversityFiscalYear());
+
+        sequenceHelper.increment();
+
+        GeneralLedgerPendingEntry taxWithholdingOffset = new GeneralLedgerPendingEntry(offsetEntry);
+        taxWithholdingOffset.setTransactionLedgerEntrySequenceNumber(sequenceHelper.getSequenceCounter());
+        taxWithholdingOffset.setFinancialObjectCode(glpeOffsetObjectCode);
+        taxWithholdingOffset.setFinancialObjectTypeCode(options.getFinancialObjectTypeAssetsCd());
+        // Using the Debit/Credit code from the explicit entry so it's the opposite of the offset entry
+        taxWithholdingOffset.setTransactionDebitCreditCode(explicitEntry.getTransactionDebitCreditCode());
+
+        addPendingEntry(taxWithholdingOffset);
+
+    }
+
+    private String getTaxAccount() {
+        String taxAccount = getParameterService().getParameterValueAsString(KFSConstants.CoreModuleNamespaces.FINANCIAL, DISBURSEMENT_VOUCHER_TYPE, DisbursementVoucherConstants.FEDERAL_TAX_PARM_PREFIX + DisbursementVoucherConstants.TAX_PARM_ACCOUNT_SUFFIX);
+        return taxAccount;
+    }
+
+    private String getGlpeOffsetObjectCode() {
+        String glpeOffsetObjectCode = getParameterService().getParameterValueAsString(KFSConstants.OptionalModuleNamespaces.PURCHASING_ACCOUNTS_PAYABLE, KfsParameterConstants.DOCUMENT_COMPONENT, AuxiliaryVoucherDocumentRuleConstants.GENERAL_LEDGER_PENDING_ENTRY_OFFSET_CODE);
+        return glpeOffsetObjectCode;
+    }
+
+    private OptionsService getOptionsService() {
+        return SpringContext.getBean(OptionsService.class);
+    }
 }

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/DisbursementVoucherDocument.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/DisbursementVoucherDocument.java
@@ -436,14 +436,14 @@ public class DisbursementVoucherDocument extends org.kuali.kfs.fp.document.Disbu
             // Don't process actual withholding entry
             String taxAccount = getTaxAccount();
             if (!offsetEntry.getAccountNumber().equals(taxAccount)) {
-                DisbursementVoucherNonResidentAlienTax dvnrat = ((DisbursementVoucherDocument) this).getDvNonResidentAlienTax();
+                DisbursementVoucherNonResidentAlienTax dvnrat = getDvNonResidentAlienTax();
                 BigDecimal amount = offsetEntry.getTransactionLedgerEntryAmount().bigDecimalValue();
                 BigDecimal taxPercentWhole = dvnrat.getFederalIncomeTaxPercent().add(dvnrat.getStateIncomeTaxPercent()).bigDecimalValue();
                 BigDecimal taxPercent = taxPercentWhole.divide(new BigDecimal(100), 5, BigDecimal.ROUND_HALF_UP);
                 KualiDecimal withholdingAmount = new KualiDecimal(amount.multiply(taxPercent).setScale(KualiDecimal.SCALE, KualiDecimal.ROUND_BEHAVIOR));
                 KualiDecimal remitAmount = new KualiDecimal(amount).subtract(withholdingAmount);
 
-                if ((withholdingAmount != null) && KualiDecimal.ZERO.compareTo(withholdingAmount) != 0) {
+                if (KualiDecimal.ZERO.compareTo(withholdingAmount) != 0) {
                     explicitEntry.setTransactionLedgerEntryAmount(remitAmount);
                     offsetEntry.setTransactionLedgerEntryAmount(remitAmount);
 

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/service/impl/DisbursementVoucherExtractionHelperServiceImpl.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/service/impl/DisbursementVoucherExtractionHelperServiceImpl.java
@@ -1,0 +1,234 @@
+package edu.arizona.kfs.fp.document.service.impl;
+
+import java.sql.Date;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.fp.businessobject.DisbursementVoucherNonEmployeeExpense;
+import org.kuali.kfs.fp.businessobject.DisbursementVoucherNonEmployeeTravel;
+import org.kuali.kfs.fp.businessobject.DisbursementVoucherPayeeDetail;
+import org.kuali.kfs.fp.businessobject.DisbursementVoucherPreConferenceDetail;
+import org.kuali.kfs.fp.businessobject.DisbursementVoucherPreConferenceRegistrant;
+import org.kuali.kfs.fp.document.DisbursementVoucherConstants;
+import org.kuali.kfs.fp.document.DisbursementVoucherDocument;
+import org.kuali.kfs.pdp.PdpParameterConstants;
+import org.kuali.kfs.pdp.businessobject.PaymentAccountDetail;
+import org.kuali.kfs.pdp.businessobject.PaymentDetail;
+import org.kuali.kfs.pdp.businessobject.PaymentNoteText;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.businessobject.SourceAccountingLine;
+import org.kuali.kfs.sys.service.impl.KfsParameterConstants;
+import org.kuali.rice.core.api.util.type.KualiDecimal;
+import org.kuali.rice.core.api.util.type.KualiInteger;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public class DisbursementVoucherExtractionHelperServiceImpl extends org.kuali.kfs.fp.document.service.impl.DisbursementVoucherExtractionHelperServiceImpl {
+    public static final org.apache.log4j.Logger LOG = org.apache.log4j.Logger.getLogger(DisbursementVoucherExtractionHelperServiceImpl.class);
+
+    @Override
+    protected PaymentDetail buildPaymentDetail(DisbursementVoucherDocument document, Date processRunDate) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("buildPaymentDetail() started");
+        }
+        final String maxNoteLinesParam = getParameterService().getParameterValueAsString(KfsParameterConstants.PRE_DISBURSEMENT_ALL.class, PdpParameterConstants.MAX_NOTE_LINES);
+
+        int maxNoteLines;
+        try {
+            maxNoteLines = Integer.parseInt(maxNoteLinesParam);
+        } catch (NumberFormatException nfe) {
+            throw new IllegalArgumentException("Invalid Max Notes Lines parameter, value: " + maxNoteLinesParam + " cannot be converted to an integer");
+        }
+
+        PaymentDetail pd = new PaymentDetail();
+        if (StringUtils.isNotEmpty(document.getDocumentHeader().getOrganizationDocumentNumber())) {
+            pd.setOrganizationDocNbr(document.getDocumentHeader().getOrganizationDocumentNumber());
+        }
+        pd.setCustPaymentDocNbr(document.getDocumentNumber());
+        pd.setInvoiceDate(new java.sql.Date(processRunDate.getTime()));
+        pd.setOrigInvoiceAmount(document.getDisbVchrCheckTotalAmount());
+        pd.setInvTotDiscountAmount(KualiDecimal.ZERO);
+        pd.setInvTotOtherCreditAmount(KualiDecimal.ZERO);
+        pd.setInvTotOtherDebitAmount(KualiDecimal.ZERO);
+        pd.setInvTotShipAmount(KualiDecimal.ZERO);
+        pd.setNetPaymentAmount(document.getDisbVchrCheckTotalAmount());
+        pd.setPrimaryCancelledPayment(Boolean.FALSE);
+        pd.setFinancialDocumentTypeCode(DisbursementVoucherConstants.DOCUMENT_TYPE_CHECKACH);
+        pd.setFinancialSystemOriginCode(KFSConstants.ORIGIN_CODE_KUALI);
+
+        // Handle accounts
+        for (SourceAccountingLine sal : (List<? extends SourceAccountingLine>) document.getSourceAccountingLines()) {
+            PaymentAccountDetail pad = new PaymentAccountDetail();
+            pad.setFinChartCode(sal.getChartOfAccountsCode());
+            pad.setAccountNbr(sal.getAccountNumber());
+            if (StringUtils.isNotEmpty(sal.getSubAccountNumber())) {
+                pad.setSubAccountNbr(sal.getSubAccountNumber());
+            } else {
+                pad.setSubAccountNbr(KFSConstants.getDashSubAccountNumber());
+            }
+            pad.setFinObjectCode(sal.getFinancialObjectCode());
+            if (StringUtils.isNotEmpty(sal.getFinancialSubObjectCode())) {
+                pad.setFinSubObjectCode(sal.getFinancialSubObjectCode());
+            } else {
+                pad.setFinSubObjectCode(KFSConstants.getDashFinancialSubObjectCode());
+            }
+            if (StringUtils.isNotEmpty(sal.getOrganizationReferenceId())) {
+                pad.setOrgReferenceId(sal.getOrganizationReferenceId());
+            }
+            if (StringUtils.isNotEmpty(sal.getProjectCode())) {
+                pad.setProjectCode(sal.getProjectCode());
+            } else {
+                pad.setProjectCode(KFSConstants.getDashProjectCode());
+            }
+            pad.setAccountNetAmount(sal.getAmount());
+            pd.addAccountDetail(pad);
+        }
+
+        // Handle notes
+        DisbursementVoucherPayeeDetail dvpd = document.getDvPayeeDetail();
+
+        int line = 0;
+        PaymentNoteText pnt = new PaymentNoteText();
+        pnt.setCustomerNoteLineNbr(new KualiInteger(line++));
+        pnt.setCustomerNoteText("Info: " + document.getDisbVchrContactPersonName() + " " + document.getDisbVchrContactPhoneNumber());
+        pd.addNote(pnt);
+
+        String dvSpecialHandlingPersonName = null;
+        String dvSpecialHandlingLine1Address = null;
+        String dvSpecialHandlingLine2Address = null;
+        String dvSpecialHandlingCity = null;
+        String dvSpecialHandlingState = null;
+        String dvSpecialHandlingZip = null;
+
+        dvSpecialHandlingPersonName = dvpd.getDisbVchrSpecialHandlingPersonName();
+        dvSpecialHandlingLine1Address = dvpd.getDisbVchrSpecialHandlingLine1Addr();
+        dvSpecialHandlingLine2Address = dvpd.getDisbVchrSpecialHandlingLine2Addr();
+        dvSpecialHandlingCity = dvpd.getDisbVchrSpecialHandlingCityName();
+        dvSpecialHandlingState = dvpd.getDisbVchrSpecialHandlingStateCode();
+        dvSpecialHandlingZip = dvpd.getDisbVchrSpecialHandlingZipCode();
+
+        if (StringUtils.isNotEmpty(dvSpecialHandlingPersonName)) {
+            pnt = new PaymentNoteText();
+            pnt.setCustomerNoteLineNbr(new KualiInteger(line++));
+            pnt.setCustomerNoteText("Send Check To: " + dvSpecialHandlingPersonName);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Creating special handling person name note: " + pnt.getCustomerNoteText());
+            }
+            pd.addNote(pnt);
+        }
+        if (StringUtils.isNotEmpty(dvSpecialHandlingLine1Address)) {
+            pnt = new PaymentNoteText();
+            pnt.setCustomerNoteLineNbr(new KualiInteger(line++));
+            pnt.setCustomerNoteText(dvSpecialHandlingLine1Address);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Creating special handling address 1 note: " + pnt.getCustomerNoteText());
+            }
+            pd.addNote(pnt);
+        }
+        if (StringUtils.isNotEmpty(dvSpecialHandlingLine2Address)) {
+            pnt = new PaymentNoteText();
+            pnt.setCustomerNoteLineNbr(new KualiInteger(line++));
+            pnt.setCustomerNoteText(dvSpecialHandlingLine2Address);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Creating special handling address 2 note: " + pnt.getCustomerNoteText());
+            }
+            pd.addNote(pnt);
+        }
+        if (StringUtils.isNotEmpty(dvSpecialHandlingCity)) {
+            pnt = new PaymentNoteText();
+            pnt.setCustomerNoteLineNbr(new KualiInteger(line++));
+            pnt.setCustomerNoteText(dvSpecialHandlingCity + ", " + dvSpecialHandlingState + " " + dvSpecialHandlingZip);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Creating special handling city note: " + pnt.getCustomerNoteText());
+            }
+            pd.addNote(pnt);
+        }
+        if (document.isDisbVchrAttachmentCode()) {
+            pnt = new PaymentNoteText();
+            pnt.setCustomerNoteLineNbr(new KualiInteger(line++));
+            pnt.setCustomerNoteText("Attachment Included");
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("create attachment note: " + pnt.getCustomerNoteText());
+            }
+            pd.addNote(pnt);
+        }
+
+        String paymentReasonCode = dvpd.getDisbVchrPaymentReasonCode();
+        if (/* REFACTORME */getParameterEvaluatorService().getParameterEvaluator(DisbursementVoucherDocument.class, DisbursementVoucherConstants.NONEMPLOYEE_TRAVEL_PAY_REASONS_PARM_NM, paymentReasonCode).evaluationSucceeds()) {
+            DisbursementVoucherNonEmployeeTravel dvnet = document.getDvNonEmployeeTravel();
+
+            pnt = new PaymentNoteText();
+            pnt.setCustomerNoteLineNbr(new KualiInteger(line++));
+            pnt.setCustomerNoteText("Reimbursement associated with " + dvnet.getDisbVchrServicePerformedDesc());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Creating non employee travel notes: " + pnt.getCustomerNoteText());
+            }
+            pd.addNote(pnt);
+
+            pnt = new PaymentNoteText();
+            pnt.setCustomerNoteLineNbr(new KualiInteger(line++));
+            pnt.setCustomerNoteText("The total per diem amount for your daily expenses is " + dvnet.getDisbVchrPerdiemCalculatedAmt());
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Creating non employee travel notes: " + pnt.getCustomerNoteText());
+            }
+            pd.addNote(pnt);
+
+            if (dvnet.getDisbVchrPersonalCarAmount() != null && dvnet.getDisbVchrPersonalCarAmount().compareTo(KualiDecimal.ZERO) != 0) {
+                pnt = new PaymentNoteText();
+                pnt.setCustomerNoteLineNbr(new KualiInteger(line++));
+                pnt.setCustomerNoteText("The total dollar amount for your vehicle mileage is " + dvnet.getDisbVchrPersonalCarAmount());
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Creating non employee travel vehicle note: " + pnt.getCustomerNoteText());
+                }
+                pd.addNote(pnt);
+
+                for (DisbursementVoucherNonEmployeeExpense exp : (List<DisbursementVoucherNonEmployeeExpense>) dvnet.getDvNonEmployeeExpenses()) {
+                    if (line < (maxNoteLines - 8)) {
+                        pnt = new PaymentNoteText();
+                        pnt.setCustomerNoteLineNbr(new KualiInteger(line++));
+                        pnt.setCustomerNoteText(exp.getDisbVchrExpenseCompanyName() + " " + exp.getDisbVchrExpenseAmount());
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("Creating non employee travel expense note: " + pnt.getCustomerNoteText());
+                        }
+                        pd.addNote(pnt);
+                    }
+                }
+            }
+        } else if (/* REFACTORME */getParameterEvaluatorService().getParameterEvaluator(DisbursementVoucherDocument.class, DisbursementVoucherConstants.PREPAID_TRAVEL_PAYMENT_REASONS_PARM_NM, paymentReasonCode).evaluationSucceeds()) {
+            pnt = new PaymentNoteText();
+            pnt.setCustomerNoteLineNbr(new KualiInteger(line++));
+            pnt.setCustomerNoteText("Payment is for the following individuals/charges:");
+            pd.addNote(pnt);
+            if (LOG.isDebugEnabled()) {
+                LOG.info("Creating prepaid travel note note: " + pnt.getCustomerNoteText());
+            }
+
+            DisbursementVoucherPreConferenceDetail dvpcd = document.getDvPreConferenceDetail();
+
+            for (DisbursementVoucherPreConferenceRegistrant dvpcr : (List<DisbursementVoucherPreConferenceRegistrant>) dvpcd.getDvPreConferenceRegistrants()) {
+                if (line < (maxNoteLines - 8)) {
+                    pnt = new PaymentNoteText();
+                    pnt.setCustomerNoteLineNbr(new KualiInteger(line++));
+                    pnt.setCustomerNoteText(dvpcr.getDvConferenceRegistrantName() + " " + dvpcr.getDisbVchrExpenseAmount());
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Creating pre-paid conference registrants note: " + pnt.getCustomerNoteText());
+                    }
+                    pd.addNote(pnt);
+                }
+            }
+        }
+
+        // Get the original, raw form, note text from the DV document.
+        final String text = document.getDisbVchrCheckStubText();
+        if (!StringUtils.isBlank(text)) {
+            pnt = this.getPaymentSourceHelperService().buildNoteForCheckStubText(text, line);
+            // Logging...
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Creating check stub text note: " + pnt.getCustomerNoteText());
+            }
+            pd.addNote(pnt);
+        }
+
+        return pd;
+    }
+}

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/spring-fp.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/spring-fp.xml
@@ -184,4 +184,6 @@
       </property>
     </bean>
 
+    <bean id="disbursementVoucherExtractionHelperService" parent="disbursementVoucherExtractionHelperService-parentBean" class="org.kuali.kfs.fp.document.service.impl.DisbursementVoucherExtractionHelperServiceImpl" />
+
 </beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/spring-fp.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/spring-fp.xml
@@ -184,6 +184,6 @@
       </property>
     </bean>
 
-    <bean id="disbursementVoucherExtractionHelperService" parent="disbursementVoucherExtractionHelperService-parentBean" class="org.kuali.kfs.fp.document.service.impl.DisbursementVoucherExtractionHelperServiceImpl" />
+    <bean id="disbursementVoucherExtractionHelperService" parent="disbursementVoucherExtractionHelperService-parentBean" class="edu.arizona.kfs.fp.document.service.impl.DisbursementVoucherExtractionHelperServiceImpl" />
 
 </beans>


### PR DESCRIPTION
This pull request was left as 2 commits intentionally.
The first commit contains the buildPaymentDetail(DisbursementVoucherDocument, Date), copied from KFS6 org.kuali DisbursementVoucherExtractionHelperServiceImpl to the edu.arizona child object. This was done so the (very long) method could be minimally modified without refactoring it to fall within UA best coding practices and risk additional bugs being added.

The second commit contains the change to the method and the additional code to support the change.

That being said, if the reviewer would prefer to have this squashed into a single commit, that can be done.