### PR TITLE
UAF-4465 - BUG - Doc Search Display Does Not Show Correct Number Items Found

### DIFF
--- a/kfs-core/src/main/resources/spring-rice-kew-overrides.xml
+++ b/kfs-core/src/main/resources/spring-rice-kew-overrides.xml
@@ -21,14 +21,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:p="http://www.springframework.org/schema/p"
-       xmlns:aop="http://www.springframework.org/schema/aop"
-       xmlns:tx="http://www.springframework.org/schema/tx"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-                           http://www.springframework.org/schema/tx
-                           http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
-                           http://www.springframework.org/schema/aop
-                           http://www.springframework.org/schema/aop/spring-aop-3.0.xsd" default-lazy-init="false">
+                           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd" default-lazy-init="false">
 
 
     <bean id="enDocumentSearchDAO" class="edu.arizona.rice.kew.docsearch.dao.impl.DocumentSearchDAOJdbcImpl">
@@ -47,18 +41,5 @@
     <bean id="documentSearchCriteriaTranslator" class="org.kuali.rice.kew.impl.document.search.DocumentSearchCriteriaTranslatorImpl"/>
     <bean id="rice.kew.import.enDocumentSearchService" class="org.kuali.rice.krad.config.GlobalResourceLoaderServiceFactoryBean"
         p:serviceName="enDocumentSearchService"/>
-    
-    <bean id="documentSearchCriteriaBoLookupableHelperService"
-        class="edu.arizona.rice.kew.impl.document.search.DocumentSearchCriteriaBoLookupableHelperService" scope="prototype">
-        <property name="documentSearchCriteriaProcessor" ref="documentSearchCriteriaProcessor"/>
-        <property name="documentSearchCriteriaTranslator" ref="documentSearchCriteriaTranslator"/>
-        <property name="documentSearchService" ref="rice.kew.import.enDocumentSearchService"/>
-    </bean>
 
-    <bean id="documentSearchCriteriaBoLookupable" class="org.kuali.rice.kns.lookup.KualiLookupableImpl" scope="prototype">
-        <property name="lookupableHelperService">
-            <ref local="documentSearchCriteriaBoLookupableHelperService" />
-        </property>
-        <property name="extraOnLoad" value="storeCurrentDocTypeNameOnLoad()"/>
-    </bean>
 </beans>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <oracle.artifactId>ojdbc6</oracle.artifactId>
     <oracle.version>11.2.0.3</oracle.version>
     <p6spy.version>1.3-patched</p6spy.version>
-    <rice.version>ua-release8-SNAPSHOT</rice.version>
+    <rice.version>ua-release9-SNAPSHOT</rice.version>
     <servlet-api.version>2.5</servlet-api.version>
     <velocity.version>1.5</velocity.version>
     <wss4j.version>1.6.18</wss4j.version>


### PR DESCRIPTION
Removing dead spring wiring that will interfere with the Rice PR under the same name. It appears this wiring was dropped into place from v3, but the blocks I removed were not even backed by existing classes. In fact, I wonder if this file is not being used at all, since in it's old state, should have been failing DD validation (perhaps this is a runtime check in this instance?).

Note: This PR has an analogous Rice change under the same name too, and should be released together.