### PR TITLE
UAF-4677 BUG - POA - Unable to edit accounting lines on a partially p…

### DIFF
--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/authorization/PurchaseOrderAmendAccountingLineAuthorizer.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/authorization/PurchaseOrderAmendAccountingLineAuthorizer.java
@@ -1,0 +1,53 @@
+package edu.arizona.kfs.module.purap.document.authorization;
+
+import java.util.Set;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.kuali.kfs.module.purap.document.authorization.PurapAccountingLineAuthorizer;
+import org.kuali.kfs.sys.KFSConstants;
+import org.kuali.kfs.sys.KFSPropertyConstants;
+import org.kuali.kfs.sys.businessobject.AccountingLine;
+import org.kuali.kfs.sys.document.AccountingDocument;
+import org.kuali.rice.kew.api.WorkflowDocument;
+import org.kuali.rice.kim.api.identity.Person;
+
+import edu.arizona.kfs.module.purap.PurapConstants;
+
+public class PurchaseOrderAmendAccountingLineAuthorizer extends PurapAccountingLineAuthorizer {
+    
+    @Override
+    public boolean renderNewLine(AccountingDocument accountingDocument, String accountingGroupProperty) {
+        WorkflowDocument workflowDoc = accountingDocument.getFinancialSystemDocumentHeader().getWorkflowDocument();
+        Set<String> currentRouteNodeName = workflowDoc.getCurrentNodeNames();
+
+        // if its in the NEW_UNORDERED_ITEMS node, then allow the new line to be drawn
+        if (CollectionUtils.isNotEmpty(currentRouteNodeName) && PurapConstants.PurchaseOrderStatuses.NODE_AWAIT_NEW_UNORDERED_ITEM_REVIEW.equals(currentRouteNodeName.toString())) {
+            return true;
+        }
+        
+        if (CollectionUtils.isNotEmpty(currentRouteNodeName) && KFSConstants.RouteLevelNames.ACCOUNT.equals(currentRouteNodeName.toString())) {
+            return true;
+        }
+
+        return super.renderNewLine(accountingDocument, accountingGroupProperty);
+    }
+
+    @Override
+    public boolean determineEditPermissionOnLine(AccountingDocument accountingDocument, AccountingLine accountingLine, String accountingLineCollectionProperty, boolean currentUserIsDocumentInitiator, boolean pageIsEditable) {
+        // the fields in a new line should be always editable
+        if (accountingLine.getSequenceNumber() == null) {
+            return true;
+        }
+
+        return super.determineEditPermissionOnLine(accountingDocument, accountingLine, accountingLineCollectionProperty, currentUserIsDocumentInitiator, pageIsEditable);
+    }
+    
+    @Override
+    public Set<String> getUnviewableBlocks(AccountingDocument accountingDocument, AccountingLine accountingLine, boolean newLine, Person currentUser) {
+        Set<String> unviewableBlocks = super.getUnviewableBlocks(accountingDocument, accountingLine, newLine, currentUser);
+        unviewableBlocks.remove(KFSPropertyConstants.PERCENT);
+        unviewableBlocks.remove(KFSPropertyConstants.AMOUNT);
+
+        return unviewableBlocks;
+    }
+}

--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/authorization/PurchaseOrderAmendmentDocumentPresentationController.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/authorization/PurchaseOrderAmendmentDocumentPresentationController.java
@@ -20,6 +20,16 @@ import org.kuali.rice.kew.api.WorkflowDocument;
 public class PurchaseOrderAmendmentDocumentPresentationController extends org.kuali.kfs.module.purap.document.authorization.PurchaseOrderAmendmentDocumentPresentationController {
 
     @Override
+    public boolean canEdit(Document document) {
+        PurchaseOrderDocument poDocument = (PurchaseOrderDocument)document;
+
+        if (PurchaseOrderStatuses.APPDOC_AWAIT_FISCAL_REVIEW.equals(poDocument.getApplicationDocumentStatus())) {
+            return true;
+        }
+        return super.canEdit(document);
+    }
+    
+    @Override
     public Set<String> getEditModes(Document document) {
         Set<String> editModes = super.getEditModes(document);
         PurchaseOrderDocument poDocument = (PurchaseOrderDocument) document;

--- a/kfs-purap/src/main/resources/edu/arizona/kfs/module/purap/document/datadictionary/PurchaseOrderAmendmentDocument.xml
+++ b/kfs-purap/src/main/resources/edu/arizona/kfs/module/purap/document/datadictionary/PurchaseOrderAmendmentDocument.xml
@@ -4,6 +4,18 @@
     <property name="documentClass" value="edu.arizona.kfs.module.purap.document.PurchaseOrderAmendmentDocument"/>
     <property name="baseDocumentClass" value="org.kuali.kfs.module.purap.document.PurchaseOrderAmendmentDocument"/>
     <property name="documentPresentationControllerClass" value="edu.arizona.kfs.module.purap.document.authorization.PurchaseOrderAmendmentDocumentPresentationController"/>
+    <property name="accountingLineGroups">
+        <map>
+            <entry>
+                <key><value>source</value></key>
+                <ref bean="PurchaseOrderAmendmentDocument-sourceAccountingLineGroup" parent="AccountingLineGroup"/>
+            </entry>
+            <entry>
+                <key><value>distributeSource</value></key>
+                <ref bean="PurchaseOrderAmendmentDocument-distributeSourceAccountingLineGroup" parent="AccountingLineGroup"/>
+            </entry>
+        </map>
+    </property>
     <property name="attributes">
       <list merge="true">
         <ref bean="PurchaseOrderAmendmentDocument-routeCode"/>
@@ -36,5 +48,15 @@
     		</map>
     	</property>
 	</bean>
+	
+	<!-- accounting line groups -->
+    <bean id="PurchaseOrderAmendmentDocument-sourceAccountingLineGroup" parent="PurchaseOrderDocument-sourceAccountingLineGroup">
+        <property name="accountingLineAuthorizerClass" value="edu.arizona.kfs.module.purap.document.authorization.PurchaseOrderAmendAccountingLineAuthorizer"/>
+    </bean>
+
+    <bean id="PurchaseOrderAmendmentDocument-distributeSourceAccountingLineGroup" parent="PurchaseOrderDocument-distributeSourceAccountingLineGroup">
+        <property name="accountingLineAuthorizerClass" value="edu.arizona.kfs.module.purap.document.authorization.PurchaseOrderAmendAccountingLineAuthorizer"/>
+    </bean>
+    
 </beans>
 


### PR DESCRIPTION
…aid line item when amending PO

Added new file PurchaseOrderAmendAccountingLineAuthorizer.java to override renderNewLine and determineEditPermissionOnLine methods to make the accounting lines editable. Also override getUnviewableBlocks method, otherwise the 'Amt' column will not show on the accounting lines table.
Modified PurchaseOrderAmendmentDocumentPresentationController.java to override the canEdit method. This makes the accounting lines editable to the Fiscal Officer when the document is at the 'Awaiting Fiscal Officer Review' status.
Modified PurchaseOrderAmendmentDocument.xml to point to the new PurchaseOrderAmendAccountingLineAuthorizer class.