### PR TITLE
UAF-3893 BUG - Job Logs Generated in UAF 6.0 are missing Date / Time …

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/sys/batch/JobListener.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/sys/batch/JobListener.java
@@ -1,0 +1,50 @@
+package edu.arizona.kfs.sys.batch;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Calendar;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.log4j.Appender;
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.FileAppender;
+import org.apache.log4j.Logger;
+import org.apache.log4j.NDC;
+import org.apache.log4j.PatternLayout;
+import org.kuali.kfs.sys.batch.BatchSpringContext;
+import org.kuali.kfs.sys.batch.Job;
+import org.kuali.kfs.sys.context.NDCFilter;
+import org.quartz.JobExecutionContext;
+
+import edu.arizona.kfs.sys.KFSParameterKeyConstants;
+
+public class JobListener extends org.kuali.kfs.sys.batch.JobListener {
+    private static final Logger LOG = Logger.getLogger(JobListener.class);
+    private static final String STD_OUT = "StdOut";
+    private static final String PATTERN = "%d [%t] %p %c %x - %m%n";
+    
+    @Override
+    protected void initializeLogging(JobExecutionContext jobExecutionContext) {
+        try {
+            if(Logger.getRootLogger().getAppender(STD_OUT) == null) {
+                Appender appender = new ConsoleAppender(new PatternLayout(PATTERN));
+                appender.setName(STD_OUT);
+                Logger.getRootLogger().addAppender(appender);
+            }
+            Calendar startTimeCalendar = dateTimeService.getCurrentCalendar();
+            StringBuilder nestedDiagnosticContext = new StringBuilder(StringUtils.substringAfter(BatchSpringContext.getJobDescriptor(jobExecutionContext.getJobDetail().getName()).getNamespaceCode(), KFSParameterKeyConstants.HYPHEN).toLowerCase());
+            nestedDiagnosticContext.append(File.separator);
+            nestedDiagnosticContext.append(jobExecutionContext.getJobDetail().getName());
+            nestedDiagnosticContext.append(KFSParameterKeyConstants.HYPHEN);
+            nestedDiagnosticContext.append(dateTimeService.toDateTimeStringForFilename(dateTimeService.getCurrentDate()));
+            
+            ((Job) jobExecutionContext.getJobInstance()).setNdcAppender(new FileAppender(Logger.getRootLogger().getAppender(STD_OUT).getLayout(), getLogFileName(nestedDiagnosticContext.toString())));
+            ((Job) jobExecutionContext.getJobInstance()).getNdcAppender().addFilter(new NDCFilter(nestedDiagnosticContext.toString()));
+            Logger.getRootLogger().addAppender(((Job) jobExecutionContext.getJobInstance()).getNdcAppender());
+            NDC.push(nestedDiagnosticContext.toString());
+        }
+        catch (IOException e) {
+            LOG.warn("Could not initialize special custom logging for job: " + jobExecutionContext.getJobDetail().getName(), e);
+        }
+    }
+}

--- a/kfs-core/src/main/resources/edu/arizona/kfs/sys/spring-sys.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/sys/spring-sys.xml
@@ -180,5 +180,8 @@
 			<ref bean="lookupDao" />
 		</property>
 	</bean>
+	
+	<bean id="jobListener" parent="jobListener-parentBean" class="edu.arizona.kfs.sys.batch.JobListener">
+    </bean>
     
 </beans>


### PR DESCRIPTION
…Stamp

Added new file JobListener.java to override the initializeLogging method to use the correct pattern for logging. It's the same pattern used in the parent class (PatternLayout.TTCC_CONVERSION_PATTERN) except %r (number of milliseconds elapsed from the construction of the layout until the creation of the logging event. This is the 'generic number' described in the description of the JIRA ticket) is replaced with %d (the date of the logging event). For more information on patterns see the API for org.apache.log4j.PatternLayout.java.
Modified spring-sys.xml to point to the new JobListener class.