### PR TITLE
UAF-4918 Bug - PREQ's and Checks/ACH are not zeroing out 9100 correctly

### DIFF
--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/PaymentRequestDocument.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/PaymentRequestDocument.java
@@ -303,8 +303,6 @@ public class PaymentRequestDocument extends org.kuali.kfs.module.purap.document.
 
         this.setPaymentRequestPayDate(SpringContext.getBean(PaymentRequestService.class).calculatePayDate(this.getInvoiceDate(), this.getVendorPaymentTerms()));
 
-        AccountsPayableService accountsPayableService = SpringContext.getBean(AccountsPayableService.class);
-
         if(SpringContext.getBean(PaymentRequestService.class).encumberedItemExistsForInvoicing(po))
         {
             for (PurchaseOrderItem poi : (List<PurchaseOrderItem>) po.getItems()) {
@@ -525,7 +523,7 @@ public class PaymentRequestDocument extends org.kuali.kfs.module.purap.document.
 		GeneralLedgerPendingEntry offsetEntry = new GeneralLedgerPendingEntry(explicitEntry);
 		boolean success = processOffsetGeneralLedgerPendingEntry(sequenceHelper, glpeSourceDetail, explicitEntry, offsetEntry);
 
-		processUseTaxOffsetGeneralLedgerPendingEntries(sequenceHelper, glpeSourceDetail, explicitEntry, offsetEntry);
+		processUseTaxOffsetGeneralLedgerPendingEntries(sequenceHelper, explicitEntry, offsetEntry);
 
 		processTaxWithholdingGeneralLedgerPendingEntriesPREQ(sequenceHelper, glpeSourceDetail, explicitEntry, offsetEntry);
 
@@ -597,8 +595,8 @@ public class PaymentRequestDocument extends org.kuali.kfs.module.purap.document.
 	}
 
 	private void processTaxWithholdingGeneralLedgerPendingEntriesPREQ(GeneralLedgerPendingEntrySequenceHelper sequenceHelper, GeneralLedgerPendingEntrySourceDetail glpeSourceDetail, GeneralLedgerPendingEntry explicitEntry, GeneralLedgerPendingEntry offsetEntry) {
-		String incomeClassCode = ((PaymentRequestDocument) this).getTaxClassificationCode();
-		if ((StringUtils.isNotEmpty(incomeClassCode) && !StringUtils.equalsIgnoreCase(incomeClassCode, "N")) && ((((PaymentRequestDocument) this).getTaxFederalPercent().compareTo(new BigDecimal(0)) != 0) || (((PaymentRequestDocument) this).getTaxStatePercent().compareTo(new BigDecimal(0)) != 0))) {
+		String incomeClassCode = this.getTaxClassificationCode();
+		if ((StringUtils.isNotEmpty(incomeClassCode) && !StringUtils.equalsIgnoreCase(incomeClassCode, "N")) && ((this.getTaxFederalPercent().compareTo(new BigDecimal(0)) != 0) || (this.getTaxStatePercent().compareTo(new BigDecimal(0)) != 0))) {
 			ParameterService parameterService = SpringContext.getBean(ParameterService.class);
 			String taxAccount = parameterService.getParameterValueAsString(PaymentRequestDocument.class, NRATaxParameters.FEDERAL_TAX_PARM_PREFIX + NRATaxParameters.TAX_PARM_ACCOUNT_SUFFIX);
 			if (!offsetEntry.getAccountNumber().equals(taxAccount)) {
@@ -629,14 +627,14 @@ public class PaymentRequestDocument extends org.kuali.kfs.module.purap.document.
 		addPendingEntry(taxWithholdingOffset);
 	}
 
-	private void processUseTaxOffsetGeneralLedgerPendingEntries( GeneralLedgerPendingEntrySequenceHelper sequenceHelper, GeneralLedgerPendingEntrySourceDetail glpeSourceDetail, GeneralLedgerPendingEntry explicitEntry, GeneralLedgerPendingEntry offsetEntry) {
+	private void processUseTaxOffsetGeneralLedgerPendingEntries( GeneralLedgerPendingEntrySequenceHelper sequenceHelper, GeneralLedgerPendingEntry explicitEntry, GeneralLedgerPendingEntry offsetEntry) {
 		ParameterService parameterService = SpringContext.getBean(ParameterService.class);
 
 		String glpeOffsetObjectCode = parameterService.getParameterValueAsString(KfsParameterConstants.PURCHASING_DOCUMENT.class, PurapParameterConstants.GENERAL_LEDGER_PENDING_ENTRY_OFFSET_OBJECT_CODE);
 
 		Map<String, String> pkMap = new HashMap<String, String>();
 		pkMap.put(KFSPropertyConstants.TAX_REGION_CODE, parameterService.getParameterValueAsString(ProcurementCardDocument.class, PurapParameterConstants.GL_USETAX_TAX_REGION));
-		TaxRegion taxRegion = (TaxRegion) getBusinessObjectService().findByPrimaryKey(TaxRegion.class, pkMap);
+		TaxRegion taxRegion = getBusinessObjectService().findByPrimaryKey(TaxRegion.class, pkMap);
 
 		if (offsetEntry.getAccountNumber().equals(taxRegion.getAccountNumber())) {
 			offsetEntry.setSubAccountNumber(null);

--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/service/impl/PurapAccountingHelperServiceImpl.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/service/impl/PurapAccountingHelperServiceImpl.java
@@ -22,13 +22,9 @@ public class PurapAccountingHelperServiceImpl implements PurapAccountingHelperSe
 	}
 
 	// local constants
-	protected static final Boolean ITEM_TYPES_INCLUDED_VALUE = Boolean.TRUE;;
 	protected static final Boolean ITEM_TYPES_EXCLUDED_VALUE = Boolean.FALSE;
-	protected static final Boolean ZERO_TOTALS_RETURNED_VALUE = Boolean.TRUE;
 	protected static final Boolean ZERO_TOTALS_NOT_RETURNED_VALUE = Boolean.FALSE;
 	protected static final Boolean ALTERNATE_AMOUNT_USED = Boolean.TRUE;
-	protected static final Boolean ALTERNATE_AMOUNT_NOT_USED = Boolean.FALSE;
-	protected static final Boolean USE_TAX_INCLUDED = Boolean.TRUE;
 	protected static final Boolean USE_TAX_EXCLUDED = Boolean.FALSE;
 
 	@Override
@@ -40,7 +36,7 @@ public class PurapAccountingHelperServiceImpl implements PurapAccountingHelperSe
 			PurapConstants.ItemTypeCodes.ITEM_TYPE_FEDERAL_TAX_CODE, 
 			PurapConstants.ItemTypeCodes.ITEM_TYPE_STATE_TAX_CODE };
 		
-		Set itemsToExclude = new HashSet(Arrays.asList(taxItemTypeCodes));
+		Set<String> itemsToExclude = new HashSet<String>(Arrays.asList(taxItemTypeCodes));
 
 		List<SourceAccountingLine> returnList = purapAccountingService.generateAccountSummary(items, itemsToExclude, ITEM_TYPES_EXCLUDED_VALUE, ZERO_TOTALS_NOT_RETURNED_VALUE, ALTERNATE_AMOUNT_USED, USE_TAX_EXCLUDED, false);
 		if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
Files modified:

Per Scott's request on pull request #387 UAF-4567 BUG - PREQ With Federal Withholding Doubles Use Tax, I made changes to:
1. PaymentRequestDocument.java - removed some dead variables and unnecessary casts
2. PurapAccountingHelperServiceImpl.java - removed some dead variables and added type to the Set variable

Modification made to fix current bug.
3. PurapAccountingServiceImpl.java - overrode updateAccountAmountsWithTotal() so the source lines and GL lines could be calculated correctly