### PR TITLE
UAF-4955 BUG - 3.0 Enroute/Final PCDO Documents Cannot Be Searched by…

### DIFF
--- a/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/changesets/db.changelog-UAF-4955.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/changesets/db.changelog-UAF-4955.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="UAF-4955" author="Mark Moen">
+        <preConditions onError="MARK_RAN" onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM KREW_DOC_HDR_EXT_T WHERE KEY_CD = 'creditCardLastFour'
+            </sqlCheck>
+            <sqlCheck expectedResult="4">
+                SELECT COUNT(*) FROM KREW_DOC_HDR_EXT_T WHERE KEY_CD = 'name'
+            </sqlCheck>
+        </preConditions>
+        <comment>
+            UAF-4955 - 3.0 Enroute/Final PCDO Documents Cannot Be Searched by Credit Card Last 4 and Group Name In 6.0
+        </comment>
+        <sql>
+            <!-- Update Key Code on KREW_DOC_HDR_EXT_T table to reflect field name changes from KFS 3.0 to KFS 6 -->
+            UPDATE KREW_DOC_HDR_EXT_T SET KEY_CD = 'creditCardLastFour' WHERE KEY_CD = 'cardApprovalOfficial';
+            UPDATE KREW_DOC_HDR_EXT_T SET KEY_CD = 'name' WHERE KEY_CD = 'groupName';
+        </sql>
+        <rollback>
+            <sql>
+                UPDATE KREW_DOC_HDR_EXT_T SET KEY_CD = 'cardApprovalOfficial' WHERE KEY_CD = 'creditCardLastFour';
+                UPDATE KREW_DOC_HDR_EXT_T SET KEY_CD = 'groupName' WHERE KEY_CD = 'name' AND VAL NOT LIKE 'SALES_TAX_%_VARIANCE_PERCENT';
+            </sql>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/db.changelog-master.xml
+++ b/kfs-core/src/main/resources/edu/arizona/kfs/db/changelog/db.changelog-master.xml
@@ -30,4 +30,5 @@
   <include file="changesets/db.changelog-UAF-2969.xml" />
   <include file="changesets/db.changelog-UAF-2347.xml" />
   <include file="changesets/db.changelog-UAF-4597.xml" />
+  <include file="changesets/db.changelog-UAF-4955.xml" />
 </databaseChangeLog>


### PR DESCRIPTION
… Credit Card Last 4 and Group Name In 6.0

Added new file db.changelog-UAF-4955.xml. Field names, Credit Card Last 4 and Group Name, were changed from KFS 3.0 to KFS 6 and this changeset captures the database changes that rename them and fix the search.
Modified db.changelog-master.xml to include the new changeset.