### PR TITLE
UAF-1136 Bug - POA - Capital - Changing the Capital Asset System Type…

### DIFF
--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/web/struts/PurchaseOrderForm.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/web/struts/PurchaseOrderForm.java
@@ -1,0 +1,14 @@
+package edu.arizona.kfs.module.purap.document.web.struts;
+
+import org.kuali.kfs.integration.purap.CapitalAssetLocation;
+import org.kuali.kfs.module.purap.businessobject.PurchaseOrderCapitalAssetLocation;
+
+public class PurchaseOrderForm extends org.kuali.kfs.module.purap.document.web.struts.PurchaseOrderForm {
+
+    @Override
+    public CapitalAssetLocation setupNewPurchasingCapitalAssetLocationLine() {
+        CapitalAssetLocation location = new PurchaseOrderCapitalAssetLocation();
+        return location;
+    }
+
+}

--- a/kfs-web/src/main/webapp/WEB-INF/struts-config.xml
+++ b/kfs-web/src/main/webapp/WEB-INF/struts-config.xml
@@ -238,7 +238,7 @@
 		<form-bean name="RequisitionForm"
 			type="org.kuali.kfs.module.purap.document.web.struts.RequisitionForm" />
 		<form-bean name="PurchaseOrderForm"
-			type="org.kuali.kfs.module.purap.document.web.struts.PurchaseOrderForm" />
+			type="edu.arizona.kfs.module.purap.document.web.struts.PurchaseOrderForm" />
 		<form-bean name="PaymentRequestForm"
 			type="edu.arizona.kfs.module.purap.document.web.struts.PaymentRequestForm" />
 		<form-bean name="VendorCreditMemoForm"


### PR DESCRIPTION
… on a PO Amendment and submitting is returning a stack trace

Added new file PurchaseOrderForm.java to override the setupNewPurchasingCapitalAssetLocationLine method. This will save to PUR_PO_CPTL_AST_LOC_T instead of PUR_REQS_CPTL_AST_LOC_T on submit which will prevent the 'integrity constraint violated - parent key not found' error & subsequent stack trace.
Modified struts-config.xml to point to the new PurchaseOrderForm file.