### PR TITLE
UAF-4211: Adding fixes for the Bank Of America records

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/dataaccess/impl/BankTransactionDigesterAdapter.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/dataaccess/impl/BankTransactionDigesterAdapter.java
@@ -128,14 +128,14 @@ public class BankTransactionDigesterAdapter {
                 BofaCcRecordChecker bofaRecordChecker = new BofaCcRecordChecker(bankTransactionVO.getAccountNumber(), bankTransactionVO.getBaiType(), custRefNum, bankTransactionVO.getDescriptiveTxt6());
                 if (bofaRecordChecker.isBofaCreditCardRecord()) {
                     custRefNum = bofaRecordChecker.getCustRefNum();
-                    if (StringUtils.isNotEmpty(custRefNum)) {
+                    if (StringUtils.isEmpty(custRefNum)) {
                         //something went wrong with the identification of BofA customer reference number
                         errorList.add("ERROR: Could not parse Bank of America Customer Reference Number :" + bankTransactionVO.toString());
                         return null;
                     }
                 }
 
-                // All CustRefNumbers must be ten digits EXACTLY - if longer, truncate to first ten digits which is all that KFS needs
+                // All CustRefNumbers must be ten digits EXACTLY - if longer, truncate to last ten digits which is all that KFS needs
                 if (custRefNum.length() > 10) {
                     custRefNum = custRefNum.substring(custRefNum.length() - 10);
                 } else if (custRefNum.length() != 10) {

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/impl/BankParametersAccessServiceImpl.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/impl/BankParametersAccessServiceImpl.java
@@ -633,7 +633,7 @@ public class BankParametersAccessServiceImpl implements BankParametersAccessServ
      */
     public String getBofaNotesIndicator() {
         if (bofaNotesIndicator == null) {
-            bofaNotesRegexFormat = parameterService.getParameterValueAsString(DocumentCreationStep.class, KFSConstants.BankTransactionsParameters.BOFA_NOTES_INDICATOR);
+            bofaNotesIndicator = parameterService.getParameterValueAsString(DocumentCreationStep.class, KFSConstants.BankTransactionsParameters.BOFA_NOTES_INDICATOR);
         }
         return bofaNotesIndicator;
     }


### PR DESCRIPTION
Fixing issues with the regex expression matching BofA records to the notes field.