### PR TITLE
UAF-1081 Bug-Error Removing Asset Representative

### DIFF
--- a/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/document/validation/impl/AssetRule.java
+++ b/kfs-cam/src/main/java/edu/arizona/kfs/module/cam/document/validation/impl/AssetRule.java
@@ -146,4 +146,48 @@ public class AssetRule extends org.kuali.kfs.module.cam.document.validation.impl
 		
 		return valid;
 	}
+	
+	@Override
+    protected boolean processAssetValidation(MaintenanceDocument document) {
+        boolean valid = true;
+
+        // validate Inventory Status Code.
+        if (!StringUtils.equalsIgnoreCase(oldAsset.getInventoryStatusCode(), newAsset.getInventoryStatusCode())) {
+            valid &= validateInventoryStatusCode(oldAsset.getInventoryStatusCode(), newAsset.getInventoryStatusCode());
+        }
+
+        // validate Organization Owner Account Number
+        if (!StringUtils.equalsIgnoreCase(oldAsset.getOrganizationOwnerAccountNumber(), newAsset.getOrganizationOwnerAccountNumber())) {
+            valid &= validateAccount();
+        }
+
+        // validate asset representative name
+        if (ObjectUtils.isNotNull(oldAsset.getAssetRepresentative())
+                && ObjectUtils.isNotNull(newAsset.getAssetRepresentative())
+                && StringUtils.isNotBlank(oldAsset.getAssetRepresentative().getPrincipalName())
+                && StringUtils.isNotBlank(newAsset.getAssetRepresentative().getPrincipalName())
+                && !StringUtils.equalsIgnoreCase(oldAsset.getAssetRepresentative().getPrincipalName(), newAsset.getAssetRepresentative().getPrincipalName())) {
+            valid &= validateAssetRepresentative();
+        }
+
+
+        // validate Vendor Name.
+        if (!StringUtils.equalsIgnoreCase(oldAsset.getVendorName(), newAsset.getVendorName())) {
+            valid &= validateVendorName();
+        }
+
+        // validate Tag Number.
+        if (!StringUtils.equalsIgnoreCase(oldAsset.getCampusTagNumber(), newAsset.getCampusTagNumber())) {
+            valid &= validateTagNumber();
+        }
+
+        // validate location.
+        valid &= validateLocation();
+
+        // validate In-service Date
+        if (assetService.isInServiceDateChanged(oldAsset, newAsset)) {
+            valid &= validateInServiceDate();
+        }
+        return valid;
+    }
 }


### PR DESCRIPTION
Modified AssetRule.java to override the processAssetValidation method, specifically the validate asset representative name part. Added a null check on getAssetRepresentative for oldAsset and newAsset to prevent the first stack trace. Also added a null check on newAsset.getAssetRepresentative().getPrincipalName() to prevent the second stack trace. For the second STE, the newAsset.getAssetRepresentative() object is not null, but the principalName is, which causes an error when the code eventually calls getPersonByPrincipalName.