### PR TITLE
UAF-57 UAF-4446 Non-Check Non-ACH Payments Step 12 (Direct CMNC to CAB AP & Process from CAB to CAM)

### DIFF
--- a/kfs-cam/src/main/java/edu/arizona/kfs/module/cab/CabConstants.java
+++ b/kfs-cam/src/main/java/edu/arizona/kfs/module/cab/CabConstants.java
@@ -2,4 +2,5 @@ package edu.arizona.kfs.module.cab;
 
 public class CabConstants extends org.kuali.kfs.module.cab.CabConstants {
 	public static final String PRNC = "PRNC";
+	public static final String CMNC = "CMNC";
 }

--- a/kfs-cam/src/main/java/edu/arizona/kfs/module/cab/businessobject/PurchasingAccountsPayableDocument.java
+++ b/kfs-cam/src/main/java/edu/arizona/kfs/module/cab/businessobject/PurchasingAccountsPayableDocument.java
@@ -4,14 +4,18 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
-import edu.arizona.kfs.module.cab.CabConstants;
 import org.kuali.kfs.module.cab.CabPropertyConstants;
-import org.kuali.rice.krad.service.BusinessObjectService;
-import edu.arizona.kfs.module.purap.document.PaymentRequestDocument;
-import edu.arizona.kfs.module.purap.document.VendorCreditMemoDocument;
 import org.kuali.kfs.sys.context.SpringContext;
+import org.kuali.kfs.sys.service.impl.KfsParameterConstants;
+import org.kuali.rice.coreservice.framework.parameter.ParameterConstants.NAMESPACE;
+import org.kuali.rice.krad.service.BusinessObjectService;
 import org.kuali.rice.krad.util.ObjectUtils;
 
+import edu.arizona.kfs.module.cab.CabConstants;
+import edu.arizona.kfs.module.purap.document.PaymentRequestDocument;
+import edu.arizona.kfs.module.purap.document.VendorCreditMemoDocument;
+
+@NAMESPACE(namespace = KfsParameterConstants.PURCHASING_NAMESPACE)
 public class PurchasingAccountsPayableDocument extends org.kuali.kfs.module.cab.businessobject.PurchasingAccountsPayableDocument {
 	
     @Override

--- a/kfs-cam/src/main/java/edu/arizona/kfs/module/cab/businessobject/lookup/GeneralLedgerEntryLookupableHelperServiceImpl.java
+++ b/kfs-cam/src/main/java/edu/arizona/kfs/module/cab/businessobject/lookup/GeneralLedgerEntryLookupableHelperServiceImpl.java
@@ -30,21 +30,19 @@ public class GeneralLedgerEntryLookupableHelperServiceImpl extends org.kuali.kfs
         List<GeneralLedgerEntry> newList = new ArrayList<GeneralLedgerEntry>();
         for (BusinessObject businessObject : searchResults) {
             GeneralLedgerEntry entry = (GeneralLedgerEntry) businessObject;
-            if (!CabConstants.PREQ.equals(entry.getFinancialDocumentTypeCode())) {
-            	if (!CabConstants.PRNC.equals(entry.getFinancialDocumentTypeCode())) {
-	                if (!CabConstants.CM.equals(entry.getFinancialDocumentTypeCode())) {
-	                    newList.add(entry);
-	                }
-	                else if (CabConstants.CM.equals(entry.getFinancialDocumentTypeCode())) {
-	                    Map<String, String> cmKeys = new HashMap<String, String>();
-	                    cmKeys.put(CabPropertyConstants.PurchasingAccountsPayableDocument.DOCUMENT_NUMBER, entry.getDocumentNumber());
-	                    // check if CAB PO document exists, if not included
-	                    Collection<PurchasingAccountsPayableDocument> matchingCreditMemos = getBusinessObjectService().findMatching(PurchasingAccountsPayableDocument.class, cmKeys);
-	                    if (matchingCreditMemos == null || matchingCreditMemos.isEmpty()) {
-	                        newList.add(entry);
-	                    }
-	                }
-	            }
+            if (CabConstants.CM.equals(entry.getFinancialDocumentTypeCode()) || CabConstants.CMNC.equals(entry.getFinancialDocumentTypeCode())) {
+                Map<String, String> cmKeys = new HashMap<String, String>();
+                cmKeys.put(CabPropertyConstants.PurchasingAccountsPayableDocument.DOCUMENT_NUMBER, entry.getDocumentNumber());
+                // check if CAB PO document exists, if not included
+                Collection<PurchasingAccountsPayableDocument> matchingCreditMemos = getBusinessObjectService().findMatching(PurchasingAccountsPayableDocument.class, cmKeys);
+                if (matchingCreditMemos == null || matchingCreditMemos.isEmpty()) {
+                    newList.add(entry);
+                }
+            }
+            else if (!CabConstants.PREQ.equals(entry.getFinancialDocumentTypeCode())) {
+                if (!CabConstants.PRNC.equals(entry.getFinancialDocumentTypeCode())) {
+                    newList.add(entry);
+                }
             }
         }
         matchingResultsCount = Long.valueOf(newList.size());

--- a/kfs-cam/src/main/java/edu/arizona/kfs/module/cab/dataaccess/impl/PurchasingAccountsPayableReportDaoOjb.java
+++ b/kfs-cam/src/main/java/edu/arizona/kfs/module/cab/dataaccess/impl/PurchasingAccountsPayableReportDaoOjb.java
@@ -19,7 +19,8 @@ public class PurchasingAccountsPayableReportDaoOjb extends org.kuali.kfs.module.
             if (StringUtils.isEmpty(fieldValue)) {
                 docTypeCodes.add(CabConstants.PREQ);
                 docTypeCodes.add(CabConstants.CM);
-                docTypeCodes.add(CabConstants.PRNC); 
+                docTypeCodes.add(CabConstants.PRNC);
+                docTypeCodes.add(CabConstants.CMNC);
             }
             else {
                 docTypeCodes.add(fieldValue);

--- a/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/service/impl/AssetLockServiceImpl.java
+++ b/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/service/impl/AssetLockServiceImpl.java
@@ -6,6 +6,6 @@ public class AssetLockServiceImpl extends org.kuali.kfs.module.cam.service.impl.
 	
 	@Override
 	protected boolean isPurApDocument(String documentTypeName) {
-		return super.isPurApDocument(documentTypeName) || CabConstants.PRNC.equals(documentTypeName);
+		return super.isPurApDocument(documentTypeName) || CabConstants.PRNC.equals(documentTypeName) || CabConstants.CMNC.equals(documentTypeName);
     }
 }


### PR DESCRIPTION
File(s) modified
1. CabConstants.java - added a constant for CMNC. This constant will be used by BatchExtractServiceImpl.java
2. BatchExtractServiceImpl.java -
	* modified separatePOLines() to check if the FinancialDocumentTypeCode was CMNC.
	* added findCmncDocument() to get a CMNC document entry
	* modified createPurchasingAccountsPayableDocument() so it could be able to find and use a CMNC document. This way a CMNC document will be able to be found on the CAB AP lookup
	* overrode method createPurchasingAccountsPayableLineAssetAccount() so CMNC lines could be negated when added to the purap account line table
3. PurchasingAccountsPayableDocument.java -- added the following on line 18 @NAMESPACE(namespace =KfsParameterConstants.PURCHASING_NAMESPACE) per Scott's request on UAF-3244. This will stop an error message from showing up on the building logs.
4. GeneralLedgerEntryLookupableHelperServiceImpl.java -- modified getSearchResults() so new CMNC docs would not be displayed on the CAB GL look up. But those created/processed before these changes will still show on the lookup. 
5. PurchasingAccountsPayableReportDaoOjb.java -- modified getDocumentType() so the CMNC docs will be displayed on the CAB AP look up.