### PR TITLE
UAF-4597 - Adding missed liquibase file to master list.

### DIFF
--- a/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/db.changelog-master.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/db.changelog-master.xml
@@ -30,4 +30,5 @@
   <include file="changesets/db.changelog-UAF-4337.xml" />
   <include file="changesets/db.changelog-UAF-2969.xml" />
   <include file="changesets/db.changelog-UAF-2347.xml" />
+  <include file="changesets/db.changelog-UAF-4597.xml" />
 </databaseChangeLog>


### PR DESCRIPTION
I had forgotten to add my SQL change file to the master list file, and so my needed column did not get added. This adds the feature's SQL file for execution during build time.