### PR TITLE
UAF-4211: Fixing uppercase and length issues and check recon line ending.

### DIFF
--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/dataaccess/impl/BankTransactionCSVBuilder.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/dataaccess/impl/BankTransactionCSVBuilder.java
@@ -31,8 +31,8 @@ public class BankTransactionCSVBuilder {
         btv.setCustRefNo( currentRowData[ fieldPositions.get(KFSConstants.BankTransactionFields.CUST_REF_NO) ] );
         btv.setValueDate( currentRowData[ fieldPositions.get(KFSConstants.BankTransactionFields.VALUE_DATE) ] );
         btv.setBankReference( currentRowData[ fieldPositions.get(KFSConstants.BankTransactionFields.BANK_REFERENCE) ] );
-        btv.setDescriptiveTxt6( currentRowData[ fieldPositions.get(KFSConstants.BankTransactionFields.DESC_TEXT6) ] );
-        btv.setDescriptiveTxt7( currentRowData[ fieldPositions.get(KFSConstants.BankTransactionFields.DESC_TEXT7) ] );
+        btv.setDescriptiveTxt6( currentRowData[ fieldPositions.get(KFSConstants.BankTransactionFields.DESC_TEXT6) ].toUpperCase() );
+        btv.setDescriptiveTxt7( currentRowData[ fieldPositions.get(KFSConstants.BankTransactionFields.DESC_TEXT7) ].toUpperCase() );
 
         return btv;
     }

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/dataaccess/impl/BankTransactionDigesterAdapter.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/dataaccess/impl/BankTransactionDigesterAdapter.java
@@ -51,7 +51,7 @@ public class BankTransactionDigesterAdapter {
         bt.setDescriptiveTxt6(bankTransactionVO.getDescriptiveTxt6());
 
         //if this is a VA record, this will Mask the "VA Case File Number"
-        bt.setDescriptiveTxt7(convertDescriptiveText7(bankTransactionVO, errorList));
+        bt.setDescriptiveTxt7(convertDescriptiveText7(bankTransactionVO, bt.getCustRefNo(), errorList));
 
         //parse Value Date
         bt.setValueDate(convertValueDate(bankTransactionVO, errorList));
@@ -163,12 +163,12 @@ public class BankTransactionDigesterAdapter {
      * If the conditions indicate this is not a VA record, then the original
      * notesFieldSeven is returned, unmodified.
      */
-    private String convertDescriptiveText7(BankTransactionDigesterVO bankTransactionVO, List<String> errorList) {
+    private String convertDescriptiveText7(BankTransactionDigesterVO bankTransactionVO, String customerRefNumber, List<String> errorList) {
         String descText7 = null;
 
         try {
             // Mask the "VA Case File Number" if this is a VA record, otherwise no-op assign original value back in
-            VaRecordNotesMasker vaNotesMasker = new VaRecordNotesMasker(bankTransactionVO.getAccountNumber(), bankTransactionVO.getBaiType(), bankTransactionVO.getCustRefNo(), bankTransactionVO.getDescriptiveTxt6(), bankTransactionVO.getDescriptiveTxt7());
+            VaRecordNotesMasker vaNotesMasker = new VaRecordNotesMasker(bankTransactionVO.getAccountNumber(), bankTransactionVO.getBaiType(), customerRefNumber, bankTransactionVO.getDescriptiveTxt6(), bankTransactionVO.getDescriptiveTxt7());
 
             descText7 = vaNotesMasker.getAppropriateNotesFieldSeven();
         } catch (Exception e) {

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/dataaccess/impl/CheckReconciliationAdapter.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/dataaccess/impl/CheckReconciliationAdapter.java
@@ -31,7 +31,8 @@ public class CheckReconciliationAdapter {
         String[] checkReconRowData = new String[8];
         checkReconRowData[ fieldPositions.get(KFSConstants.BankTransactionFields.ACCOUNT_NUMBER) ] = bankTransaction.getAccountNumber().toString();
         checkReconRowData[ fieldPositions.get(KFSConstants.BankTransactionFields.BAI_TYPE) ] = bankTransaction.getBaiType().toString();
-        checkReconRowData[ fieldPositions.get(KFSConstants.BankTransactionFields.AMOUNT) ] = bankTransaction.getAmount().abs().toString();
+        String amount = bankTransaction.getAmount().abs().toString().replace(".","");
+        checkReconRowData[ fieldPositions.get(KFSConstants.BankTransactionFields.AMOUNT) ] = amount;
         checkReconRowData[ fieldPositions.get(KFSConstants.BankTransactionFields.CUST_REF_NO) ] = bankTransaction.getCustRefNo();
         checkReconRowData[ fieldPositions.get(KFSConstants.BankTransactionFields.VALUE_DATE) ] = convertValueDate(bankTransaction.getValueDate());
         checkReconRowData[ fieldPositions.get(KFSConstants.BankTransactionFields.BANK_REFERENCE) ] = bankTransaction.getBankReference();

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/dataaccess/impl/CheckReconciliationFileType.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/dataaccess/impl/CheckReconciliationFileType.java
@@ -4,6 +4,8 @@ import edu.arizona.kfs.fp.batch.service.BankParametersAccessService;
 import edu.arizona.kfs.fp.batch.service.BankTransactionsLoadService;
 import edu.arizona.kfs.fp.businessobject.BankTransaction;
 import edu.arizona.kfs.sys.KFSConstants;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
@@ -88,6 +90,10 @@ public class CheckReconciliationFileType extends BatchInputFileTypeBase {
         return getFileName();
     }
 
+    public void resetFileNameTimestamp(){
+        fileName = null;
+    }
+
 
     /**
      * @see org.kuali.kfs.sys.batch.CsvBatchInputFileTypeBase#parse(byte[])
@@ -114,8 +120,25 @@ public class CheckReconciliationFileType extends BatchInputFileTypeBase {
     public void process(String fileName, Object parsedFileContents) {
     }
 
+    /**
+     *  Creates a matching .done file for the check recon file, if one exists.
+     *  The .done file should only be created when the check recon file is complete.
+     */
+    public void createCheckReconDoneFile() {
+        File checkReconFile = new File(getAbsoulutePath());
+        if (checkReconFile.exists()) {
+            File doneFile = null;
+            try {
 
+                doneFile = new File(getDoneFilePath(checkReconFile));
+                doneFile.createNewFile();
 
+            } catch (IOException e) {
+                LOG.error("Check reconciliation .DONE file " + doneFile.getAbsolutePath() + " could not be created. ABORTING.");
+                throw new RuntimeException("Check reconciliation .DONE file " + doneFile.getAbsolutePath() + " could not be created. ABORTING.");
+            }
+        }
+    }
 
     /**
      * Creates and opens the file on the output path. the .done corresponding to the given file, if one exists.
@@ -125,6 +148,8 @@ public class CheckReconciliationFileType extends BatchInputFileTypeBase {
         if ( !checkReconFile.exists() ) {
             try {
                 checkReconFile.createNewFile();
+                File doneFile = new File(getDoneFilePath(checkReconFile));
+                doneFile.createNewFile();
                 if (!checkReconFile.canWrite()) {
                     LOG.error("Check reconciliation file " + getAbsoulutePath() + " cannot be opened for writing. ABORTING.");
                     throw new RuntimeException("Check reconciliation file " + getAbsoulutePath() + " cannot be opened for writing. ABORTING.");
@@ -165,6 +190,10 @@ public class CheckReconciliationFileType extends BatchInputFileTypeBase {
         return getDirectoryPath() + File.separator + getFileName() + KFSConstants.DOT_CHAR + getFileExtension();
     }
 
+    public String getDoneFilePath(File reconFile) {
+        String doneFileName = FilenameUtils.getBaseName(reconFile.getName());
+        return getDirectoryPath() + File.separator + doneFileName + KFSConstants.DONE_FILE_EXTENSION;
+    }
 
     /**
      * @see org.kuali.kfs.sys.batch.BatchInputType#getTitleKey()

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/dataaccess/impl/CheckReconciliationFileType.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/dataaccess/impl/CheckReconciliationFileType.java
@@ -77,6 +77,8 @@ public class CheckReconciliationFileType extends BatchInputFileTypeBase {
             checkReconRow.append(delimiter);
         }
         checkReconRow.append( getBankParametersAccessService().getCheckReconClearedStatusCode());
+        //each row needs to end with a COMMA and EOL
+        checkReconRow.append( KFSConstants.COMMA_CHAR);
         checkReconRow.append("\n");
         LOG.debug("getCheckReconciliationRow for transaction="+bankTransaction.toString()+" is="+checkReconRow.toString());
         return checkReconRow.toString();

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/TransactionPostingService.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/TransactionPostingService.java
@@ -11,12 +11,6 @@ import java.util.List;
  */
 public interface TransactionPostingService {
 
-    /**
-     * Initializes all resources - files etc, before starting to post transactions in the documentCreateJob
-     *
-     * @return empty errorList if transaction was posted with no errors
-     */
-    public void initialize();
 
     /**
      * Posts the given bank transaction and create the appropriate document for it:
@@ -36,4 +30,11 @@ public interface TransactionPostingService {
      * Returns TRUE if any files were already processed for the posting date of this file
      */
     public boolean isDuplicateBatch(String bankTransactionsFileName, Timestamp timestampBatchDate, String bankTransactionBatchName);
+
+
+    /**
+     * If there is an output check recon file, it creates a .done for it and resets the timestamp for the filename.
+     *
+     */
+    public void finalizeCheckRecon();
 }

--- a/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/impl/TransactionPostingServiceImpl.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/fp/batch/service/impl/TransactionPostingServiceImpl.java
@@ -103,9 +103,14 @@ public class TransactionPostingServiceImpl implements TransactionPostingService 
         return errorList;
     }
 
-    public void initialize(){
-        //make sure a new instance of the CheckReconFileType is created before starting to post transactions to avoid file name colisions
-        setCheckReconciliationFileType(SpringContext.getBean(CheckReconciliationFileType.class));
+    /**
+     * If there is an output check recon file, it creates a .done for it and resets the timestamp for the filename.
+     */
+    public void finalizeCheckRecon(){
+        //create a .done file in CheckReconFileType
+        getCheckReconciliationFileType().createCheckReconDoneFile();
+        //make sure a new instance of the CheckReconFileType is created before starting to post transactions to avoid file name collisions
+        getCheckReconciliationFileType().resetFileNameTimestamp();
     }
 
 

--- a/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSConstants.java
+++ b/kfs-core/src/main/java/edu/arizona/kfs/sys/KFSConstants.java
@@ -14,6 +14,7 @@ public class KFSConstants extends org.kuali.kfs.sys.KFSConstants {
     public static final String EQUALS = "=";
     public static final char QUOTE_CHAR = '"';
     public static final char DOT_CHAR = '.';
+    public static final char COMMA_CHAR = ',';
 
     public static final String INVOICE_NUMBER = "Invoice Number";
     public static final String DUPLICATE_INVOICE_QUESTION_ID = "DVDuplicateInvoice";
@@ -310,8 +311,8 @@ public class KFSConstants extends org.kuali.kfs.sys.KFSConstants {
         public static final String DOCUMENT_TYPE_DI = "DI";
         public static final String BANK_TRANSACTION_ORIGIN_CODE = "BT";
         public static final String ACCT_LINE_DATE_FORMAT = "MMddyyyy";
-        public static final int MAX_DESCRIPTION_LEN = 40;
-        public static final int MAX_NUMBER_LEN = 8;
+        public static final int MAX_DESCRIPTION_LEN = 39;
+        public static final int MAX_NUMBER_LEN = 7;
         public static final int MAX_BANK_REF_NBR = 10;
     }
 

--- a/kfs-core/src/main/resources/edu/arizona/kfs/fp/spring-fp.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/fp/spring-fp.xml
@@ -305,6 +305,9 @@
     <property name="transactionPostingDao">
       <ref bean="transactionPostingDao"/>
     </property>
+    <property name="checkReconciliationFileType">
+      <ref bean="checkReconciliationFileType"/>
+    </property>
     <property name="bankDocServiceMap">
       <map>
         <entry key="CCR" value-ref="bankCreditCardReceiptDocumentService"/>
@@ -365,7 +368,7 @@
 
   <bean id="checkReconciliationFileType" class="edu.arizona.kfs.fp.batch.dataaccess.impl.CheckReconciliationFileType" scope="prototype">
     <property name="directoryPath">
-      <value>${staging.directory}/fp/bankTransactions/validated</value>
+      <value>${staging.directory}/recon/upload</value>
     </property>
     <property name="fileExtension">
       <value>data</value>


### PR DESCRIPTION
Issues fixed:
1. In the Description field (Document Overview tab), its populating an extra character in the AWS environment. For example, for the same record, in 3.0 SUP, its showing "AMERICAN EXPRESS SETTLEMENT 170516 5026" in the description, whereas in AWS, it's populated as "AMERICAN EXPRESS SETTLEMENT 170516 50265" - with the extra 5 at the end.
2. In the Explanation field (Document Overview tab), its populating the field in the format 8 digit - 3-digit - 8 digit instead of 7 digit - 3 digit - 7 digit. The format of the explanation field is first 7 digits of account number (field 0) - BAI code (field1) - first 7 digits of customer reference number (field3). Example - in 3.0 it shows 5297883 - 169 - 5026509 whereas in AWS it shows 52978834 - 169 - 50265091 - with the extra "4" and "1" at the end of the account and customer ref# respectively.
3. VA Masking not working - this can been seen in the notes and attachment tab.
4. Found another small difference from 3.0 - in 3.0 the description, notes, line description is all upper case, and in 6.0 its as it is, its not converting to uppercase.
5. CheckRecon: the comma is missing at the end of each line (at the end of field 8 - which says "POSTED"). For example, its showing "POSTED" at the end of each line in 6.0 instead of "POSTED," which is how its in 3.0
