### PR TITLE
UAF-4909 PREQ Open quantity amount is not correct on multiple line items

### DIFF
--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/businessobject/PaymentRequestItem.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/businessobject/PaymentRequestItem.java
@@ -43,10 +43,7 @@ public class PaymentRequestItem extends org.kuali.kfs.module.purap.businessobjec
 				if (ObjectUtils.isNotNull(items)) {
 					for (Object object : items) {
 						PurchaseOrderItem item = (PurchaseOrderItem) object;
-						if (ObjectUtils.isNotNull(item) && item.getItemLineNumber().equals(this.getItemLineNumber())) {
-							poi = item;
-							break;
-						} else if (ObjectUtils.isNotNull(item) && getItemLineNumber().intValue() <= items.size()) { //This else if section was added to make sure the PREQ does not error when a tax withholding is added
+						if (ObjectUtils.isNotNull(item) && ObjectUtils.isNotNull(item.getItemLineNumber()) && item.getItemLineNumber().equals(this.getItemLineNumber())) {
 							poi = item;
 							break;
 						}


### PR DESCRIPTION
Modified PaymentRequestItem.java to correct an issue in the getPurchaseOrderItem method. Reverted the method to fix this issue (UAF-4909) and added a null check for item.getItemLineNumber(), which fixes the stack trace from UAF-4553.