### PR TITLE
UAF-58 / UAF-5022 BUG - eInvoicing file fails when sub account is inactivated

### DIFF
--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/service/impl/ElectronicInvoiceHelperServiceImpl.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/service/impl/ElectronicInvoiceHelperServiceImpl.java
@@ -539,7 +539,9 @@ public class ElectronicInvoiceHelperServiceImpl extends org.kuali.kfs.module.pur
             extraDescription.append(", ");
         }
 
-        extraDescription.setLength(extraDescription.length() - 2);
+        if (extraDescription.length() >= 2) {
+            extraDescription.setLength(extraDescription.length() - 2);
+        }
         return extraDescription.toString();
     }
 


### PR DESCRIPTION
Minor fix for when the error message list has no errors.