### PR TITLE
UAF-4490 BUG - PCard Auto-Approved for $0 by Reversing Accounting Line Entries; PCDO Total Does Not Have To Balance To Accounting Entries

### DIFF
--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/ProcurementCardDocument.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/datadictionary/ProcurementCardDocument.xml
@@ -31,7 +31,7 @@
   <bean id="ProcurementCardDocument-validations" parent="ProcurementCardDocument-validations-parentBean"/>
   <bean id="ProcurementCardDocument-validations-parentBean" class="org.springframework.beans.factory.config.MapFactoryBean">
   	<property name="sourceMap">
-		<map>
+		<map key-type="java.lang.Class">
 		    <entry>
 				<key><value>org.kuali.kfs.sys.document.validation.event.AttributedSaveDocumentEvent</value></key>
 				<value>ProcurementCard-saveDocumentValidation</value>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/validation/configuration/ProcurementCardValidation.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/validation/configuration/ProcurementCardValidation.xml
@@ -51,4 +51,21 @@
     </property>
   </bean>
 
+  <bean id="ProcurementCard-saveDocumentValidation" parent="ProcurementCard-saveDocumentValidation-parentBean" scope="prototype">
+    <property name="validations">
+      <list>
+        <bean parent="ProcurementCard-balanceValidation" scope="prototype">
+          <property name="parameterProperties">
+            <list>
+              <bean parent="validationFieldConversion">
+                <property name="sourceEventProperty" value="document" />
+                <property name="targetValidationProperty" value="accountingDocumentForValidation" />
+              </bean>
+            </list>
+          </property>
+        </bean>
+      </list>
+    </property>
+  </bean>
+  
 </beans>


### PR DESCRIPTION
File(s) modified
1. ProcurementCardDocument.xml -- added key-type="java.lang.Class" to the map tag on line 34 so spring would read the key/values and work with them.
2. ProcurementCardValidation.xml -- overrode ProcurementCard-saveDocumentValidation bean so this will make reference to the ProcurementCard-balanceValidation bean.