### PR TITLE
UAF-1180 Bug - Invalid Ad Hoc Routing Person Network Id error when ad…

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/service/impl/DisbursementVoucherPayeeServiceImpl.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/service/impl/DisbursementVoucherPayeeServiceImpl.java
@@ -1,0 +1,32 @@
+package edu.arizona.kfs.fp.document.service.impl;
+
+import java.util.List;
+import java.util.Set;
+
+import org.kuali.kfs.fp.document.DisbursementVoucherDocument;
+import org.kuali.rice.krad.bo.AdHocRoutePerson;
+import org.kuali.rice.kew.api.KewApiConstants;
+import org.kuali.rice.kim.api.identity.Person;
+import org.kuali.rice.kim.api.services.KimApiServiceLocator;
+import org.kuali.kfs.sys.document.authorization.FinancialSystemTransactionalDocumentAuthorizerBase;
+
+public class DisbursementVoucherPayeeServiceImpl extends org.kuali.kfs.fp.document.service.impl.DisbursementVoucherPayeeServiceImpl {
+    
+    @Override
+    protected void setupFYIs(DisbursementVoucherDocument dvDoc, Set<Person> priorApprovers, String initiatorUserId) {
+        List<AdHocRoutePerson> adHocRoutePersons = dvDoc.getAdHocRoutePersons();
+        final FinancialSystemTransactionalDocumentAuthorizerBase documentAuthorizer = getDocumentAuthorizer(dvDoc);
+
+        // Add FYI for each approver who has already approved the document
+        for (Person approver : priorApprovers) {
+            if (documentAuthorizer.canReceiveAdHoc(dvDoc, approver, KewApiConstants.ACTION_REQUEST_FYI_REQ)) {
+                String approverPersonUserId = approver.getPrincipalName();
+                adHocRoutePersons.add(buildFyiRecipient(approverPersonUserId));
+            }
+        }
+
+        Person person = KimApiServiceLocator.getPersonService().getPerson(initiatorUserId);
+        // Add FYI for initiator
+        adHocRoutePersons.add(buildFyiRecipient(person.getPrincipalName()));
+    }
+}

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/spring-fp.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/spring-fp.xml
@@ -214,5 +214,8 @@
     </bean>
 
     <bean id="disbursementVoucherExtractionHelperService" parent="disbursementVoucherExtractionHelperService-parentBean" class="edu.arizona.kfs.fp.document.service.impl.DisbursementVoucherExtractionHelperServiceImpl" />
-
+    
+    <bean id="disbursementVoucherPayeeService"  parent="disbursementVoucherPayeeService-parentBean" class="edu.arizona.kfs.fp.document.service.impl.DisbursementVoucherPayeeServiceImpl">
+    </bean>
+    
 </beans>


### PR DESCRIPTION
…dress on DV changed by FO

Added new file DisbursementVoucherPayeeServiceImpl.java to override the setupFYIs method. Pass in the principal name instead of the principal id to buildFyiRecipient because that value is eventually passed into the getPersonByPrincipalName method (see AdHocRoutePerson.java, setId method), which was returning the wrong Person object.
Modified spring-fp.xml to point to the new DisbursementVoucherPayeeServiceImpl class.