### PR TITLE
UAF-4758 Bug - PCDO - Accounting Line Permissions Not Being Respected for Reconciler or Fiscal Officer

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/document/validation/impl/CapitalAccountingLinesAccessibleValidation.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/document/validation/impl/CapitalAccountingLinesAccessibleValidation.java
@@ -1,0 +1,59 @@
+package edu.arizona.kfs.fp.document.validation.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.kuali.kfs.fp.document.CapitalAccountingLinesDocumentBase;
+import org.kuali.kfs.fp.document.authorization.CapitalAccountingLinesAuthorizer;
+import org.kuali.kfs.fp.document.validation.impl.ProcurementCardAccountAccessibilityValidation;
+import org.kuali.kfs.integration.cab.CapitalAssetBuilderModuleService;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.kfs.sys.businessobject.FinancialSystemDocumentHeader;
+import org.kuali.kfs.sys.document.Correctable;
+import org.kuali.kfs.sys.document.validation.event.AttributedDocumentEvent;
+
+public class CapitalAccountingLinesAccessibleValidation extends ProcurementCardAccountAccessibilityValidation {
+	protected CapitalAssetBuilderModuleService capitalAssetBuilderModuleService;
+
+	/**
+	 * Due to code in CapitalAccountingLinesAuthorizerBase we need alter the
+	 * accessible logic a bit. Otherwise the user gets stopped for reasons they
+	 * shouldn't be
+	 * 
+	 * @see org.kuali.kfs.fp.document.authorization.CapitalAccountingLinesAuthorizerBase#determineEditPermissionOnField
+	 * @see org.kuali.kfs.sys.document.authorization.AccountingLineAuthorizerBase#determineEditPermissionOnField
+	 * @see org.kuali.kfs.sys.document.validation.impl.AccountingLineAccessibleValidation#validate(org.kuali.kfs.sys.document.validation.event.AttributedDocumentEvent)
+	 */
+	@Override
+	public boolean validate(AttributedDocumentEvent event) {
+		if (accountingDocumentForValidation instanceof CapitalAccountingLinesDocumentBase) {
+			CapitalAccountingLinesDocumentBase caldb = (CapitalAccountingLinesDocumentBase) accountingDocumentForValidation;
+
+			if (caldb.getCapitalAccountingLines().size() > 0 && capitalAssetBuilderModuleService.hasCapitalAssetObjectSubType(accountingLineForValidation)) {
+				// In this scenario the line is readOnly because of the logic in CapitalAccountingLinesAuthorizerBase. We only stop the user from updating
+				// if the document shouldn't be editable. That means call AccountingLineAuthorizerBase#determineEditPermissionOnField and skip
+				// CapitalAccountingLinesAuthorizerBase#determineEditPermissionOnField. Furthermore error correction documents should not be stopped
+				if (accountingDocumentForValidation instanceof Correctable) {
+					final String errorDocumentNumber = ((FinancialSystemDocumentHeader) accountingDocumentForValidation.getDocumentHeader()).getFinancialDocumentInErrorNumber();
+					if (StringUtils.isNotBlank(errorDocumentNumber)) {
+						return true;
+					}
+				}
+
+				// we can safely cast the lookup result to CapitalAccountingLinesAuthorizer, because even if the security module is turned on so that the returned result is CapitalAccountingLinesAuthorizer, it's
+				// still fine since the latter implements CapitalAccountingLinesAuthorizer
+				final CapitalAccountingLinesAuthorizer capitalAccountingLineAuthorizer = (CapitalAccountingLinesAuthorizer) lookupAccountingLineAuthorizer();
+				return capitalAccountingLineAuthorizer.determineEditPermissionOnFieldBypassCapitalCheck(accountingDocumentForValidation, accountingLineForValidation, getAccountingLineCollectionProperty(), KFSPropertyConstants.ACCOUNT_NUMBER, true);
+			}
+		}
+
+		return super.validate(event);
+	}
+
+	/**
+	 * Set the capitalAssetBuilderModuleService
+	 * 
+	 * @param capitalAssetBuilderModuleService
+	 */
+	public void setCapitalAssetBuilderModuleService(CapitalAssetBuilderModuleService capitalAssetBuilderModuleService) {
+		this.capitalAssetBuilderModuleService = capitalAssetBuilderModuleService;
+	}
+}

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/validation/configuration/FinancialProcessingValidators.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/validation/configuration/FinancialProcessingValidators.xml
@@ -53,5 +53,9 @@
   </bean>
   
   <bean id="DisbursementVoucher-nonResidentAlienInformationValidation" class="edu.arizona.kfs.fp.document.validation.impl.DisbursementVoucherNonResidentAlienInformationValidation" abstract="true" />
+  
+  <bean id="AccountingDocument-capitalAccountingLinesAccessibleValidation" parent="AccountingDocument-accountingLineAccessibleValidation" class="edu.arizona.kfs.fp.document.validation.impl.CapitalAccountingLinesAccessibleValidation" abstract="true">
+    <property name="capitalAssetBuilderModuleService" ref="capitalAssetBuilderModuleService" />
+  </bean>
 
 </beans>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/validation/configuration/ProcurementCardValidation.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/document/validation/configuration/ProcurementCardValidation.xml
@@ -53,7 +53,7 @@
 
   <bean id="ProcurementCard-saveDocumentValidation" parent="ProcurementCard-saveDocumentValidation-parentBean" scope="prototype">
     <property name="validations">
-      <list>
+      <list merge="true">
         <bean parent="ProcurementCard-balanceValidation" scope="prototype">
           <property name="parameterProperties">
             <list>


### PR DESCRIPTION
Created
* edu/arizona/kfs/fp/document/validation/impl/CapitalAccountingLinesAccessibleValidation.java was created so the code on ProcurementCardAccountAccessibilityValidation could be referenced when the Accounting lines were being validated. 

Modified
* edu/arizona/kfs/fp/document/validation/configuration/FinancialProcessingValidators.xml was modified to add a new bean override of AccountDocument-capitalAccountingLinesAccessibleValidation so the new CapitalAccountingLinesAccessibleValidation could be referenced

* edu/arizona/kfs/fp/document/validation/configuration/ProcurementCardValidation.xml was modified to make sure prior validation added to bean ProcurementCard-saceDocumentValidation bean is being referenced