### PR TITLE
UAF-4587 BUG - PCard UAF-46 AWS Issues

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/impl/ProcurementCardCreateDocumentServiceImpl.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/impl/ProcurementCardCreateDocumentServiceImpl.java
@@ -584,71 +584,71 @@ public class ProcurementCardCreateDocumentServiceImpl extends org.kuali.kfs.fp.b
     
     @Override
     protected String validateTargetAccountingLine(ProcurementCardTargetAccountingLine targetLine) {
-        String errorText = KFSConstants.EMPTY_STRING;
+        StringBuilder errorText = new StringBuilder(KFSConstants.EMPTY_STRING);
 
         targetLine.refresh();
         final String lineNumber = targetLine.getSequenceNumber() == null ? KFSPropertyConstants.NEW : targetLine.getSequenceNumber().toString();
 
-        if (!accountingLineRuleUtil.isValidChart(KFSConstants.EMPTY_STRING, targetLine.getChart(), dataDictionaryService.getDataDictionary())) {
+        if (!accountingLineRuleUtil.isValidChart(KFSConstants.EMPTY_STRING, targetLine.getChart(), getDataDictionaryService().getDataDictionary())) {
             String tempErrorText = "Target Accounting Line "+lineNumber+" Chart " + targetLine.getChartOfAccountsCode() + " is invalid; using error Chart Code.";
             if ( LOG.isInfoEnabled() ) {
                 LOG.info(tempErrorText);
             }
-            errorText += " " + tempErrorText;
+            errorText.append(" " + tempErrorText);
 
             targetLine.setChartOfAccountsCode(getErrorChartCode());
             targetLine.refresh();
         }
 
-        if (!accountingLineRuleUtil.isValidAccount(KFSConstants.EMPTY_STRING, targetLine.getAccount(), dataDictionaryService.getDataDictionary()) || targetLine.getAccount().isExpired()) {
+        if (!accountingLineRuleUtil.isValidAccount(KFSConstants.EMPTY_STRING, targetLine.getAccount(), getDataDictionaryService().getDataDictionary()) || targetLine.getAccount().isExpired()) {
             //changing this line from delivered code to correct the error text
             String tempErrorText = targetLine.getChartOfAccountsCode() + " Account " + targetLine.getAccountNumber() + " is invalid; using error account.";
             if ( LOG.isInfoEnabled() ) {
                 LOG.info(tempErrorText);
             }
-            errorText += " " + tempErrorText;
+            errorText.append(" " + tempErrorText);
 
             targetLine.setChartOfAccountsCode(getErrorChartCode());
             targetLine.setAccountNumber(getErrorAccountNumber());
             targetLine.refresh();
         }
 
-        if (!accountingLineRuleUtil.isValidObjectCode(KFSConstants.EMPTY_STRING, targetLine.getObjectCode(), dataDictionaryService.getDataDictionary())) {
+        if (!accountingLineRuleUtil.isValidObjectCode(KFSConstants.EMPTY_STRING, targetLine.getObjectCode(), getDataDictionaryService().getDataDictionary())) {
             String tempErrorText = "Target Accounting Line "+lineNumber+" Chart " + targetLine.getChartOfAccountsCode() + " Object Code " + targetLine.getFinancialObjectCode() + " is invalid; using default Object Code.";
             if ( LOG.isInfoEnabled() ) {
                 LOG.info(tempErrorText);
             }
-            errorText += " " + tempErrorText;
+            errorText.append(" " + tempErrorText);
 
             targetLine.setFinancialObjectCode(getDefaultObjectCode());
             targetLine.refresh();
         }
 
-        if (StringUtils.isNotBlank(targetLine.getSubAccountNumber()) && !accountingLineRuleUtil.isValidSubAccount(KFSConstants.EMPTY_STRING, targetLine.getSubAccount(), dataDictionaryService.getDataDictionary())) {
+        if (StringUtils.isNotBlank(targetLine.getSubAccountNumber()) && !accountingLineRuleUtil.isValidSubAccount(KFSConstants.EMPTY_STRING, targetLine.getSubAccount(), getDataDictionaryService().getDataDictionary())) {
             String tempErrorText = "Target Accounting Line "+lineNumber+" Chart " + targetLine.getChartOfAccountsCode() + " Account " + targetLine.getAccountNumber() + " Sub Account " + targetLine.getSubAccountNumber() + " is invalid; Setting Sub Account to blank.";
             if ( LOG.isInfoEnabled() ) {
                 LOG.info(tempErrorText);
             }
-            errorText += " " + tempErrorText;
+            errorText.append(" " + tempErrorText);
 
             targetLine.setSubAccountNumber("");
         }
 
-        if (StringUtils.isNotBlank(targetLine.getFinancialSubObjectCode()) && !accountingLineRuleUtil.isValidSubObjectCode(KFSConstants.EMPTY_STRING, targetLine.getSubObjectCode(), dataDictionaryService.getDataDictionary())) {
+        if (StringUtils.isNotBlank(targetLine.getFinancialSubObjectCode()) && !accountingLineRuleUtil.isValidSubObjectCode(KFSConstants.EMPTY_STRING, targetLine.getSubObjectCode(), getDataDictionaryService().getDataDictionary())) {
             String tempErrorText = "Target Accounting Line "+lineNumber+" Chart " + targetLine.getChartOfAccountsCode() + " Account " + targetLine.getAccountNumber() + " Object Code " + targetLine.getFinancialObjectCode() + " Sub Object Code " + targetLine.getFinancialSubObjectCode() + " is invalid; setting Sub Object to blank.";
             if ( LOG.isInfoEnabled() ) {
                 LOG.info(tempErrorText);
             }
-            errorText += " " + tempErrorText;
+            errorText.append(" " + tempErrorText);
 
             targetLine.setFinancialSubObjectCode("");
         }
 
-        if (StringUtils.isNotBlank(targetLine.getProjectCode()) && !accountingLineRuleUtil.isValidProjectCode(KFSConstants.EMPTY_STRING, targetLine.getProject(), dataDictionaryService.getDataDictionary())) {
+        if (StringUtils.isNotBlank(targetLine.getProjectCode()) && !accountingLineRuleUtil.isValidProjectCode(KFSConstants.EMPTY_STRING, targetLine.getProject(), getDataDictionaryService().getDataDictionary())) {
             if ( LOG.isInfoEnabled() ) {
                 LOG.info("Target Accounting Line "+lineNumber+" Project Code " + targetLine.getProjectCode() + " is invalid; setting to blank.");
             }
-            errorText += " Target Accounting Line "+lineNumber+" Project Code " + targetLine.getProjectCode() + " is invalid; setting to blank.";
+            errorText.append(" Target Accounting Line "+lineNumber+" Project Code " + targetLine.getProjectCode() + " is invalid; setting to blank.");
 
             targetLine.setProjectCode(KFSConstants.EMPTY_STRING);
         }
@@ -656,7 +656,7 @@ public class ProcurementCardCreateDocumentServiceImpl extends org.kuali.kfs.fp.b
         // clear out GlobalVariable message map, since we have taken care of the errors
         GlobalVariables.setMessageMap(new MessageMap());
 
-        return errorText;
+        return errorText.toString();
     }
     
     /**

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/validation/impl/ProcurementCardDefaultRule.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/validation/impl/ProcurementCardDefaultRule.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.apache.commons.lang.StringUtils;
 import org.kuali.kfs.sys.KFSKeyConstants;
 import org.kuali.rice.kns.document.MaintenanceDocument;
+import org.kuali.rice.krad.util.ObjectUtils;
 
 import edu.arizona.kfs.fp.businessobject.ProcurementCardDefault;
 import edu.arizona.kfs.sys.KFSPropertyConstants;
@@ -76,15 +77,15 @@ public class ProcurementCardDefaultRule extends org.kuali.kfs.fp.document.valida
                 putFieldErrorWithLabel(KFSPropertyConstants.PROCUREMENT_CARD_HOLDER_WORK_PHONE_NUMBER, KFSKeyConstants.ERROR_REQUIRED);
                 valid = false;
             }
-            if (newProcurementCardDefault.getCardLimit() == null) {
+            if (ObjectUtils.isNull(newProcurementCardDefault.getCardLimit())) {
                 putFieldErrorWithLabel(KFSPropertyConstants.PROCUREMENT_CARD_LIMIT, KFSKeyConstants.ERROR_REQUIRED);
                 valid = false;
             }
-            if (newProcurementCardDefault.getCardCycleAmountLimit() == null) {
+            if (ObjectUtils.isNull(newProcurementCardDefault.getCardCycleAmountLimit())) {
                 putFieldErrorWithLabel(KFSPropertyConstants.PROCUREMENT_CARD_CYCLE_AMOUNT_LIMIT, KFSKeyConstants.ERROR_REQUIRED);
                 valid = false;
             }
-            if (newProcurementCardDefault.getCardCycleVolLimit() == null) {
+            if (ObjectUtils.isNull(newProcurementCardDefault.getCardCycleVolLimit())) {
                 putFieldErrorWithLabel(KFSPropertyConstants.CARD_CYCLE_VOL_LIMIT, KFSKeyConstants.ERROR_REQUIRED);
                 valid = false;
             }

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardHolder.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/businessobject/datadictionary/ProcurementCardHolder.xml
@@ -117,7 +117,7 @@
 		abstract="true" parent="PersonImpl-name">
 		<property name="name" value="cardHolderAlternateName" />
 		<property name="forceUppercase" value="false" />
-		<property name="label" value="Card Holder Alternate Name" />
+		<property name="label" value="Cardholder Alternate Name" />
 		<property name="shortLabel" value="Name" />
 		<property name="required" value="false" />
 		<property name="control">
@@ -130,7 +130,7 @@
 		abstract="true" parent="AttributeDefinition">
 		<property name="name" value="cardHolderCityName" />
 		<property name="forceUppercase" value="false" />
-		<property name="label" value="Card Holder City Name" />
+		<property name="label" value="Cardholder City Name" />
 		<property name="shortLabel" value="Name" />
 		<property name="maxLength" value="45" />
 		<property name="control">
@@ -143,7 +143,7 @@
 		abstract="true" parent="AttributeDefinition">
 		<property name="name" value="cardHolderLine1Address" />
 		<property name="forceUppercase" value="false" />
-		<property name="label" value="Card Holder Line1 Address" />
+		<property name="label" value="Cardholder Line1 Address" />
 		<property name="shortLabel" value="Address" />
 		<property name="maxLength" value="45" />
 		<property name="control">
@@ -156,7 +156,7 @@
 		abstract="true" parent="AttributeDefinition">
 		<property name="name" value="cardHolderLine2Address" />
 		<property name="forceUppercase" value="false" />
-		<property name="label" value="Card Holder Line2 Address" />
+		<property name="label" value="Cardholder Line2 Address" />
 		<property name="shortLabel" value="Address" />
 		<property name="maxLength" value="45" />
 		<property name="control">
@@ -169,7 +169,7 @@
 		abstract="true" parent="PersonImpl-name">
 		<property name="name" value="cardHolderName" />
 		<property name="forceUppercase" value="false" />
-		<property name="label" value="Card Holder Name" />
+		<property name="label" value="Cardholder Name" />
 		<property name="shortLabel" value="Name" />
 		<property name="control">
 			<bean parent="TextControlDefinition" p:size="37" />
@@ -180,7 +180,7 @@
 	<bean id="ProcurementCardHolder-cardHolderStateCode-parentBean"
 		abstract="true" parent="State-code">
 		<property name="name" value="cardHolderStateCode" />
-		<property name="label" value="Card Holder State Code" />
+		<property name="label" value="Cardholder State Code" />
 		<property name="shortLabel" value="Code" />
 		<property name="required" value="false"/>
 	</bean>
@@ -191,7 +191,7 @@
 		abstract="true" parent="AttributeDefinition">
 		<property name="name" value="cardHolderWorkPhoneNumber" />
 		<property name="forceUppercase" value="false" />
-		<property name="label" value="Card Holder Work Phone Number" />
+		<property name="label" value="Cardholder Work Phone Number" />
 		<property name="shortLabel" value="Number" />
 		<property name="maxLength" value="10" />
 		<property name="control">
@@ -203,7 +203,7 @@
 	<bean id="ProcurementCardHolder-cardHolderZipCode-parentBean"
 		abstract="true" parent="PostalCode-code" >
 		<property name="name" value="cardHolderZipCode" />
-		<property name="label" value="Card Holder Postal (ZIP) Code" />
+		<property name="label" value="Cardholder Postal (ZIP) Code" />
 		<property name="shortLabel" value="Code" />
 		<property name="required" value="false"/>
 		<property name="validationPattern">
@@ -232,7 +232,7 @@
 		parent="AttributeDefinition">
 		<property name="name" value="cardNoteText" />
 		<property name="forceUppercase" value="false" />
-		<property name="label" value="Card Note Text" />
+		<property name="label" value="Original Vendor Name" />
 		<property name="shortLabel" value="Text" />
 		<property name="maxLength" value="50" />
 		<property name="control">
@@ -305,7 +305,7 @@
 
 	<bean id="ProcurementCardHolder-inquiryDefinition-parentBean"
 		abstract="true" parent="InquiryDefinition">
-		<property name="title" value="Procurement Card Holder Inquiry" />
+		<property name="title" value="Procurement Cardholder Inquiry" />
 		<property name="inquirySections">
 			<list>
 				<ref bean="ProcurementCardHolder-inquirySectionDefinition" />

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/ProcurementCardDocument.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/ProcurementCardDocument.xml
@@ -85,6 +85,14 @@
 					<property name="lines">
 						<list>
 							<ref bean="accountingInformation"/>
+							<bean parent="AccountingLineView-line">
+                                <property name="elementName" value="lineDescription"/>
+                                <property name="fields">
+                                    <list>
+                                        <bean parent="AccountingLineView-field" p:name="financialDocumentLineDescription" p:overrideColSpan="2"/>
+                                    </list>
+                                </property>
+                            </bean>
 							<ref bean="salesTaxInformation"/>
 						</list>
 					</property>

--- a/kfs-web/src/main/webapp/WEB-INF/tags/fp/procurementCardTransactions.tag
+++ b/kfs-web/src/main/webapp/WEB-INF/tags/fp/procurementCardTransactions.tag
@@ -103,7 +103,7 @@
            </td>
            <c:if test="${KualiForm.enableSalesTaxIndicator}">
              <th><div align="right"><kul:htmlAttributeLabel attributeEntry="${transactionAttributes.transactionTaxExemptIndicator}"/></div></th>
-             <td valign=top><kul:htmlControlAttribute attributeEntry="${transactionAttributes.transactionTaxExemptIndicator}" property="document.transactionEntries[${ctr}].transactionTaxExemptIndicator" readOnly="false"/></td>
+             <td valign=top><kul:htmlControlAttribute attributeEntry="${transactionAttributes.transactionTaxExemptIndicator}" property="document.transactionEntries[${ctr}].transactionTaxExemptIndicator" readOnly="${!canEdit}"/></td>
            </c:if>
            <c:if test="${!KualiForm.enableSalesTaxIndicator}">
              <html:hidden write="false" property="document.transactionEntries[${ctr}].transactionTaxExemptIndicator"/>


### PR DESCRIPTION
Modified ProcurementCardCreateDocumentServiceImpl.java and ProcurementCardDefaultRule.java. These changes were suggestions made by Scott in the code review for UAF-2977 that make the code 'a little more robust', but did not hold it up from being merged into the epic branch UAF-0046.
Modified ProcurementCardHolder.xml to fix the spelling of Cardholder and also change 'Card Note Text' to 'Original Vendoer Name'.
Modified ProcurementCardDocument.xml to add in the line description on the accounting lines section of the procurement card document.
Modified procurementCardTransactions.tag to change the readOnly property of the tax exempt indicator from always false to whether the user has the permissions to edit it.