### PR TITLE
UAF-4109 investigate PURAP / Asset Error 'catalog number must contain…

### DIFF
--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/service/impl/B2BShoppingServiceImpl.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/service/impl/B2BShoppingServiceImpl.java
@@ -1,0 +1,22 @@
+package edu.arizona.kfs.module.purap.document.service.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.module.purap.businessobject.B2BShoppingCartItem;
+import org.kuali.kfs.module.purap.businessobject.RequisitionItem;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+public class B2BShoppingServiceImpl extends org.kuali.kfs.module.purap.document.service.impl.B2BShoppingServiceImpl {
+
+    @Override
+    protected RequisitionItem createRequisitionItem(B2BShoppingCartItem item, Integer itemLine,
+    		String defaultCommodityCode) {
+    	RequisitionItem reqsItem = super.createRequisitionItem(item, itemLine, defaultCommodityCode);
+    	// rescan item description and trim any characters that will fail Rice anyCharacterValidation
+    	if (StringUtils.isNotBlank(reqsItem.getItemDescription())) {
+    		reqsItem.setItemDescription(reqsItem.getItemDescription().replaceAll("[^\\p{Graph}\\p{Space}]",""));
+    	}
+    	
+    	return reqsItem;
+    }
+}

--- a/kfs-purap/src/main/resources/edu/arizona/kfs/module/purap/spring-purap.xml
+++ b/kfs-purap/src/main/resources/edu/arizona/kfs/module/purap/spring-purap.xml
@@ -176,5 +176,7 @@
         <property name="personService" ref="personService" />
         <property name="workflowDocumentService" ref="workflowDocumentService"/>
     </bean>
+    
+    <bean id="b2BShoppingService" parent="b2BShoppingService-parentBean" class="edu.arizona.kfs.module.purap.document.service.impl.B2BShoppingServiceImpl" />
 
 </beans>


### PR DESCRIPTION
This is to fix item description field of REQS created through B2B interface with trimming off non-basic(7-bit) ASCII characters. Thus, special characters won't propagate to PO and block downstream PurAp processing. If no such special character, item description will be no changed.