### PR TITLE
UAF-4933 Credit Memo Defaulting Zero Into Credit Processed Field Caus…

### DIFF
--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/businessobject/CreditMemoItem.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/businessobject/CreditMemoItem.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 
 import org.kuali.kfs.module.purap.businessobject.CreditMemoAccount;
 import org.kuali.kfs.module.purap.businessobject.PaymentRequestAccount;
+import org.kuali.kfs.module.purap.businessobject.PaymentRequestItem;
 import org.kuali.kfs.module.purap.businessobject.PurchaseOrderAccount;
 import org.kuali.kfs.module.purap.businessobject.PurchaseOrderItem;
 import org.kuali.kfs.module.purap.document.VendorCreditMemoDocument;
@@ -130,5 +131,22 @@ public class CreditMemoItem extends org.kuali.kfs.module.purap.businessobject.Cr
 
             getSourceAccountingLines().add(new CreditMemoAccount(account));
         }
+    }
+    
+    @Override
+    public KualiDecimal calculateExtendedPrice() {
+        KualiDecimal extendedPrice = null;
+        if (ObjectUtils.isNotNull(getItemUnitPrice())) {
+            if (this.getItemType().isAmountBasedGeneralLedgerIndicator()) {
+                // SERVICE ITEM: return unit price as extended price
+                extendedPrice = new KualiDecimal(this.getItemUnitPrice().toString());
+            }
+            else if (ObjectUtils.isNotNull(this.getItemQuantity())) {
+                BigDecimal calcExtendedPrice = this.getItemUnitPrice().multiply(this.getItemQuantity().bigDecimalValue());
+                // ITEM TYPE (qty driven): return (unitPrice x qty)
+                extendedPrice = new KualiDecimal(calcExtendedPrice.setScale(KualiDecimal.SCALE, KualiDecimal.ROUND_BEHAVIOR));
+            }
+        }
+        return extendedPrice;
     }
 }

--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/businessobject/CreditMemoItem.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/businessobject/CreditMemoItem.java
@@ -135,17 +135,9 @@ public class CreditMemoItem extends org.kuali.kfs.module.purap.businessobject.Cr
     
     @Override
     public KualiDecimal calculateExtendedPrice() {
-        KualiDecimal extendedPrice = null;
-        if (ObjectUtils.isNotNull(getItemUnitPrice())) {
-            if (this.getItemType().isAmountBasedGeneralLedgerIndicator()) {
-                // SERVICE ITEM: return unit price as extended price
-                extendedPrice = new KualiDecimal(this.getItemUnitPrice().toString());
-            }
-            else if (ObjectUtils.isNotNull(this.getItemQuantity())) {
-                BigDecimal calcExtendedPrice = this.getItemUnitPrice().multiply(this.getItemQuantity().bigDecimalValue());
-                // ITEM TYPE (qty driven): return (unitPrice x qty)
-                extendedPrice = new KualiDecimal(calcExtendedPrice.setScale(KualiDecimal.SCALE, KualiDecimal.ROUND_BEHAVIOR));
-            }
+        KualiDecimal extendedPrice = super.calculateExtendedPrice();
+        if (extendedPrice.equals(KualiDecimal.ZERO)) {
+            extendedPrice = null;
         }
         return extendedPrice;
     }

--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/VendorCreditMemoDocument.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/VendorCreditMemoDocument.java
@@ -27,6 +27,7 @@ import org.kuali.rice.krad.util.KRADConstants;
 import edu.arizona.kfs.fp.service.PaymentMethodGeneralLedgerPendingEntryService;
 import edu.arizona.kfs.module.purap.PurapConstants;
 import edu.arizona.kfs.module.purap.businessobject.CreditMemoIncomeType;
+import edu.arizona.kfs.module.purap.businessobject.CreditMemoItem;
 import edu.arizona.kfs.module.purap.document.service.PurapIncomeTypeHandler;
 import edu.arizona.kfs.sys.KFSConstants;
 import edu.arizona.kfs.sys.document.IncomeTypeContainer;
@@ -80,6 +81,12 @@ public class VendorCreditMemoDocument extends org.kuali.kfs.module.purap.documen
      */
     public boolean getPayment1099IndicatorForSearching() {
         return payment1099Indicator;
+    }
+    
+    @SuppressWarnings("rawtypes")
+    @Override
+    public Class getItemClass() {
+        return CreditMemoItem.class;
     }
 
     @Override

--- a/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/service/impl/CreditMemoServiceImpl.java
+++ b/kfs-purap/src/main/java/edu/arizona/kfs/module/purap/document/service/impl/CreditMemoServiceImpl.java
@@ -12,6 +12,7 @@ import org.kuali.kfs.module.purap.PurapPropertyConstants;
 import org.kuali.kfs.module.purap.businessobject.CreditMemoAccount;
 import org.kuali.kfs.module.purap.businessobject.PurApAccountingLine;
 import org.kuali.kfs.module.purap.businessobject.PurchaseOrderItem;
+import org.kuali.kfs.module.purap.businessobject.PurchasingCapitalAssetItem;
 import org.kuali.kfs.module.purap.document.PurchaseOrderDocument;
 import org.kuali.kfs.module.purap.document.VendorCreditMemoDocument;
 import org.kuali.kfs.module.purap.document.validation.event.AttributedContinuePurapEvent;
@@ -274,6 +275,29 @@ public class CreditMemoServiceImpl extends org.kuali.kfs.module.purap.document.s
             if (preqItemToTemplate.getItemType().isLineItemIndicator() && ((preqItemToTemplate.getItemType().isQuantityBasedGeneralLedgerIndicator() && preqItemToTemplate.getItemQuantity().isNonZero())
                     || (preqItemToTemplate.getItemType().isAmountBasedGeneralLedgerIndicator() && preqItemToTemplate.getTotalAmount().isNonZero()))) {
                 cmDocument.getItems().add(new CreditMemoItem((edu.arizona.kfs.module.purap.document.VendorCreditMemoDocument) cmDocument, preqItemToTemplate, preqItemToTemplate.getPurchaseOrderItem(), expiredOrClosedAccountList));
+            }
+        }
+
+        // add below the line items
+        purapService.addBelowLineItems(cmDocument);
+
+        cmDocument.fixItemReferences();
+    }
+    
+    @Override
+    protected void populateItemLinesFromPO(VendorCreditMemoDocument cmDocument, HashMap<String, ExpiredOrClosedAccountEntry> expiredOrClosedAccountList) {
+        List<PurchaseOrderItem> invoicedItems = getPOInvoicedItems(cmDocument.getPurchaseOrderDocument());
+        for (PurchaseOrderItem poItem : invoicedItems) {
+            poItem.refreshReferenceObject(PurapPropertyConstants.ITEM_TYPE);
+
+            if ((poItem.getItemType().isQuantityBasedGeneralLedgerIndicator() && poItem.getItemInvoicedTotalQuantity().isNonZero())
+                    || (poItem.getItemType().isAmountBasedGeneralLedgerIndicator() && poItem.getItemInvoicedTotalAmount().isNonZero())) {
+                CreditMemoItem creditMemoItem = new CreditMemoItem(cmDocument, poItem, expiredOrClosedAccountList);
+                cmDocument.getItems().add(creditMemoItem);
+                PurchasingCapitalAssetItem purchasingCAMSItem = cmDocument.getPurchaseOrderDocument().getPurchasingCapitalAssetItemByItemIdentifier(poItem.getItemIdentifier());
+                if (purchasingCAMSItem != null) {
+                    creditMemoItem.setCapitalAssetTransactionTypeCode(purchasingCAMSItem.getCapitalAssetTransactionTypeCode());
+                }
             }
         }
 


### PR DESCRIPTION
…ing Calculation Error

Modified CreditMemoItem.java to override the calculateExtendedPrice method. Default the extendedPrice to null so it doesn't get set to 0.00 when it shouldn't.
Modified CreditMemoServiceImpl.java to override the populateItemLinesFromPO method. This was copied and pasted from the parent class so an edu/arizona version of CreditMemoItem will be created instead of org/kuali.
Modified VendorCreditMemoDocument.java to override the getItemClass method. This fixes the ClassCastException (and consequent stack trace) when the calculate button was clicked on a newly created CM document.