### PR TITLE
UAF-4750 BUG-Stack trace error received when initiating a Credit Memo against a Purchase Order

### DIFF
--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/validation/impl/VendorCreditMemoInitTabPaymentRequestApprovedValidation.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/validation/impl/VendorCreditMemoInitTabPaymentRequestApprovedValidation.java
@@ -15,6 +15,10 @@ public class VendorCreditMemoInitTabPaymentRequestApprovedValidation extends Gen
         if (event.getDocument() instanceof VendorCreditMemoDocument) {
             VendorCreditMemoDocument cmDocument = (VendorCreditMemoDocument) event.getDocument();
             PaymentRequestDocument preq = (PaymentRequestDocument) cmDocument.getPaymentRequestDocument();
+            if (preq == null) {
+                // the Payment Request # option on the Credit Memo initiation screen wasn't used.
+                return true;
+            }
             boolean isApproved = preq.getDocumentHeader().getWorkflowDocument().isApproved();
             if (!isApproved) {
                 GlobalVariables.getMessageMap().putErrorWithoutFullErrorPath(PurapPropertyConstants.PAYMENT_REQUEST_ID, PurapKeyConstants.ERROR_CREDIT_MEMO_PAYMENT_REQEUEST_INVALID_DOCUMENT_STATUS, cmDocument.getPaymentRequestIdentifier().toString());


### PR DESCRIPTION
When initiating a Credit Memo with a Purchase Order #, the Payment Request # is null. When this happens, there is no Payment Request Document that is attached to the Credit Memo, and so this validation should pass. This will ignore whether there are Payment Requests that are not approved and related to the PO on purpose, because that is how it works in the UA implementation of KFS3.