### PR TITLE
UAF-1197 BUG-Capital Asset Errors Message Presented in Wrong Tab

### DIFF
--- a/kfs-cam/src/main/java/edu/arizona/kfs/module/cab/service/impl/CapitalAssetBuilderModuleServiceImpl.java
+++ b/kfs-cam/src/main/java/edu/arizona/kfs/module/cab/service/impl/CapitalAssetBuilderModuleServiceImpl.java
@@ -23,6 +23,9 @@ public class CapitalAssetBuilderModuleServiceImpl extends org.kuali.kfs.module.c
 
     @Override
     protected boolean validateUpdateCapitalAssetField(CapitalAssetInformation capitalAssetInformation, AccountingDocument accountingDocument, int index) {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Beginning method validateUpdateCapitalAssetField");
+        }
         boolean valid = true;
 
         Map<String, String> params = new HashMap<String, String>();
@@ -38,14 +41,17 @@ public class CapitalAssetBuilderModuleServiceImpl extends org.kuali.kfs.module.c
         errors.removeFromErrorPath(KFSPropertyConstants.DOCUMENT);
 
         String errorPathPrefix = KFSPropertyConstants.DOCUMENT + "." + KFSPropertyConstants.CAPITAL_ASSET_INFORMATION + "[" + index + "]." + KFSPropertyConstants.CAPITAL_ASSET_NUMBER;
+        String errorPathModifyTab = KFSPropertyConstants.DOCUMENT + "." + KFSPropertyConstants.CAPITAL_ASSET_MODIFY_INFORMATION;
         if (ObjectUtils.isNull(asset)) {
             valid = false;
             String label = this.getDataDictionaryService().getAttributeLabel(CapitalAssetInformation.class, KFSPropertyConstants.CAPITAL_ASSET_NUMBER);
             GlobalVariables.getMessageMap().putErrorWithoutFullErrorPath(errorPathPrefix, KFSKeyConstants.ERROR_EXISTENCE, label);
+            GlobalVariables.getMessageMap().putErrorWithoutFullErrorPath(errorPathModifyTab, KFSKeyConstants.ERROR_EXISTENCE, label);
         } else if (!(this.getAssetService().isCapitalAsset(asset) && !this.getAssetService().isAssetRetired(asset))) {
             // check asset status must be capital asset active.
             valid = false;
             GlobalVariables.getMessageMap().putErrorWithoutFullErrorPath(errorPathPrefix, CabKeyConstants.CapitalAssetInformation.ERROR_ASSET_ACTIVE_CAPITAL_ASSET_REQUIRED);
+            GlobalVariables.getMessageMap().putErrorWithoutFullErrorPath(errorPathModifyTab, CabKeyConstants.CapitalAssetInformation.ERROR_ASSET_ACTIVE_CAPITAL_ASSET_REQUIRED);
         } else {
             String documentNumber = accountingDocument.getDocumentNumber();
             String documentType = getDocumentTypeName(accountingDocument);

--- a/kfs-cam/src/main/java/edu/arizona/kfs/module/cab/service/impl/CapitalAssetBuilderModuleServiceImpl.java
+++ b/kfs-cam/src/main/java/edu/arizona/kfs/module/cab/service/impl/CapitalAssetBuilderModuleServiceImpl.java
@@ -1,0 +1,60 @@
+package edu.arizona.kfs.module.cab.service.impl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.log4j.Logger;
+import org.kuali.kfs.fp.businessobject.CapitalAssetInformation;
+import org.kuali.kfs.integration.cab.CapitalAssetBuilderModuleService;
+import org.kuali.kfs.module.cab.CabKeyConstants;
+import org.kuali.kfs.module.cam.businessobject.Asset;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.KFSKeyConstants;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.kfs.sys.document.AccountingDocument;
+import org.kuali.rice.krad.util.GlobalVariables;
+import org.kuali.rice.krad.util.MessageMap;
+import org.kuali.rice.krad.util.ObjectUtils;
+
+public class CapitalAssetBuilderModuleServiceImpl extends org.kuali.kfs.module.cab.service.impl.CapitalAssetBuilderModuleServiceImpl {
+    private static final Logger LOG = Logger.getLogger(CapitalAssetBuilderModuleService.class);
+
+    @Override
+    protected boolean validateUpdateCapitalAssetField(CapitalAssetInformation capitalAssetInformation, AccountingDocument accountingDocument, int index) {
+        boolean valid = true;
+
+        Map<String, String> params = new HashMap<String, String>();
+        params.put(KFSPropertyConstants.CAPITAL_ASSET_NUMBER, capitalAssetInformation.getCapitalAssetNumber().toString());
+        Asset asset = businessObjectService.findByPrimaryKey(Asset.class, params);
+
+        List<Long> assetNumbers = new ArrayList<Long>();
+        assetNumbers.add(capitalAssetInformation.getCapitalAssetNumber());
+
+        MessageMap errors = GlobalVariables.getMessageMap();
+        errors.removeFromErrorPath(KFSPropertyConstants.CAPITAL_ASSET_INFORMATION + "[" + index + "].");
+        errors.removeFromErrorPath(capitalAssetInformation.getCapitalAssetActionIndicator().equalsIgnoreCase(KFSConstants.CapitalAssets.CAPITAL_ASSET_CREATE_ACTION_INDICATOR) ? KFSPropertyConstants.CAPITAL_ASSET_INFORMATION : KFSPropertyConstants.CAPITAL_ASSET_MODIFY_INFORMATION);
+        errors.removeFromErrorPath(KFSPropertyConstants.DOCUMENT);
+
+        String errorPathPrefix = KFSPropertyConstants.DOCUMENT + "." + KFSPropertyConstants.CAPITAL_ASSET_INFORMATION + "[" + index + "]." + KFSPropertyConstants.CAPITAL_ASSET_NUMBER;
+        if (ObjectUtils.isNull(asset)) {
+            valid = false;
+            String label = this.getDataDictionaryService().getAttributeLabel(CapitalAssetInformation.class, KFSPropertyConstants.CAPITAL_ASSET_NUMBER);
+            GlobalVariables.getMessageMap().putErrorWithoutFullErrorPath(errorPathPrefix, KFSKeyConstants.ERROR_EXISTENCE, label);
+        } else if (!(this.getAssetService().isCapitalAsset(asset) && !this.getAssetService().isAssetRetired(asset))) {
+            // check asset status must be capital asset active.
+            valid = false;
+            GlobalVariables.getMessageMap().putErrorWithoutFullErrorPath(errorPathPrefix, CabKeyConstants.CapitalAssetInformation.ERROR_ASSET_ACTIVE_CAPITAL_ASSET_REQUIRED);
+        } else {
+            String documentNumber = accountingDocument.getDocumentNumber();
+            String documentType = getDocumentTypeName(accountingDocument);
+
+            if (getCapitalAssetManagementModuleService().isFpDocumentEligibleForAssetLock(accountingDocument, documentType) && getCapitalAssetManagementModuleService().isAssetLocked(assetNumbers, documentType, documentNumber)) {
+                valid = false;
+            }
+        }
+
+        return valid;
+    }
+}

--- a/kfs-cam/src/main/resources/edu/arizona/kfs/module/cab/spring-cab.xml
+++ b/kfs-cam/src/main/resources/edu/arizona/kfs/module/cab/spring-cab.xml
@@ -88,4 +88,6 @@
 	<bean id="purApReportLookupableHelperService" scope="prototype" parent="purApReportLookupableHelperService-parentBean" class="edu.arizona.kfs.module.cab.businessobject.lookup.PurApReportLookupableHelperServiceImpl">
 	</bean>
 	
+    <bean id="capitalAssetBuilderModuleService"  parent="capitalAssetBuilderModuleService-parentBean" class="edu.arizona.kfs.module.cab.service.impl.CapitalAssetBuilderModuleServiceImpl" />
+
 </beans>


### PR DESCRIPTION
These errors are being caused by the Create Capital Asset and Modify Capital Asset tabs utilizing the same set of data, with the error path for this particular field being identified as "document.capitalAssetInformation[index].capitalAssetNumber". The error message could be attached to the Modify Capital Asset tab instead of the Create Capital Asset tab, but that causes the red (-) to disappear from the field causing the problem. A significant amount of refactoring would be needed to use the error path "document.capitalAssetModify[index].capitalAssetNumber" (or something similarly appropriate). It was decided by Matt and Ada to leave the existing messages so the (-) would show on the field and add a message to the Modify Capital Asset tab.

This pull request was left as 2 commits intentionally.
The first commit contains the validateUpdateCapitalAssetField(CapitalAssetInformation, AccountingDocument, int), copied from KFS6 org.kuali CapitalAssetBuilderModuleServiceImpl to the edu.arizona child object. This was done so the changes to the method could be easily recognized.

The second commit contains the changes to the method.

That being said, if the reviewer would prefer to have this squashed into a single commit, that can be done.
