### PR TITLE
UAF-1169 Bug-System Generated Notes not added when new vendor created

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/vnd/document/VendorMaintainableImpl.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/vnd/document/VendorMaintainableImpl.java
@@ -1,0 +1,51 @@
+package edu.arizona.kfs.vnd.document;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.kfs.vnd.VendorConstants;
+import org.kuali.rice.kns.document.MaintenanceDocument;
+import org.kuali.rice.krad.bo.Note;
+import org.kuali.rice.krad.service.NoteService;
+
+@SuppressWarnings("deprecation")
+public class VendorMaintainableImpl extends org.kuali.kfs.vnd.document.VendorMaintainableImpl {
+    private static final long serialVersionUID = 4691307271066839354L;
+
+    private NoteService noteService;
+
+    public NoteService getNoteService() {
+        if (noteService == null) {
+            noteService = SpringContext.getBean(NoteService.class);
+        }
+        return noteService;
+    }
+
+    @Override
+    public void setGenerateDefaultValues(String docTypeName) {
+        String objectId = getBusinessObject().getObjectId();
+        if (objectId == null) {
+            UUID objectUUID = UUID.randomUUID();
+            objectId = objectUUID.toString();
+            getBusinessObject().setObjectId(objectId);
+            Note newBoNote = getNewBoNoteForAdding(VendorConstants.VendorCreateAndUpdateNotePrefixes.ADD);
+            getNoteService().save(newBoNote);
+        }
+
+        super.setGenerateDefaultValues(docTypeName);
+    }
+
+    @Override
+    public void processAfterNew(MaintenanceDocument document, Map<String, String[]> requestParameters) {
+        super.processAfterNew(document, requestParameters);
+        List<Note> notes = new ArrayList<Note>();
+        if (getBusinessObject().getObjectId() != null) {
+            notes = getNoteService().getByRemoteObjectId(getBusinessObject().getObjectId());
+        }
+        document.setNotes(notes);
+    }
+
+}

--- a/kfs-core/src/main/resources/edu/arizona/kfs/vnd/document/datadictionary/VendorMaintenanceDocument.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/vnd/document/datadictionary/VendorMaintenanceDocument.xml
@@ -19,6 +19,7 @@
  -->
 
   <bean id="VendorMaintenanceDocument" parent="VendorMaintenanceDocument-parentBean">
+    <property name="maintainableClass" value="edu.arizona.kfs.vnd.document.VendorMaintainableImpl"/>
     <property name="businessRulesClass" value="edu.arizona.kfs.vnd.document.validation.impl.VendorRule"/>
     <property name="maintainableSections">
         <list merge="true">


### PR DESCRIPTION
What is happening is that when a new PersistableBusinessObject is created, it does not have a universally unique object Id until after the maintenance document is approved and finalized. In most cases, this does not cause problems because the BO is not usable until it's been persisted. This was a change that occurred between Rice 1 and Rice 2 to leverage code within the Persistence framework. Unfortunately, the NoteService makes use of that objectId when saving a note to the system for BOs, so a UUID needs to be generated and saved to the object being created by the maintenance document.

From PersistableBusinessObject.java:

> The object id represents a globally unique identifier for the business object.  In practice, this can be used by other portions of the system to link to persistable business objects which might be stored in different locations or even different persistent data stores.  In general, it is not the responsibility of the client who implements a persistable business object to handle generating this value.  **The framework will handle this automatically at the point in time when the business object is persisted.**  If the client does need to do this themselves, however, care should be taken that an appropriate globally unique value generator algorithm is used (such as the one provided by UUID).

Special Note: This technique will be needed to be performed for any other BOs that require the Notes and Attachments section to contain an Add note when creating new objects via a maintenance document (such as Asset, Customer, and etc.)